### PR TITLE
openshift.ks: Use /root/.ssh and not ~/.ssh

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1365,7 +1365,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker
   ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
-  cp ~/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes, but there is no good way
   # to script that generically. Nodes should not have password-less 
   # access to brokers to copy the .pub key, but this can be performed

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1657,7 +1657,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker
   ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
-  cp ~/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes, but there is no good way
   # to script that generically. Nodes should not have password-less 
   # access to brokers to copy the .pub key, but this can be performed

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1705,7 +1705,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker
   ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
-  cp ~/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes, but there is no good way
   # to script that generically. Nodes should not have password-less 
   # access to brokers to copy the .pub key, but this can be performed


### PR DESCRIPTION
In configure_access_keys_on_broker, use /root/.ssh instead of ~/.ssh because ~ expands to /tmp in kickstarts, and so the rsync keys weren't being copied to /etc/openshift.

Thanks to Rich Lucente for the report.
