### PR TITLE
Only add the host property to jetty.xml if it doesn't already exist 

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1158,14 +1158,14 @@ EOF
 
   # secure the ActiveMQ console
   sed -i -e '/name="authenticate"/s/false/true/' /etc/activemq/jetty.xml
-  
+
   # only add the host property if it's not already there
   # (so you can run the script multiple times)
   grep '<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml > /dev/null
   if [ $? -ne 0 ]; then
     sed -i -e '/name="port"/a<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml
   fi
-  
+
   sed -i -e "/admin:/s/admin,/${activemq_admin_password},/" /etc/activemq/jetty-realm.properties
 
 


### PR DESCRIPTION
Previously, if you ran openshift.sh multiple times,
/etc/activemq/jetty.xml would end up with multiple copies of the host
property line, which caused ActiveMQ to fail to start up.
