### PR TITLE
Add support for configuring mod_auth_kerb.

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1274,7 +1274,21 @@ EOF
 # Configure httpd for authentication.
 configure_httpd_auth()
 {
-  # Install the Apache configuration file.
+  # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
+  # and CONF_BROKER_KRB_AUTH_REALMS are specified
+  if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
+  then
+    yum_install_or_exit -y mod_auth_kerb
+    for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
+    do
+      sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
+        -e "s#KrbAuthRealms.*#KrbAuthRealms ${CONF_BROKER_KRB_AUTH_REALMS}#" \
+	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
+    done
+    return
+  fi
+
+  # Install the Apache Basic Authentication configuration file.
   cp /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
      /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -215,6 +215,15 @@
 #conf_valid_gear_sizes / CONF_VALID_GEAR_SIZES
 #CONF_VALID_GEAR_SIZES="small"
 
+# The KrbServiceName value for mod_auth_kerb configuration
+#CONF_BROKER_KRB_SERVICE_NAME=""
+
+# The KrbAuthRealms value for mod_auth_kerb configuration
+#CONF_BROKER_KRB_AUTH_REALMS=""
+
+# The Krb5KeyTab value of mod_auth_kerb is not configurable -- the keytab
+# is expected in /var/www/openshift/broker/httpd/conf.d/http.keytab
+
 # IMPORTANT NOTES - DEPENDENCIES
 #
 # In order for the %post section to succeed, it must have a way of
@@ -1540,7 +1549,21 @@ EOF
 # Configure httpd for authentication.
 configure_httpd_auth()
 {
-  # Install the Apache configuration file.
+  # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
+  # and CONF_BROKER_KRB_AUTH_REALMS are specified
+  if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
+  then
+    yum_install_or_exit -y mod_auth_kerb
+    for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
+    do
+      sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
+        -e "s#KrbAuthRealms.*#KrbAuthRealms ${CONF_BROKER_KRB_AUTH_REALMS}#" \
+	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
+    done
+    return
+  fi
+
+  # Install the Apache Basic Authentication configuration file.
   cp /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
      /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf
 


### PR DESCRIPTION
Two new configuration variables are recognized:
- CONF_BROKER_KRB_SERVICE_NAME for the KrbServiceName
- CONF_BROKER_KRB_AUTH_REALMS for the KrbAuthRealms

If both are specified, mod_auth_kerb package gets installed and enabled and AuthType Kerberos is configured with these values, instead of the default AuthType Basic.
