### PR TITLE
openshift.ks: Add CONF_DATASTORE_REPLICANTS

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -980,6 +980,25 @@ enable_services_on_broker()
   chown apache:root /var/log/mcollective-client.log
 }
 
+
+generate_mcollective_pools_configuration()
+{
+  num_replicants=0
+  members=
+  for replicant in ${activemq_replicants//,/ }
+  do
+    let num_replicants=num_replicants+1
+    new_member="plugin.activemq.pool.${num_replicants}.host = ${replicant}
+plugin.activemq.pool.${num_replicants}.port = 61613
+plugin.activemq.pool.${num_replicants}.user = ${mcollective_user}
+plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
+"
+    members="${members}${new_member}"
+  done
+
+  printf 'plugin.activemq.pool.size = %d\n%s' "$num_replicants" "$members"
+}
+
 # Configure mcollective on the broker to use ActiveMQ.
 configure_mcollective_for_activemq_on_broker()
 {
@@ -997,11 +1016,7 @@ securityprovider=psk
 plugin.psk = asimplething
 
 connector = activemq
-plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = ${activemq_hostname}
-plugin.activemq.pool.1.port = 61613
-plugin.activemq.pool.1.user = ${mcollective_user}
-plugin.activemq.pool.1.password = ${mcollective_password}
+$(generate_mcollective_pools_configuration)
 
 # Facts
 factsource = yaml
@@ -1030,11 +1045,7 @@ securityprovider = psk
 plugin.psk = asimplething
 
 connector = activemq
-plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = ${activemq_hostname}
-plugin.activemq.pool.1.port = 61613
-plugin.activemq.pool.1.user = ${mcollective_user}
-plugin.activemq.pool.1.password = ${mcollective_password}
+$(generate_mcollective_pools_configuration)
 
 # Facts
 factsource = yaml
@@ -1052,6 +1063,41 @@ install_activemq_pkgs()
 
 configure_activemq()
 {
+  networkConnectors=
+  authenticationUser_amq=
+  function allow_openwire() { false; }
+  for replicant in ${activemq_replicants//,/ }
+  do
+    if ! [ "$replicant" = "$activemq_hostname" ]
+    then
+      : ${networkConnectors:='        <networkConnectors>'$'\n'}
+      : ${authenticationUser_amq:="<authenticationUser username=\"amq\" password=\"${activemq_amq_user_password}\" groups=\"admins,everyone\" />"}
+      function allow_openwire() { true; }
+      networkConnectors="$networkConnectors            <!--"$'\n'
+      networkConnectors="$networkConnectors                 Create a pair of network connectors to each other"$'\n'
+      networkConnectors="$networkConnectors                 ActiveMQ broker.  It is necessary to have separate"$'\n'
+      networkConnectors="$networkConnectors                 connectors for topics and queues because we need to"$'\n'
+      networkConnectors="$networkConnectors                 leave conduitSubscriptions enabled for topics in order"$'\n'
+      networkConnectors="$networkConnectors                 to avoid duplicate messages and enable it for queues in"$'\n'
+      networkConnectors="$networkConnectors                 order to ensure that JMS selectors are propagated.  In"$'\n'
+      networkConnectors="$networkConnectors                 particular, the OpenShift broker uses the"$'\n'
+      networkConnectors="$networkConnectors                 mcollective.node queue to directly address nodes,"$'\n'
+      networkConnectors="$networkConnectors                 which subscribe to the queue using JMS selectors."$'\n'
+      networkConnectors="$networkConnectors            -->"$'\n'
+      networkConnectors="$networkConnectors            <networkConnector name=\"${activemq_hostname}-${replicant}-topics\" duplex=\"true\" uri=\"static:(tcp://${replicant}:61616)\" userName=\"amq\" password=\"password\">"$'\n'
+      networkConnectors="$networkConnectors                <excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors                    <queue physicalName=\">\" />"$'\n'
+      networkConnectors="$networkConnectors                </excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors            </networkConnector>"$'\n'
+      networkConnectors="$networkConnectors            <networkConnector name=\"${activemq_hostname}-${replicant}-queues\" duplex=\"true\" uri=\"static:(tcp://${replicant}:61616)\" userName=\"amq\" password=\"password\" conduitSubscriptions=\"false\">"$'\n'
+      networkConnectors="$networkConnectors                <excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors                    <topic physicalName=\">\" />"$'\n'
+      networkConnectors="$networkConnectors                </excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors            </networkConnector>"$'\n'
+    fi
+  done
+  networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
+
   cat <<EOF > /etc/activemq/activemq.xml
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1101,24 +1147,28 @@ configure_activemq()
 
         <destinationPolicy>
             <policyMap>
-              <policyEntries>
-                <policyEntry topic=">" producerFlowControl="true" memoryLimit="1mb">
-                  <pendingSubscriberPolicy>
-                    <vmCursor />
-                  </pendingSubscriberPolicy>
-                </policyEntry>
-                <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
-                  <!-- Use VM cursor for better latency
-                       For more information, see:
+                <policyEntries>
+                    <!--
+                      The Puppet Labs documentation for MCollective
+                      advises disabling producerFlowControl for all
+                      topics in order to avoid MCollective servers
+                      appearing blocked during heavy traffic.
 
-                       http://activemq.apache.org/message-cursors.html
+                      For more information, see:
+                      http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+                    -->
+                    <policyEntry topic=">" producerFlowControl="false" />
+                    <!--
+                      The Puppet Labs documentation advises enabling
+                      garbage-collection of queues because MCollective
+                      creates a uniquely named, single-use queue for
+                      each reply.
 
-                  <pendingQueuePolicy>
-                    <vmQueueCursor/>
-                  </pendingQueuePolicy>
-                  -->
-                </policyEntry>
-              </policyEntries>
+                      For more information, see:
+                      http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+                    -->
+                    <policyEntry queue="*.reply.>" gcInactiveDestinations="true" inactiveTimoutBeforeGC="300000" />
+                </policyEntries>
             </policyMap>
         </destinationPolicy>
 
@@ -1145,6 +1195,8 @@ configure_activemq()
             <kahaDB directory="\${activemq.data}/kahadb"/>
         </persistenceAdapter>
 
+$networkConnectors
+
         <!-- add users for mcollective -->
 
         <plugins>
@@ -1152,6 +1204,7 @@ configure_activemq()
           <simpleAuthenticationPlugin>
              <users>
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
+               ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
              </users>
           </simpleAuthenticationPlugin>
@@ -1243,6 +1296,7 @@ EOF
 
   # Allow connections to ActiveMQ.
   lokkit --nostart --port=61613:tcp
+  allow_openwire && lokkit --nostart --port=61616:tcp
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -1960,11 +2014,21 @@ set_defaults()
   # specified, append :27017 to its host name.
   datastore_replicants="$(echo "${datastore_replicants}" | sed -e 's/\([^:,]\+\)\(,\|$\)/\1:27017\2/g')"
 
+  # If no list of replicants is provided, assume there is only one
+  # ActiveMQ host.
+  activemq_replicants="${CONF_ACTIVEMQ_REPLICANTS:-$activemq_hostname}"
+
   # Set default passwords
   #
   #   This is the admin password for the ActiveMQ admin console, which 
   #   is not needed by OpenShift but might be useful in troubleshooting.
   activemq && activemq_admin_password="${CONF_ACTIVEMQ_ADMIN_PASSWORD:-${randomized//[![:alnum:]]}}"
+
+  #   This is the password for the ActiveMQ amq user, which is used by
+  #   ActiveMQ broker replicants to communicate with one another.  The
+  #   amq user is enabled only if replicants are specified using the
+  #   activemq_replicants.setting
+  activemq && activemq_amq_user_password="${CONF_ACTIVEMQ_AMQ_USER_PASSWORD:-password}"
 
   #   This is the user and password shared between broker and node for
   #   communicating over the mcollective topic channels in ActiveMQ. 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -271,6 +271,13 @@
 #   other means.
 #CONF_NO_NTP=true
 
+# activemq_replicants / CONF_ACTIVEMQ_REPLICANTS
+#   Default: the value of activemq_hostname
+#   A comma-separated list of ActiveMQ broker replicants.  If you are
+#   not installing in a configuration with ActiveMQ replication, you can
+#   leave this setting at its default value.
+#CONF_ACTIVEMQ_REPLICANTS="activemq01.example.com,activemq02.example.com"
+
 # Passwords used to secure various services. You are advised to specify
 # only alphanumeric values in this script as others may cause syntax
 # errors depending on context. If non-alphanumeric values are required,
@@ -281,6 +288,14 @@
 #   This is the admin password for the ActiveMQ admin console, which is
 #   not needed by OpenShift but might be useful in troubleshooting.
 #CONF_ACTIVEMQ_ADMIN_PASSWORD="ChangeMe"
+
+# activemq_amq_user_password / CONF_ACTIVEMQ_AMQ_USER_PASSWORD
+#   Default: password
+#   This is the password for the ActiveMQ amq user, which is
+#   used by ActiveMQ broker replicants to communicate with one another.
+#   The amq user is enabled only if replicants are specified using
+#   the activemq_replicants setting.
+#CONF_ACTIVEMQ_AMQ_USER_PASSWORD="ChangeMe"
 
 
 # datastore_replicants / CONF_DATASTORE_REPLICANTS
@@ -1328,6 +1343,25 @@ enable_services_on_broker()
   chown apache:root /var/log/mcollective-client.log
 }
 
+
+generate_mcollective_pools_configuration()
+{
+  num_replicants=0
+  members=
+  for replicant in ${activemq_replicants//,/ }
+  do
+    let num_replicants=num_replicants+1
+    new_member="plugin.activemq.pool.${num_replicants}.host = ${replicant}
+plugin.activemq.pool.${num_replicants}.port = 61613
+plugin.activemq.pool.${num_replicants}.user = ${mcollective_user}
+plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
+"
+    members="${members}${new_member}"
+  done
+
+  printf 'plugin.activemq.pool.size = %d\n%s' "$num_replicants" "$members"
+}
+
 # Configure mcollective on the broker to use ActiveMQ.
 configure_mcollective_for_activemq_on_broker()
 {
@@ -1345,11 +1379,7 @@ securityprovider=psk
 plugin.psk = asimplething
 
 connector = activemq
-plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = ${activemq_hostname}
-plugin.activemq.pool.1.port = 61613
-plugin.activemq.pool.1.user = ${mcollective_user}
-plugin.activemq.pool.1.password = ${mcollective_password}
+$(generate_mcollective_pools_configuration)
 
 # Facts
 factsource = yaml
@@ -1378,11 +1408,7 @@ securityprovider = psk
 plugin.psk = asimplething
 
 connector = activemq
-plugin.activemq.pool.size = 1
-plugin.activemq.pool.1.host = ${activemq_hostname}
-plugin.activemq.pool.1.port = 61613
-plugin.activemq.pool.1.user = ${mcollective_user}
-plugin.activemq.pool.1.password = ${mcollective_password}
+$(generate_mcollective_pools_configuration)
 
 # Facts
 factsource = yaml
@@ -1400,6 +1426,41 @@ install_activemq_pkgs()
 
 configure_activemq()
 {
+  networkConnectors=
+  authenticationUser_amq=
+  function allow_openwire() { false; }
+  for replicant in ${activemq_replicants//,/ }
+  do
+    if ! [ "$replicant" = "$activemq_hostname" ]
+    then
+      : ${networkConnectors:='        <networkConnectors>'$'\n'}
+      : ${authenticationUser_amq:="<authenticationUser username=\"amq\" password=\"${activemq_amq_user_password}\" groups=\"admins,everyone\" />"}
+      function allow_openwire() { true; }
+      networkConnectors="$networkConnectors            <!--"$'\n'
+      networkConnectors="$networkConnectors                 Create a pair of network connectors to each other"$'\n'
+      networkConnectors="$networkConnectors                 ActiveMQ broker.  It is necessary to have separate"$'\n'
+      networkConnectors="$networkConnectors                 connectors for topics and queues because we need to"$'\n'
+      networkConnectors="$networkConnectors                 leave conduitSubscriptions enabled for topics in order"$'\n'
+      networkConnectors="$networkConnectors                 to avoid duplicate messages and enable it for queues in"$'\n'
+      networkConnectors="$networkConnectors                 order to ensure that JMS selectors are propagated.  In"$'\n'
+      networkConnectors="$networkConnectors                 particular, the OpenShift broker uses the"$'\n'
+      networkConnectors="$networkConnectors                 mcollective.node queue to directly address nodes,"$'\n'
+      networkConnectors="$networkConnectors                 which subscribe to the queue using JMS selectors."$'\n'
+      networkConnectors="$networkConnectors            -->"$'\n'
+      networkConnectors="$networkConnectors            <networkConnector name=\"${activemq_hostname}-${replicant}-topics\" duplex=\"true\" uri=\"static:(tcp://${replicant}:61616)\" userName=\"amq\" password=\"password\">"$'\n'
+      networkConnectors="$networkConnectors                <excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors                    <queue physicalName=\">\" />"$'\n'
+      networkConnectors="$networkConnectors                </excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors            </networkConnector>"$'\n'
+      networkConnectors="$networkConnectors            <networkConnector name=\"${activemq_hostname}-${replicant}-queues\" duplex=\"true\" uri=\"static:(tcp://${replicant}:61616)\" userName=\"amq\" password=\"password\" conduitSubscriptions=\"false\">"$'\n'
+      networkConnectors="$networkConnectors                <excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors                    <topic physicalName=\">\" />"$'\n'
+      networkConnectors="$networkConnectors                </excludedDestinations>"$'\n'
+      networkConnectors="$networkConnectors            </networkConnector>"$'\n'
+    fi
+  done
+  networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
+
   cat <<EOF > /etc/activemq/activemq.xml
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
@@ -1449,24 +1510,28 @@ configure_activemq()
 
         <destinationPolicy>
             <policyMap>
-              <policyEntries>
-                <policyEntry topic=">" producerFlowControl="true" memoryLimit="1mb">
-                  <pendingSubscriberPolicy>
-                    <vmCursor />
-                  </pendingSubscriberPolicy>
-                </policyEntry>
-                <policyEntry queue=">" producerFlowControl="true" memoryLimit="1mb">
-                  <!-- Use VM cursor for better latency
-                       For more information, see:
+                <policyEntries>
+                    <!--
+                      The Puppet Labs documentation for MCollective
+                      advises disabling producerFlowControl for all
+                      topics in order to avoid MCollective servers
+                      appearing blocked during heavy traffic.
 
-                       http://activemq.apache.org/message-cursors.html
+                      For more information, see:
+                      http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+                    -->
+                    <policyEntry topic=">" producerFlowControl="false" />
+                    <!--
+                      The Puppet Labs documentation advises enabling
+                      garbage-collection of queues because MCollective
+                      creates a uniquely named, single-use queue for
+                      each reply.
 
-                  <pendingQueuePolicy>
-                    <vmQueueCursor/>
-                  </pendingQueuePolicy>
-                  -->
-                </policyEntry>
-              </policyEntries>
+                      For more information, see:
+                      http://docs.puppetlabs.com/mcollective/deploy/middleware/activemq.html
+                    -->
+                    <policyEntry queue="*.reply.>" gcInactiveDestinations="true" inactiveTimoutBeforeGC="300000" />
+                </policyEntries>
             </policyMap>
         </destinationPolicy>
 
@@ -1493,6 +1558,8 @@ configure_activemq()
             <kahaDB directory="\${activemq.data}/kahadb"/>
         </persistenceAdapter>
 
+$networkConnectors
+
         <!-- add users for mcollective -->
 
         <plugins>
@@ -1500,6 +1567,7 @@ configure_activemq()
           <simpleAuthenticationPlugin>
              <users>
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
+               ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
              </users>
           </simpleAuthenticationPlugin>
@@ -1591,6 +1659,7 @@ EOF
 
   # Allow connections to ActiveMQ.
   lokkit --nostart --port=61613:tcp
+  allow_openwire && lokkit --nostart --port=61616:tcp
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -2308,11 +2377,21 @@ set_defaults()
   # specified, append :27017 to its host name.
   datastore_replicants="$(echo "${datastore_replicants}" | sed -e 's/\([^:,]\+\)\(,\|$\)/\1:27017\2/g')"
 
+  # If no list of replicants is provided, assume there is only one
+  # ActiveMQ host.
+  activemq_replicants="${CONF_ACTIVEMQ_REPLICANTS:-$activemq_hostname}"
+
   # Set default passwords
   #
   #   This is the admin password for the ActiveMQ admin console, which 
   #   is not needed by OpenShift but might be useful in troubleshooting.
   activemq && activemq_admin_password="${CONF_ACTIVEMQ_ADMIN_PASSWORD:-${randomized//[![:alnum:]]}}"
+
+  #   This is the password for the ActiveMQ amq user, which is used by
+  #   ActiveMQ broker replicants to communicate with one another.  The
+  #   amq user is enabled only if replicants are specified using the
+  #   activemq_replicants.setting
+  activemq && activemq_amq_user_password="${CONF_ACTIVEMQ_AMQ_USER_PASSWORD:-password}"
 
   #   This is the user and password shared between broker and node for
   #   communicating over the mcollective topic channels in ActiveMQ. 


### PR DESCRIPTION
Add the CONF_DATASTORE_REPLICANTS setting, which specifies
a comma-separated list of hostnames that will be configured to constitute
a MongoDB replica set.  This setting defaults to the value of
CONF_DATASTORE_REPLICANTS.

If the number of replicants is 1 (which is the case with the default
value), then replication is not configured.

Add the CONF_MONGODB_KEY setting, which specifies the key that will be used
by replicants.  This setting defaults to 'OSEnterprise'.

Add the CONF_MONGODB_REPLSET setting, which specifies the name of the
replica set.  This setting defaults to 'ose'.

Factor the new execute_mongodb function out of configure_datastore.

Factor the new configure_datastore_add_users function out of
configure_datastore.

Add the configure_datastore_add_replicants function, which can be
invoked as an action on the host that is to be the primary.  Note that we
cannot perform this step during the initial installation because it will
fail if not all hosts in the replica set are up and running mongod.

Factor the new set_mongodb function out of configure_datastore.

Modify configure_datastore to configure user accounts only for
a non-replicated setup and otherwise to configure appropriate settings
(rest, journal, replSet, and keyFile) for a replicated setup and to
write out mongodb.key.

Modify configure_controller to set MONGO_HOST_PORT to the entire replica
set.

Modify set_defaults to accommodate the new settings and to append the port
specification :27017 to each hostname in the replica set that does not
already have a port specification.
