### PR TITLE
Bug 965970 - Do not chown /var/named

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1046,7 +1046,8 @@ key ${domain} {
 };
 EOF
 
-  chown named:named -R /var/named
+  chgrp named -R /var/named
+  chown named -R /var/named/dynamic
   restorecon -rv /var/named
 
   # Replace named.conf.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1299,7 +1299,8 @@ key ${domain} {
 };
 EOF
 
-  chown named:named -R /var/named
+  chgrp named -R /var/named
+  chown named -R /var/named/dynamic
   restorecon -rv /var/named
 
   # Replace named.conf.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1347,7 +1347,8 @@ key ${domain} {
 };
 EOF
 
-  chown named:named -R /var/named
+  chgrp named -R /var/named
+  chown named -R /var/named/dynamic
   restorecon -rv /var/named
 
   # Replace named.conf.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=965970

Chowning /var/named introduced avc denials when restarting bind, Change
the chown to chgrp.
