### PR TITLE
openshift.ks: Don't immediately run sysctl

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -801,14 +801,6 @@ configure_sysctl_on_node()
   set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
 
   set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
-
-  # Reload sysctl.conf to get the new settings.
-  #
-  # Note: We could add -e here to ignore errors that are caused by
-  # options appearing in sysctl.conf that correspond to kernel modules
-  # that are not yet loaded.  On the other hand, adding -e might cause
-  # us to miss some important error messages.
-  sysctl -p /etc/sysctl.conf
 }
 
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1171,14 +1171,6 @@ configure_sysctl_on_node()
   set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
 
   set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
-
-  # Reload sysctl.conf to get the new settings.
-  #
-  # Note: We could add -e here to ignore errors that are caused by
-  # options appearing in sysctl.conf that correspond to kernel modules
-  # that are not yet loaded.  On the other hand, adding -e might cause
-  # us to miss some important error messages.
-  sysctl -p /etc/sysctl.conf
 }
 
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1220,14 +1220,6 @@ configure_sysctl_on_node()
   set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
 
   set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
-
-  # Reload sysctl.conf to get the new settings.
-  #
-  # Note: We could add -e here to ignore errors that are caused by
-  # options appearing in sysctl.conf that correspond to kernel modules
-  # that are not yet loaded.  On the other hand, adding -e might cause
-  # us to miss some important error messages.
-  sysctl -p /etc/sysctl.conf
 }
 
 


### PR DESCRIPTION
configure_sysctl_on_node: Delete the sysctl command to immediately load sysctl settings.

Trying to load sysctl settings during configuration produces error messages for settings that comes from kernel modules that are not loaded at installation time, and we already expect the user to reboot the host anyway to start services and put other configuration into effect after running the installation script.
