### PR TITLE
openshift.ks: Delete unused keyfile variable

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1323,10 +1323,6 @@ install_named_pkgs()
 
 configure_named()
 {
-
-  # $keyfile will contain a new DNSSEC key for our domain.
-  keyfile=/var/named/${domain}.key
-
   if [ "x$bind_key" = x ]
   then
     # Generate the new key for the domain.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1693,10 +1693,6 @@ install_named_pkgs()
 
 configure_named()
 {
-
-  # $keyfile will contain a new DNSSEC key for our domain.
-  keyfile=/var/named/${domain}.key
-
   if [ "x$bind_key" = x ]
   then
     # Generate the new key for the domain.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1742,10 +1742,6 @@ install_named_pkgs()
 
 configure_named()
 {
-
-  # $keyfile will contain a new DNSSEC key for our domain.
-  keyfile=/var/named/${domain}.key
-
   if [ "x$bind_key" = x ]
   then
     # Generate the new key for the domain.


### PR DESCRIPTION
configure_named: Delete the keyfile variable, which is defined but never used.

The variable held the full path to the key file for BIND.  There is only one place where we could use that variable, and it is clearer just to use the full path there instead of $keyfile.
