### PR TITLE
openshift.ks: Delete NAMED_ENTRIES

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1373,7 +1373,6 @@ ${domain}		IN SOA	${named_hostname}. hostmaster.${domain}. (
 \$ORIGIN ${domain}.
 ${named_hostname%.${domain}}			A	${named_ip_addr}
 EOF
-  NAMED_ENTRIES=${CONF_NAMED_ENTRIES}
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
@@ -1382,7 +1381,7 @@ EOF
     datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
-    pairs=(${NAMED_ENTRIES//,/ })
+    pairs=(${CONF_NAMED_ENTRIES//,/ })
     for i in "${!pairs[@]}"
     do
       host_ip=${pairs[i]}

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1743,7 +1743,6 @@ ${domain}		IN SOA	${named_hostname}. hostmaster.${domain}. (
 \$ORIGIN ${domain}.
 ${named_hostname%.${domain}}			A	${named_ip_addr}
 EOF
-  NAMED_ENTRIES=${CONF_NAMED_ENTRIES}
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
@@ -1752,7 +1751,7 @@ EOF
     datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
-    pairs=(${NAMED_ENTRIES//,/ })
+    pairs=(${CONF_NAMED_ENTRIES//,/ })
     for i in "${!pairs[@]}"
     do
       host_ip=${pairs[i]}

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1792,7 +1792,6 @@ ${domain}		IN SOA	${named_hostname}. hostmaster.${domain}. (
 \$ORIGIN ${domain}.
 ${named_hostname%.${domain}}			A	${named_ip_addr}
 EOF
-  NAMED_ENTRIES=${CONF_NAMED_ENTRIES}
   if [ -z $CONF_NAMED_ENTRIES ]; then
     # Add A records any other components that are being installed locally.
     broker && echo "${broker_hostname%.${domain}}			A	${broker_ip_addr}" >> $nsdb
@@ -1801,7 +1800,7 @@ EOF
     datastore && echo "${datastore_hostname%.${domain}}			A	${cur_ip_addr}${nl}" >> $nsdb
   else
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
-    pairs=(${NAMED_ENTRIES//,/ })
+    pairs=(${CONF_NAMED_ENTRIES//,/ })
     for i in "${!pairs[@]}"
     do
       host_ip=${pairs[i]}


### PR DESCRIPTION
configure_named: Instead of setting NAMED_ENTRIES=${CONF_NAMED_ENTRIES} and then using NAMED_ENTRIES, just use CONF_NAMED_ENTRIES directly.
