### PR TITLE
Enterprise 2.0 dns

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -74,17 +74,21 @@ configure_repos()
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
-    need_jbosseap_cartridge_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEAP}"; then
+      need_jbosseap_cartridge_repo() { :; }
 
-    # The jbosseap and jbossas cartridges require the jbossas packages
-    # in the jbappplatform channel.
-    need_jbosseap_repo() { :; }
+      # The jbosseap and jbossas cartridges require the jbossas packages
+      # in the jbappplatform channel.
+      need_jbosseap_repo() { :; }
+    fi
 
-    # The jbossews cartridge requires the tomcat packages in the jb-ews
-    # channel.
-    need_jbossews_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEWS}"; then
+      # The jbossews cartridge requires the tomcat packages in the jb-ews
+      # channel.
+      need_jbossews_repo() { :; }
+    fi
 
-    # The rhscl channel is needed for the ruby193 software collection.
+    # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
   fi
 
@@ -566,15 +570,19 @@ install_cartridges()
   # haproxy support.
   carts="$carts openshift-origin-cartridge-haproxy"
 
-  # JBossEWS support.
-  # Note: Be sure to subscribe to the JBossEWS entitlements during the
-  # base install or in configure_jbossews_repo.
-  carts="$carts openshift-origin-cartridge-jbossews"
+  if is_false "$CONF_NO_JBOSSEWS"; then
+    # JBossEWS support.
+    # Note: Be sure to subscribe to the JBossEWS entitlements during the
+    # base install or in configure_jbossews_repo.
+    carts="$carts openshift-origin-cartridge-jbossews"
+  fi
 
-  # JBossEAP support.
-  # Note: Be sure to subscribe to the JBossEAP entitlements during the
-  # base install or in configure_jbosseap_repo.
-  carts="$carts openshift-origin-cartridge-jbosseap"
+  if is_false "$CONF_NO_JBOSSEAP"; then
+    # JBossEAP support.
+    # Note: Be sure to subscribe to the JBossEAP entitlements during the
+    # base install or in configure_jbosseap_repo.
+    carts="$carts openshift-origin-cartridge-jbosseap"
+  fi
 
   # Jenkins server for continuous integration.
   carts="$carts openshift-origin-cartridge-jenkins"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -148,6 +148,15 @@
 #  CONF_INSTALL_COMPONENTS="node,broker,named,activemq,datastore"
 #CONF_INSTALL_COMPONENTS="node"
 
+# no_jbossews / CONF_NO_JBOSSEWS
+# no_jbosseap / CONF_NO_JBOSSEAP
+#   Default: false; do install JBoss cartridges
+#   If set, skips the parts of the installation that are necessary for
+#   using the JBoss EAP or EWS cartridge, including channels and RPMs.
+#   This makes it easier to install without JBoss channels/repos.
+#CONF_NO_JBOSSEWS=1
+#CONF_NO_JBOSSEAP=1
+
 # install_method / CONF_INSTALL_METHOD
 #   Choose from the following ways to provide packages:
 #     none - install sources are already set up when the script executes (DEFAULT)
@@ -471,17 +480,21 @@ configure_repos()
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
-    need_jbosseap_cartridge_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEAP}"; then
+      need_jbosseap_cartridge_repo() { :; }
 
-    # The jbosseap and jbossas cartridges require the jbossas packages
-    # in the jbappplatform channel.
-    need_jbosseap_repo() { :; }
+      # The jbosseap and jbossas cartridges require the jbossas packages
+      # in the jbappplatform channel.
+      need_jbosseap_repo() { :; }
+    fi
 
-    # The jbossews cartridge requires the tomcat packages in the jb-ews
-    # channel.
-    need_jbossews_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEWS}"; then
+      # The jbossews cartridge requires the tomcat packages in the jb-ews
+      # channel.
+      need_jbossews_repo() { :; }
+    fi
 
-    # The rhscl channel is needed for the ruby193 software collection.
+    # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
   fi
 
@@ -954,15 +967,19 @@ install_cartridges()
   # haproxy support.
   carts="$carts openshift-origin-cartridge-haproxy"
 
-  # JBossEWS support.
-  # Note: Be sure to subscribe to the JBossEWS entitlements during the
-  # base install or in configure_jbossews_repo.
-  carts="$carts openshift-origin-cartridge-jbossews"
+  if is_false "$CONF_NO_JBOSSEWS"; then
+    # JBossEWS support.
+    # Note: Be sure to subscribe to the JBossEWS entitlements during the
+    # base install or in configure_jbossews_repo.
+    carts="$carts openshift-origin-cartridge-jbossews"
+  fi
 
-  # JBossEAP support.
-  # Note: Be sure to subscribe to the JBossEAP entitlements during the
-  # base install or in configure_jbosseap_repo.
-  carts="$carts openshift-origin-cartridge-jbosseap"
+  if is_false "$CONF_NO_JBOSSEAP"; then
+    # JBossEAP support.
+    # Note: Be sure to subscribe to the JBossEAP entitlements during the
+    # base install or in configure_jbosseap_repo.
+    carts="$carts openshift-origin-cartridge-jbosseap"
+  fi
 
   # Jenkins server for continuous integration.
   carts="$carts openshift-origin-cartridge-jenkins"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -147,6 +147,15 @@
 #  CONF_INSTALL_COMPONENTS="node,broker,named,activemq,datastore"
 #CONF_INSTALL_COMPONENTS="node"
 
+# no_jbossews / CONF_NO_JBOSSEWS
+# no_jbosseap / CONF_NO_JBOSSEAP
+#   Default: false; do install JBoss cartridges
+#   If set, skips the parts of the installation that are necessary for
+#   using the JBoss EAP or EWS cartridge, including channels and RPMs.
+#   This makes it easier to install without JBoss channels/repos.
+#CONF_NO_JBOSSEWS=1
+#CONF_NO_JBOSSEAP=1
+
 # install_method / CONF_INSTALL_METHOD
 #   Choose from the following ways to provide packages:
 #     none - install sources are already set up when the script executes (DEFAULT)
@@ -520,17 +529,21 @@ configure_repos()
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
-    need_jbosseap_cartridge_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEAP}"; then
+      need_jbosseap_cartridge_repo() { :; }
 
-    # The jbosseap and jbossas cartridges require the jbossas packages
-    # in the jbappplatform channel.
-    need_jbosseap_repo() { :; }
+      # The jbosseap and jbossas cartridges require the jbossas packages
+      # in the jbappplatform channel.
+      need_jbosseap_repo() { :; }
+    fi
 
-    # The jbossews cartridge requires the tomcat packages in the jb-ews
-    # channel.
-    need_jbossews_repo() { :; }
+    if is_false "${CONF_NO_JBOSSEWS}"; then
+      # The jbossews cartridge requires the tomcat packages in the jb-ews
+      # channel.
+      need_jbossews_repo() { :; }
+    fi
 
-    # The rhscl channel is needed for the ruby193 software collection.
+    # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
   fi
 
@@ -1003,15 +1016,19 @@ install_cartridges()
   # haproxy support.
   carts="$carts openshift-origin-cartridge-haproxy"
 
-  # JBossEWS support.
-  # Note: Be sure to subscribe to the JBossEWS entitlements during the
-  # base install or in configure_jbossews_repo.
-  carts="$carts openshift-origin-cartridge-jbossews"
+  if is_false "$CONF_NO_JBOSSEWS"; then
+    # JBossEWS support.
+    # Note: Be sure to subscribe to the JBossEWS entitlements during the
+    # base install or in configure_jbossews_repo.
+    carts="$carts openshift-origin-cartridge-jbossews"
+  fi
 
-  # JBossEAP support.
-  # Note: Be sure to subscribe to the JBossEAP entitlements during the
-  # base install or in configure_jbosseap_repo.
-  carts="$carts openshift-origin-cartridge-jbosseap"
+  if is_false "$CONF_NO_JBOSSEAP"; then
+    # JBossEAP support.
+    # Note: Be sure to subscribe to the JBossEAP entitlements during the
+    # base install or in configure_jbosseap_repo.
+    carts="$carts openshift-origin-cartridge-jbosseap"
+  fi
 
   # Jenkins server for continuous integration.
   carts="$carts openshift-origin-cartridge-jenkins"


### PR DESCRIPTION
Some minor changes for better control of the DNS entries created (or not).

Also, enables using IPs instead of hostnames for the hosts; in this case the hostname is not changed.

Leaving this open for review...
