### PR TITLE
puppet was applying with relative user dir rather than class attr tmpdir

### DIFF
--- a/oo-install/workflows/origin_deploy/originator.rb
+++ b/oo-install/workflows/origin_deploy/originator.rb
@@ -238,7 +238,7 @@ host_order.each do |ssh_host|
     :check => 'puppet module list',
     :install => 'puppet module install openshift/openshift_origin',
     :apply => "puppet apply --verbose #{@tmpdir}/#{hostfile}",
-    :clear => "rm ~/#{hostfile}",
+    :clear => "rm #{@tmpdir}/#{hostfile}",
     :reboot => 'reboot',
   }
   # Modify the commands with sudo & ssh as necessary for this target host


### PR DESCRIPTION
On my clean vagrant fedora box script was looking at user's home dir for `.pp` configure file. Should have looked in `tmpdir`.
