### PR TITLE
openshift.ks: Remove doc for CONF_NO_SSH_KEYS

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -162,13 +162,6 @@
 #   other means.
 #CONF_NO_NTP=true
 
-# no_ssh_keys / CONF_NO_SSH_KEYS
-#   Default: false
-#   Enabling this option prevents the installation script from
-#   creating an initial authorized_keys file for ssh with a hardcoded
-#   ssh key (see install_ssh_keys).
-#CONF_NO_SSH_KEYS=true
-
 # Passwords used to secure various services. You are advised to specify
 # only alphanumeric values in this script as others may cause syntax
 # errors depending on context. If non-alphanumeric values are required,

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -161,13 +161,6 @@
 #   other means.
 #CONF_NO_NTP=true
 
-# no_ssh_keys / CONF_NO_SSH_KEYS
-#   Default: false
-#   Enabling this option prevents the installation script from
-#   creating an initial authorized_keys file for ssh with a hardcoded
-#   ssh key (see install_ssh_keys).
-#CONF_NO_SSH_KEYS=true
-
 # Passwords used to secure various services. You are advised to specify
 # only alphanumeric values in this script as others may cause syntax
 # errors depending on context. If non-alphanumeric values are required,


### PR DESCRIPTION
Remove the documentation for CONF_NO_SSH_KEYS because the setting was
removed in commit a4d5df084153f13acb4334197304f41e43d38e0b.
