### PR TITLE
<openshift.ks> Added zerombr line for full automation of KS

### DIFF
--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -369,6 +369,7 @@ selinux --enforcing
 
 bootloader --location=mbr --driveorder=vda --append=" rhgb crashkernel=auto quiet console=ttyS0"
 
+zerombr
 clearpart --all --initlabel
 firstboot --disable
 reboot


### PR DESCRIPTION
Starting in anaconda-13.21.176-1 shipped with RHEL 6.3
The 'zerombr' line was necessary to have fully automated
kickstart. Documented in RHEL 6.3 technilate notes and
Red Hat Article 117513
