### PR TITLE
updated install and kickstart scripts for priorities

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -58,6 +58,22 @@ baseurl=${CONF_RHEL_REPO}
 enabled=1
 gpgcheck=0
 sslverify=false
+priority=2
+sslverify=false
+
+YUM
+}
+
+configure_optional_repo()
+{
+  cat > /etc/yum.repos.d/rheloptional.repo <<YUM
+[rhel6_optional]
+name=RHEL 6 Optional
+baseurl=${CONF_RHEL_OPTIONAL_REPO}
+enabled=1
+gpgcheck=0
+sslverify=false
+priority=2
 sslverify=false
 
 YUM
@@ -73,6 +89,7 @@ baseurl=${CONF_REPOS_BASE}/Client/x86_64/os/
 enabled=1
 gpgcheck=0
 sslverify=false
+priority=1
 sslverify=false
 
 YUM
@@ -88,6 +105,7 @@ baseurl=${CONF_REPOS_BASE}/Infrastructure/x86_64/os/
 enabled=1
 gpgcheck=0
 sslverify=false
+priority=1
 sslverify=false
 
 YUM
@@ -103,6 +121,7 @@ baseurl=${CONF_REPOS_BASE}/Node/x86_64/os/
 enabled=1
 gpgcheck=0
 sslverify=false
+priority=1
 sslverify=false
 
 YUM
@@ -118,6 +137,7 @@ baseurl=${CONF_REPOS_BASE}/JBoss_EAP6_Cartridge/x86_64/os/
 enabled=1
 gpgcheck=0
 sslverify=false
+priority=1
 sslverify=false
 
 YUM
@@ -135,6 +155,7 @@ configure_jbosseap_repo()
 name=jbosseap
 baseurl=${CONF_JBOSS_REPO_BASE}/jbeap/6/os/
 enabled=1
+priority=3
 gpgcheck=0
 sslverify=false
 
@@ -163,6 +184,7 @@ configure_jbossews_repo()
 name=jbossews
 baseurl=${CONF_JBOSS_REPO_BASE}/jbews/${ews_version}/os/
 enabled=1
+priority=3
 gpgcheck=0
 sslverify=false
 
@@ -1547,6 +1569,7 @@ set_defaults()
   # subscriptions via RHN. Internally we use private systems.
   rhel_repo="$CONF_RHEL_REPO"
   jboss_repo_base="$CONF_JBOSS_REPO_BASE"
+  rhel_optional_repo="$CONF_RHEL_OPTIONAL_REPO"
 
   # The domain name for the OpenShift Enterprise installation.
   domain="${CONF_DOMAIN:-example.com}"
@@ -1661,10 +1684,16 @@ echo_installation_intentions
 is_false "$CONF_NO_NTP" && synchronize_clock
 is_false "$CONF_NO_SSH_KEYS" && install_ssh_keys
 
+
 # enable subscriptions / repositories according to requested method
 case "$CONF_INSTALL_METHOD" in
   (yum)
     configure_rhel_repo
+    if is_true "$CONF_OPTIONAL_REPO"
+    then
+      configure_optional_repo
+    fi
+
     if activemq || broker || datastore
     then
       configure_broker_repo
@@ -1678,12 +1707,24 @@ case "$CONF_INSTALL_METHOD" in
   (rhn)
      echo "Register with RHN using an activation key"
      rhnreg_ks --activationkey=${CONF_RHN_REG_ACTKEY} --profilename=${hostname}
-     broker && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-rhc --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     broker && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-infrastructure --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-node --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-jbosseap --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel jbappplatform-6-x86_64-server-6-rpm --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel jb-ews-1-x86_64-server-6-rpm --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+     yum-config-manager --setopt=rhel-x86_64-server-6.priority=2 rhel-x86_64-server-6 --save
+
+     for channel in rhel-x86_64-server-6-osop-1-rhc rhel-x86_64-server-6-osop-1-infrastructure
+     do
+       broker && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=1 ${channel} --save
+     done
+     for channel in rhel-x86_64-server-6-osop-1-node rhel-x86_64-server-6-osop-1-jbosseap
+     do
+       node && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=1 ${channel} --save
+     done
+     for channel in jbappplatform-6-x86_64-server-6-rpm jb-ews-1-x86_64-server-6-rpm
+     do
+       node && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=3 ${channel} --save
+     done
+
      if is_true "$CONF_OPTIONAL_REPO"
      then
        rhn-channel --add --channel rhel-x86_64-server-optional-6 --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
@@ -1696,6 +1737,9 @@ case "$CONF_INSTALL_METHOD" in
      echo "sam"
      ;;
 esac
+
+# Install yum-plugin-priorities
+yum clean all; yum install -y yum-plugin-priorities
 
 yum update -y
 

--- a/enterprise/install-scripts/generic/jbosseap.repo
+++ b/enterprise/install-scripts/generic/jbosseap.repo
@@ -3,3 +3,4 @@ name=jbosseap
 baseurl=http://${jboss_repo_base}/content/dist/rhel/server/6/6Server/x86_64/jbeap/6/os/
 enabled=1
 gpgcheck=0
+priority=3

--- a/enterprise/install-scripts/generic/jbossews.repo
+++ b/enterprise/install-scripts/generic/jbossews.repo
@@ -3,3 +3,4 @@ name=jbossews
 baseurl=http://${jboss_repo_base}/content/dist/rhel/server/6/6Server/x86_64/jbews/1/os/
 enabled=1
 gpgcheck=0
+priority=3

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -45,6 +45,7 @@
 #       repos_base / CONF_REPOS_BASE -- see below
 #       rhel_repo / CONF_RHEL_REPO -- see below
 #       jboss_repo_base / CONF_JBOSS_REPO_BASE -- see below
+#       rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO -- see below
 #     sm - use subscription-manager (not yet implemented)
 #       sm_reg_name / CONF_SM_REG_NAME
 #       sm_reg_pass / CONF_SM_REG_PASS
@@ -66,6 +67,10 @@
 # rhel_repo / CONF_RHEL_REPO
 #   The URL for a RHEL 6 yum repository used with the "yum" install method.
 #   Should end in /6Server/x86_64/os/
+
+# rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO
+#   The URL for a RHEL 6 Optional yum repository used with the "yum" install method.
+#   Should end in /6Server/x86_64/optional/os/
 
 # jboss_repo_base / CONF_JBOSS_REPO_BASE
 #   The base URL for the JBoss repositories used with the "yum" 
@@ -352,6 +357,21 @@ name=RHEL 6 base OS
 baseurl=${CONF_RHEL_REPO}
 enabled=1
 gpgcheck=0
+priority=2
+sslverify=false
+
+YUM
+}
+
+configure_optional_repo()
+{
+  cat > /etc/yum.repos.d/rheloptional.repo <<YUM
+[rhel6_optional]
+name=RHEL 6 Optional
+baseurl=${CONF_RHEL_OPTIONAL_REPO}
+enabled=1
+gpgcheck=0
+priority=2
 sslverify=false
 
 YUM
@@ -366,6 +386,7 @@ name=OpenShift Client
 baseurl=${CONF_REPOS_BASE}/Client/x86_64/os/
 enabled=1
 gpgcheck=0
+priority=1
 sslverify=false
 
 YUM
@@ -380,6 +401,7 @@ name=OpenShift Infrastructure
 baseurl=${CONF_REPOS_BASE}/Infrastructure/x86_64/os/
 enabled=1
 gpgcheck=0
+priority=1
 sslverify=false
 
 YUM
@@ -394,6 +416,7 @@ name=OpenShift Node
 baseurl=${CONF_REPOS_BASE}/Node/x86_64/os/
 enabled=1
 gpgcheck=0
+priority=1
 sslverify=false
 
 YUM
@@ -408,6 +431,7 @@ name=OpenShift JBossEAP
 baseurl=${CONF_REPOS_BASE}/JBoss_EAP6_Cartridge/x86_64/os/
 enabled=1
 gpgcheck=0
+priority=1
 sslverify=false
 
 YUM
@@ -425,6 +449,7 @@ configure_jbosseap_repo()
 name=jbosseap
 baseurl=${CONF_JBOSS_REPO_BASE}/jbeap/6/os/
 enabled=1
+priority=3
 gpgcheck=0
 
 YUM
@@ -452,6 +477,7 @@ configure_jbossews_repo()
 name=jbossews
 baseurl=${CONF_JBOSS_REPO_BASE}/jbews/${ews_version}/os/
 enabled=1
+priority=3
 gpgcheck=0
 
 YUM
@@ -1835,6 +1861,7 @@ set_defaults()
   # subscriptions via RHN. Internally we use private systems.
   rhel_repo="$CONF_RHEL_REPO"
   jboss_repo_base="$CONF_JBOSS_REPO_BASE"
+  rhel_optional_repo="$CONF_RHEL_OPTIONAL_REPO"
 
   # The domain name for the OpenShift Enterprise installation.
   domain="${CONF_DOMAIN:-example.com}"
@@ -1949,10 +1976,16 @@ configure_console_msg
 is_false "$CONF_NO_NTP" && synchronize_clock
 is_false "$CONF_NO_SSH_KEYS" && install_ssh_keys
 
+
 # enable subscriptions / repositories according to requested method
 case "$CONF_INSTALL_METHOD" in
   (yum)
     configure_rhel_repo
+    if is_true "$CONF_OPTIONAL_REPO"
+    then
+      configure_optional_repo
+    fi
+
     if activemq || broker || datastore
     then
       configure_broker_repo
@@ -1966,12 +1999,24 @@ case "$CONF_INSTALL_METHOD" in
   (rhn)
      echo "Register with RHN using an activation key"
      rhnreg_ks --activationkey=${CONF_RHN_REG_ACTKEY} --profilename=${hostname}
-     broker && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-rhc --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     broker && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-infrastructure --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-node --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel rhel-x86_64-server-6-osop-1-jbosseap --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel jbappplatform-6-x86_64-server-6-rpm --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
-     node && rhn-channel --add --channel jb-ews-1-x86_64-server-6-rpm --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+     yum-config-manager --setopt=rhel-x86_64-server-6.priority=2 rhel-x86_64-server-6 --save
+
+     for channel in rhel-x86_64-server-6-osop-1-rhc rhel-x86_64-server-6-osop-1-infrastructure
+     do
+       broker && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=1 ${channel} --save
+     done
+     for channel in rhel-x86_64-server-6-osop-1-node rhel-x86_64-server-6-osop-1-jbosseap
+     do
+       node && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=1 ${channel} --save
+     done
+     for channel in jbappplatform-6-x86_64-server-6-rpm jb-ews-1-x86_64-server-6-rpm
+     do
+       node && rhn-channel --add --channel ${channel} --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
+       yum-config-manager --setopt=${channel}.priority=3 ${channel} --save
+     done
+
      if is_true "$CONF_OPTIONAL_REPO"
      then
        rhn-channel --add --channel rhel-x86_64-server-optional-6 --user ${CONF_RHN_REG_NAME} --password ${CONF_RHN_REG_PASS}
@@ -1984,6 +2029,9 @@ case "$CONF_INSTALL_METHOD" in
      echo "sam"
      ;;
 esac
+
+# Install yum-plugin-priorities
+yum clean all; yum install -y yum-plugin-priorities
 
 yum update -y
 


### PR DESCRIPTION
Until yum-plugin-priorities is moved to a product channel, the following
env variables need to be set to make sure priorities are honored:
CONF_OPTIONAL_REPO=1
CONF_RHEL_OPTIONAL_REPO=<repo base>/6Server/x86_64/optional

CONF_RHEL_OPTIONAL_REPO is only needed if using the yum install method
