### PR TITLE
Use pam_succeed_if with pam_namespace

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -420,6 +420,7 @@ configure_pam_on_node()
     t="/etc/pam.d/$f"
     if ! grep -q "pam_namespace.so" "$t"
     then
+      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
       echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
     fi
   done

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -700,6 +700,7 @@ configure_pam_on_node()
     t="/etc/pam.d/$f"
     if ! grep -q "pam_namespace.so" "$t"
     then
+      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
       echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
     fi
   done

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -748,6 +748,7 @@ configure_pam_on_node()
     t="/etc/pam.d/$f"
     if ! grep -q "pam_namespace.so" "$t"
     then
+      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
       echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
     fi
   done


### PR DESCRIPTION
Use pam_succeed_if to check that the user's shell is set to
/usr/bin/oo-trap-user and only require pam_namespace if it is.

In this manner, we target our polyinstantiation configuration to gear
users only.  The old, less-targetted approach has been causing problems
in some environments where polyinstantiation was not desired for regular
users.

Thanks Dan Trainor for suggesting the pam_succeed_if rule!
