### PR TITLE
<install> Bug 976874 - Remove abrt-addon-python if necessary

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -229,6 +229,16 @@ install_node_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Remove abrt-addon-python if necessary
+# https://bugzilla.redhat.com/show_bug.cgi?id=907449
+# This only affects the python v2 cart
+remove_abrt_addon_python()
+{
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
+    yum remove -y abrt-addon-python
+  fi
+}
+
 # Install any cartridges developers may want.
 install_cartridges()
 {
@@ -1895,6 +1905,7 @@ node && configure_mcollective_for_activemq_on_node
 broker && install_broker_pkgs
 node && install_node_pkgs
 node && install_cartridges
+node && remove_abrt_addon_python
 broker && install_rhc_pkg
 
 broker && enable_services_on_broker

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -509,6 +509,16 @@ install_node_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Remove abrt-addon-python if necessary
+# https://bugzilla.redhat.com/show_bug.cgi?id=907449
+# This only affects the python v2 cart
+remove_abrt_addon_python()
+{
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
+    yum remove -y abrt-addon-python
+  fi
+}
+
 # Install any cartridges developers may want.
 install_cartridges()
 {
@@ -2175,6 +2185,7 @@ node && configure_mcollective_for_activemq_on_node
 broker && install_broker_pkgs
 node && install_node_pkgs
 node && install_cartridges
+node && remove_abrt_addon_python
 broker && install_rhc_pkg
 
 broker && enable_services_on_broker

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -557,6 +557,16 @@ install_node_pkgs()
   yum_install_or_exit -y $pkgs
 }
 
+# Remove abrt-addon-python if necessary
+# https://bugzilla.redhat.com/show_bug.cgi?id=907449
+# This only affects the python v2 cart
+remove_abrt_addon_python()
+{
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
+    yum remove -y abrt-addon-python
+  fi
+}
+
 # Install any cartridges developers may want.
 install_cartridges()
 {
@@ -2223,6 +2233,7 @@ node && configure_mcollective_for_activemq_on_node
 broker && install_broker_pkgs
 node && install_node_pkgs
 node && install_cartridges
+node && remove_abrt_addon_python
 broker && install_rhc_pkg
 
 broker && enable_services_on_broker


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=976874

abrt-addon-python does not play nicely with the python cartridge, remove
abrt-addon-python only if the following conditions are met:
1) RHEL 6.4 (RHEL 6.5 will contain an update to abrt-addon-python)
2) abrt-addon-python installed
3) python v2 cart installed
