### PR TITLE
openshift.ks: Install yum-utils if needed

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -395,6 +395,10 @@ configure_rhsm_channels()
    # have yum sync new list of repos from rhsm before changing settings
    yum repolist
 
+   # The yum-config-manager command is provided by the yum-utils
+   # package.
+   yum_install_or_exit yum-utils
+
    # Note: yum-config-manager never indicates errors in return code, and the output is difficult to parse; so,
    # it is tricky to determine when these fail due to subscription problems etc.
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -765,6 +765,10 @@ configure_rhsm_channels()
    # have yum sync new list of repos from rhsm before changing settings
    yum repolist
 
+   # The yum-config-manager command is provided by the yum-utils
+   # package.
+   yum_install_or_exit yum-utils
+
    # Note: yum-config-manager never indicates errors in return code, and the output is difficult to parse; so,
    # it is tricky to determine when these fail due to subscription problems etc.
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -814,6 +814,10 @@ configure_rhsm_channels()
    # have yum sync new list of repos from rhsm before changing settings
    yum repolist
 
+   # The yum-config-manager command is provided by the yum-utils
+   # package.
+   yum_install_or_exit yum-utils
+
    # Note: yum-config-manager never indicates errors in return code, and the output is difficult to parse; so,
    # it is tricky to determine when these fail due to subscription problems etc.
 


### PR DESCRIPTION
configure_rhsm_channels: Install yum-utils before trying to run yum-config-manager, which is shipped in the yum-utils package.  A minimal RHEL6 installation may not have yum-utils installed.  (Thanks for the report, Tim Hunt!)
