### PR TITLE
<install-scripts> Bug 958625 - revert fix_passenger changes, add doc comments

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -224,6 +224,11 @@ install_broker_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Currently, ruby193-rubygem-passenger-native creates
+# /usr/var/log/passenger-analytics as its log directory, but our
+# software expects it to be at /var/log/passenger-analytics, and the
+# broker doesn't work if this folder isn't present and
+# accessible. This function fixes that.
 fix_passenger()
 {
   mkdir /var/log/passenger-analytics

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -468,6 +468,11 @@ install_broker_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Currently, ruby193-rubygem-passenger-native creates
+# /usr/var/log/passenger-analytics as its log directory, but our
+# software expects it to be at /var/log/passenger-analytics, and the
+# broker doesn't work if this folder isn't present and
+# accessible. This function fixes that.
 fix_passenger()
 {
   mkdir /var/log/passenger-analytics

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -516,6 +516,11 @@ install_broker_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Currently, ruby193-rubygem-passenger-native creates
+# /usr/var/log/passenger-analytics as its log directory, but our
+# software expects it to be at /var/log/passenger-analytics, and the
+# broker doesn't work if this folder isn't present and
+# accessible. This function fixes that.
 fix_passenger()
 {
   mkdir /var/log/passenger-analytics


### PR DESCRIPTION
This addresses https://bugzilla.redhat.com/show_bug.cgi?id=958625
- reverted change which eliminated the fix_passenger function from the install scripts
- added comments explaining why the function exists
