### PR TITLE
openshift.ks: Delete redundant nl variable

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1377,9 +1377,9 @@ EOF
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
-    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}${nl}" >> $nsdb
-    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
-    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
+    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}" >> $nsdb
+    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
+    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     pairs=(${NAMED_ENTRIES//,/ })

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1747,9 +1747,9 @@ EOF
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
-    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}${nl}" >> $nsdb
-    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
-    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
+    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}" >> $nsdb
+    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
+    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     pairs=(${NAMED_ENTRIES//,/ })

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1796,9 +1796,9 @@ EOF
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
-    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}${nl}" >> $nsdb
-    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
-    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
+    node && echo "${node_hostname%.${domain}}			A	${node_ip_addr}" >> $nsdb
+    activemq && echo "${activemq_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
+    datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     pairs=(${NAMED_ENTRIES//,/ })


### PR DESCRIPTION
configure_named: Delete the ${nl} variable from several echo statements. The echo command already prints a newline, and ${nl} is undefined, so it was expanding to an empty string anyway.
