### PR TITLE
Refactor oo-admin-check-sources.py, add repo_db.py for resolving repo attributes

### DIFF
--- a/admin/check-sources/check_sources.py
+++ b/admin/check-sources/check_sources.py
@@ -17,7 +17,6 @@ NAME = 'oo-admin-check-sources'
 VERSION = '0.1'
 USAGE = 'Apply a thin layer to scalp and sing'
 RHNPLUGINCONF = '/etc/yum/pluginconf.d/rhnplugin.conf'
-PackageCopy = namedtuple('PackageCopy', 'name, arch, epoch, version, release, repoid')
 
 class OpenShiftCheckSources:
     conf_backups = {}
@@ -215,7 +214,7 @@ class OpenShiftCheckSources:
 
     def all_repoids(self):
         """Returns a list of repoids for all currently enabled repositories"""
-        return self.repoids()
+        return self.repoids(self.all_repos())
 
     def enabled_repos(self):
         """Returns a list of all currently enabled repositories"""

--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python -tt
 
 import sys
+import repo_db
 from check_sources import OpenShiftCheckSources
 from itertools import chain
 
@@ -9,8 +10,22 @@ RHEL_PRIORITY = 20
 JBOSS_PRIORITY = 30
 OTHER_PRIORITY = 40
 
+UNKNOWN, RHSM, RHN = ('unknown', 'rhsm', 'rhn')
+
+def flatten(llist):
+    """Cheap and easy flatten - only works up to two degrees of nesting.
+
+    Works on this: [1, 2, [3], [4, 5]] but won't handle [1, 2, [3], [4, [5]]]
+    """
+    try:
+        return [item for sublist in llist for item in sublist]
+    except TypeError:
+        newlist = flatten(filter(lambda xx: hasattr(xx, '__iter__'), llist))
+        return newlist + filter(lambda xx: not hasattr(xx, '__iter__'), llist)
+
 class OpenShiftAdminCheckSources:
     valid_roles = ['node', 'broker', 'client', 'node-eap']
+    valid_oo_versions = ['1.2', '2.0']
 
     pri_header = False
     pri_resolve_header = False
@@ -33,10 +48,6 @@ class OpenShiftAdminCheckSources:
     rhsm_jboss_repos = {'node': 'jb-ews-2-for-rhel-6-server-rpms',
                         'node-eap': 'jb-eap-6-for-rhel-6-server-rpms'}
 
-    required_rhn_repos = []
-    required_rhsm_repos = []
-    uses_rhn = False
-    uses_rhsm = False
     report_sections = ['start', 'missing', 'priority', 'end']
 
     def __init__(self, opts, opt_parser):
@@ -44,29 +55,98 @@ class OpenShiftAdminCheckSources:
         self.opt_parser = opt_parser
         self.oscs = OpenShiftCheckSources()
         self.report = {}
-        if not self.opts.role:
-            self.guess_role()
-        if self.opts.role:
-            self.opts.role = [xx.lower() for xx in self.opts.role]
-            if not (set(self.valid_roles).intersection(self.opts.role)):
-                self.help_quit()
-            if 'node-eap' in self.opts.role and not 'node' in self.opts.role:
-                self.opts.role.append('node')
-            # There has to be a better way...
-            self.required_rhn_repos = filter(None, [self.rhn_ose_repos.get(xx) for xx in self.opts.role])
-            self.required_rhn_repos += filter(None, [self.rhn_jboss_repos.get(xx) for xx in self.opts.role])
-            self.required_rhsm_repos = filter(None, [self.rhsm_ose_repos.get(xx) for xx in self.opts.role])
-            self.required_rhsm_repos += filter(None, [self.rhsm_jboss_repos.get(xx) for xx in self.opts.role])
-        self.calculate_enabled_repos()
-        self.uses_rhn = set(self.rhn_ose_repos.values() + [self.rhn_rhel6_repo] + self.rhn_jboss_repos.values()).intersection(self.oscs.enabled_repoids())
-        self.uses_rhsm = set(self.rhsm_ose_repos.values() + [self.rhsm_rhel6_repo] + self.rhsm_jboss_repos.values()).intersection(self.oscs.enabled_repoids())
+        self.subscription = UNKNOWN
 
-    def calculate_enabled_repos(self):
-        enabled = self.oscs.repoids(self.oscs.order_repos_by_priority())
-        self.enabled_rhsm_ose_repos   = list(set(self.rhsm_ose_repos.values()).intersection(enabled, self.required_rhsm_repos))
-        self.enabled_rhn_ose_repos    = list(set(self.rhn_ose_repos.values()).intersection(enabled, self.required_rhn_repos))
-        self.enabled_rhsm_jboss_repos = list(set(self.rhsm_jboss_repos.values()).intersection(enabled, self.required_rhsm_repos))
-        self.enabled_rhn_jboss_repos  = list(set(self.rhn_jboss_repos.values()).intersection(enabled, self.required_rhn_repos))
+    def required_repos(self):
+        return flatten([repo_db.find_repos(subscription = self.subscription,
+                                           role = rr,
+                                           product_version = self.opts.oo_version)
+                        for rr in self.opts.role])
+
+    def required_repoids(self):
+        return flatten([repo_db.find_repoids(subscription = self.subscription,
+                                             role = rr,
+                                             product_version = self.opts.oo_version)
+                        for rr in self.opts.role])
+
+    def enabled_blessed_repos(self):
+        enabled = self.oscs.enabled_repoids()
+        return [repo for repo in repo_db.find_repos_by_repoid(enabled)
+                if repo.subscription == self.subscription
+                and repo.product_version == self.opts.oo_version]
+
+    def blessed_repoids(self, **kwargs):
+        return [repo.repoid for repo in self.blessed_repos(**kwargs)]
+
+    def blessed_repos(self, enabled = False, required = False, product = None):
+        kwargs = {'subscription': self.subscription, 'product_version': self.opts.oo_version}
+        if product:
+            kwargs['product'] = product
+        req_repos = self.required_repos()
+        if enabled:
+            if required:
+                return [repo for repo in self.required_repos() 
+                        if repo.repoid in self.oscs.enabled_repoids()
+                        and (not product or repo.product == product)]
+            return [repo for repo in repo_db.find_repoids(**kwargs)
+                    if repo.repoid in self.oscs.enabled_repoids()]
+        if required:
+            return [repo for repo in self.required_repos()
+                    if not product or repo.product == product]
+        return repo_db.find_repos(**kwargs)
+        
+    def _sub_ver(self, subscription, version):
+        if subscription == 'rhsm':
+            self.subscription = RHSM
+        if subscription == 'rhn':
+            self.subscription = RHN
+        if not self.opts.oo_version:
+            self._print_report('start', 'Detected installed OpenShift Enterprise version %s'%version)
+            self.opts.oo_version = version
+
+    def guess_ose_version(self):
+        matches = repo_db.find_repos_by_repoid(self.oscs.all_repoids())
+        rhsm_ose_2_0 = [xx for xx in matches
+                        if xx in repo_db.find_repos(subscription = 'rhsm', product_version = '2.0', product = 'ose')]
+        rhn_ose_2_0 = [xx for xx in matches
+                       if xx in repo_db.find_repos(subscription = 'rhn', product_version = '2.0', product = 'ose')]
+        rhsm_ose_1_2 = [xx for xx in matches
+                        if xx in repo_db.find_repos(subscription = 'rhsm', product_version = '1.2', product = 'ose')]
+        rhn_ose_1_2 = [xx for xx in matches
+                       if xx in repo_db.find_repos(subscription = 'rhn', product_version = '1.2', product = 'ose')]
+        rhsm_2_0_avail = [xx for xx in rhsm_ose_2_0 if xx.repoid in self.oscs.enabled_repoids()]
+        rhn_2_0_avail = [xx for xx in rhn_ose_2_0 if xx.repoid in self.oscs.enabled_repoids()]
+        rhsm_1_2_avail = [xx for xx in rhsm_ose_1_2 if xx.repoid in self.oscs.enabled_repoids()]
+        rhn_1_2_avail = [xx for xx in rhn_ose_1_2 if xx.repoid in self.oscs.enabled_repoids()]
+        rhsm_2_0_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhsm_2_0_avail])
+        rhn_2_0_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhn_2_0_avail])
+        rhsm_1_2_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhsm_1_2_avail])
+        rhn_1_2_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhn_1_2_avail])
+        if rhsm_2_0_pkgs:
+            self._sub_ver('rhsm', '2.0')
+            return True
+        if rhn_2_0_pkgs:
+            self._sub_ver('rhn', '2.0')
+            return True
+        if rhsm_1_2_pkgs:
+            self._sub_ver('rhsm', '1.2')
+            return True
+        if rhn_1_2_pkgs:
+            self._sub_ver('rhn', '1.2')
+            return True
+        if rhsm_2_0_avail:
+            self._sub_ver('rhsm', '2.0')
+            return True
+        if rhn_2_0_avail:
+            self._sub_ver('rhn', '2.0')
+            return True
+        if rhsm_1_2_avail:
+            self._sub_ver('rhsm', '1.2')
+            return True
+        if rhn_1_2_avail:
+            self._sub_ver('rhn', '1.2')
+            return True
+        return False
 
     def help_quit(self, msg=None):
         if msg:
@@ -120,9 +200,15 @@ class OpenShiftAdminCheckSources:
         else:
             if not self.pri_resolve_header:
                 self.pri_resolve_header = True
-                self._print_report('priority', "To resolve conflicting repositories, update repo priority by running:")
+                if self.oscs.repo_is_rhn(repoid):
+                    self._print_report('priority', "To resolve conflicting repositories, update /yum/pluginconf.d/rhnplugin.conf with the following changes:")
+                else:
+                    self._print_report('priority', "To resolve conflicting repositories, update repo priority by running:")
             # TODO: in the next version this should read "# subscription-manager override --repo=%s --add=priority:%d"
-            self._print_report('priority', "# yum-config-manager --setopt=%s.priority=%d %s --save"%(repoid, priority, repoid))
+            if self.oscs.repo_is_rhn(repoid):
+                self._print_report('priority', "Set priority=%d in the [%s] section"%(priority, repoid))
+            else:
+                self._print_report('priority', "# yum-config-manager --setopt=%s.priority=%d %s --save"%(repoid, priority, repoid))
 
     def _check_valid_pri(self, repos):
         bad_repos = [(xx, self.oscs.repo_priority(xx)) for xx in repos if self.oscs.repo_priority(xx) >= 99]
@@ -156,32 +242,16 @@ class OpenShiftAdminCheckSources:
 
     def verify_priorities(self):
         self._print_report('priority', 'Checking channel/repository priorities')
-        if self.uses_rhsm:
-            self.verify_rhel_priorities(self.enabled_rhsm_ose_repos, self.rhsm_rhel6_repo)
-            if 0 < len(self.enabled_rhsm_jboss_repos):
-                self.verify_jboss_priorities(self.enabled_rhsm_ose_repos, self.enabled_rhsm_jboss_repos, self.rhsm_rhel6_repo)
-        if self.uses_rhn:
-            self.verify_rhel_priorities(self.enabled_rhn_ose_repos, self.rhn_rhel6_repo)
-            if 0 < len(self.enabled_rhn_jboss_repos):
-                self.verify_jboss_priorities(self.enabled_rhn_ose_repos, self.enabled_rhn_jboss_repos, self.rhn_rhel6_repo)
+        ose = self.blessed_repoids(enabled=True, required=True, product='ose')
+        jboss = self.blessed_repoids(enabled=True, required=True, product='jboss')
+        rhel = self.blessed_repoids(product='rhel')[0]
+        self.verify_rhel_priorities(ose, rhel)
+        if jboss:
+            self.verify_jboss_priorities(ose, jboss, rhel)
         return True
 
-    def check_missing_repos(self):
-        missing_repos = []
-        disabled_repos = []
-        for role in self.opts.role:
-            if self.uses_rhsm:
-                for repoid in filter(None, [self.rhsm_ose_repos.get(role), self.rhsm_jboss_repos.get(role)]):
-                    if repoid in self.oscs.disabled_repoids():
-                        disabled_repos.append(repoid)
-                    elif repoid not in self.oscs.enabled_repoids():
-                        missing_repos.append(repoid)
-            elif self.uses_rhn:
-                for repoid in filter(None, [self.rhn_ose_repos.get(role), self.rhn_jboss_repos.get(role)]):
-                    if repoid in self.oscs.disabled_repoids():
-                        disabled_repos.append(repoid)
-                    elif repoid not in self.oscs.enabled_repoids():
-                        missing_repos.append(repoid)
+    def check_disabled_repos(self):
+        disabled_repos = list(set(self.blessed_repoids(required = True)).intersection(self.oscs.disabled_repoids()))
         if disabled_repos:
             if self.opts.fix:
                 for ii in disabled_repos:
@@ -190,28 +260,30 @@ class OpenShiftAdminCheckSources:
                 self.calculate_enabled_repos()
             else:
                 self._print_report('missing', "The required OpenShift Enterprise repositories are disabled: %s"%disabled_repos)
-                if self.uses_rhn:
+                if self.subscription == RHN:
                     self._print_report('missing', 'Make the following modifications to /etc/yum/pluginconf.d/rhnplugin.conf')
                 else:
                     self._print_report('missing', "Enable these repositories with the following commands:")
                 for repoid in disabled_repos:
-                    if self.uses_rhn:
-                        self._print_report('missing', '    Add the [%s] section if missing, and under that make sure that "enabled=1" is set.'%repoid)
+                    if self.subscription == RHN:
+                        self._print_report('missing', "    Set enabled=1 in the [%s] section"%repoid)
                     else:
                         self._print_report('missing', "# yum-config-manager --enablerepo=%s %s --save"%(repoid, repoid))
-        if missing_repos:       # Not all of the missing repositories could be enabled
-            # if not self.opts.fix:
-            if True:
-                self._print_report('missing', "The required OpenShift Enterprise repositories are missing: %s"%missing_repos)
-                if self.uses_rhsm:
-                    self._print_report('missing', 'Follow the instructions at the following URL to add the necessary subscriptions for the selected roles: https://access.redhat.com/site/documentation//en-US/OpenShift_Enterprise/1/html/Deployment_Guide/chap-Installing_and_Configuring_Node_Hosts.html#Using_Red_Hat_Subscription_Management1')
-                    self._print_report('missing', 'After adding the subscriptions, verify that the following repoids are available and enabled:')
-                    for repoid in missing_repos:
-                        self._print_report('missing', "    %s"%repoid)
-                elif self.uses_rhn:
-                    self._print_report('missing', "Add the missing repositories with the following commands:")
-                    for repoid in missing_repos:
-                        self._print_report('missing', "# rhn-channel -a -c %s"%repoid)
+        return True
+
+    def check_missing_repos(self):
+        missing_repos = [repo for repo in self.blessed_repoids(required = True) if repo not in self.oscs.all_repoids()]
+        if missing_repos:
+            self._print_report('missing', "The required OpenShift Enterprise repositories are missing: %s"%missing_repos)
+            if self.subscription == RHSM:
+                self._print_report('missing', 'Follow the instructions at the following URL to add the necessary subscriptions for the selected roles: https://access.redhat.com/site/documentation//en-US/OpenShift_Enterprise/1/html/Deployment_Guide/chap-Installing_and_Configuring_Node_Hosts.html#Using_Red_Hat_Subscription_Management1')
+                self._print_report('missing', 'After adding the subscriptions, verify that the following repoids are available and enabled:')
+                for repoid in missing_repos:
+                    self._print_report('missing', "    %s"%repoid)
+            elif self.subscription == RHN:
+                self._print_report('missing', "Add the missing repositories with the following commands:")
+                for repoid in missing_repos:
+                    self._print_report('missing', "# rhn-channel -a -c %s"%repoid)
         return True             # Needed?
 
     def verify_repo_priority(self, repoid, required_repos):
@@ -230,15 +302,10 @@ class OpenShiftAdminCheckSources:
 
     def find_package_conflicts(self):
         self.pri_resolve_header = False
-        enabled_ose_repos = list(set(self.required_rhsm_repos + self.required_rhn_repos).intersection(self.enabled_rhsm_ose_repos + self.enabled_rhn_ose_repos))
-        # other_ose_repos = list(set(rhn_ose_repos.values() + rhsm_ose_repos.values()).difference(enabled_rhn_ose_repos))
-        all_repos = self.rhn_ose_repos.values() + self.rhsm_ose_repos.values() + self.rhsm_jboss_repos.values() + self.rhn_jboss_repos.values() + [self.rhsm_rhel6_repo, self.rhn_rhel6_repo]
-        enabled_jboss_repos = list(set(self.required_rhsm_repos + self.required_rhn_repos).intersection(self.enabled_rhsm_jboss_repos + self.enabled_rhn_jboss_repos))
-        rhel6_repo = []
-        if self.uses_rhsm:
-            rhel6_repo = [self.rhsm_rhel6_repo]
-        elif self.uses_rhn:
-            rhel6_repo = [self.rhn_rhel6_repo]
+        all_blessed_repos = repo_db.find_repoids(product_version = self.opts.oo_version)
+        enabled_ose_repos = self.blessed_repoids(enabled = True, required = True, product = 'ose')
+        enabled_jboss_repos = self.blessed_repoids(enabled = True, required = True, product = 'jboss')
+        rhel6_repo = self.blessed_repoids(product='rhel')
         required_repos = enabled_ose_repos + rhel6_repo + enabled_jboss_repos
         if not self._check_valid_pri(required_repos):
             return False
@@ -251,7 +318,7 @@ class OpenShiftAdminCheckSources:
             # print "ose_pkg_names count: %d"%(len(ose_pkg_names))
             # print "ose_pkg_names: "
             # map(sys.stdout.write, ('    %s\n'%xx for xx in ose_pkg_names))
-            other_pkg_matches = [xx for xx in self.oscs.all_packages_matching(ose_pkg_names, True) if xx.repoid not in all_repos]
+            other_pkg_matches = [xx for xx in self.oscs.all_packages_matching(ose_pkg_names, True) if xx.repoid not in all_blessed_repos]
             conflicts = sorted(set([xx.repoid for xx in other_pkg_matches]))
             # map(sys.stdout.write, ('nvr: %s-%s-%s   repoid: %s\n'%(xx.name, xx.ver, xx.release, xx.repoid) for xx in other_pkg_matches))
             for ii in conflicts:
@@ -277,6 +344,8 @@ class OpenShiftAdminCheckSources:
         return True
 
     def validate_roles(self):
+        if not self.opts.role:
+            return True
         for role in self.opts.role:
             if not role in self.valid_roles:
                 self._print_report('start', 'ERROR: You have specified an invalid role: %s is not one of %s'%(role, self.valid_roles))
@@ -284,36 +353,60 @@ class OpenShiftAdminCheckSources:
                 return False
         return True
 
-    def main(self):
-        if self.validate_roles():
+    def validate_version(self):
+        if self.opts.oo_version:
+            if not self.opts.oo_version in self.valid_oo_versions:
+                self._print_report('start', 'ERROR: You have specified an invalid version: %s is not one of %s'%(self.opts.oo_version, self.valid_oo_versions))
+                self.opt_parser.print_help()
+                return False
+        return True
+
+    def massage_roles(self):
+        if not self.opts.role:
+            self.guess_role()
+        if self.opts.role:
+            self.opts.role = [xx.lower() for xx in self.opts.role]
+            if 'node-eap' in self.opts.role and not 'node' in self.opts.role:
+                self.opts.role.append('node')
             if 'node' in self.opts.role and not 'node-eap' in self.opts.role:
                 self._print_report('start', 'NOTE: If this system will be providing the JBossEAP cartridge, re-run this command with the --role=node-eap argument')
-            yum_plugin_priorities = self.verify_yum_plugin_priorities()
-            self.check_missing_repos()
-            if not yum_plugin_priorities:
-                self._print_report('priority', 'Skipping yum priorities verification')
-            else:
-                self.verify_priorities()
-                self.find_package_conflicts()
-            if not self.opts.fix:
-                self._print_report('end', 'NOTE: Please re-run this tool after making any recommended repairs to this system')
 
+    def main(self):
+        if not self.validate_roles():
+            return False
+        self.massage_roles()
+        if not self.guess_ose_version():
+            self._print_report('start', 'ERROR: Could not determine subscription type or product version. Register your system to RHSM or RHN and re-run this script with the --oo_version argument')
+            return False
+        yum_plugin_priorities = self.verify_yum_plugin_priorities()
+        self.check_disabled_repos()
+        self.check_missing_repos()
+        if not yum_plugin_priorities:
+            self._print_report('priority', 'Skipping yum priorities verification')
+        else:
+            self.verify_priorities()
+            self.find_package_conflicts()
+        if not self.opts.fix:
+            self._print_report('end', 'NOTE: Please re-run this tool after making any recommended repairs to this system')
         # oacs.do_report()
 
 
 if __name__ == "__main__":
     ROLE_HELP='Role of this server (broker, node, node-eap, client)'
+    OO_VERSION_HELP='Version of OpenShift Enterprise in use on this system (1.2, 2.0, etc.)'
 
     try:
         import argparse
         opt_parser = argparse.ArgumentParser()
         opt_parser.add_argument('-r', '--role', default=None, type=str, action='append', help=ROLE_HELP)
+        opt_parser.add_argument('-o', '--oo_version', default=None, type=str, help=OO_VERSION_HELP)
         opt_parser.add_argument('-f', '--fix', action='store_true', help='If set, attempt to repair issues as well as warn')
         opts = opt_parser.parse_args()
     except ImportError:
         import optparse
         opt_parser = optparse.OptionParser()
         opt_parser.add_option('-r', '--role', default=None, type='string', action='append', help=ROLE_HELP)
+        opt_parser.add_option('-o', '--oo_version', default=None, type='string', help=OO_VERSION_HELP)
         opt_parser.add_option('-f', '--fix', action='store_true', help='If set, attempt to repair issues as well as warn')
         (opts, args) = opt_parser.parse_args()
     oacs = OpenShiftAdminCheckSources(opts, opt_parser)

--- a/admin/check-sources/repo_db.py
+++ b/admin/check-sources/repo_db.py
@@ -1,0 +1,226 @@
+#!/usr/bin/python -tt
+from collections import namedtuple
+from copy import copy
+
+RepoTuple = namedtuple('RepoTuple', 'subscription, product, product_version, role, repoid, key_pkg')
+
+repositories = [
+    # RHSM Common
+    RepoTuple(subscription = 'rhsm',
+              product = 'rhel',
+              product_version = ('1.2', '2.0'),
+              role = 'base',
+              repoid = 'rhel-6-server-rpms',
+              key_pkg = None),
+    RepoTuple(subscription = 'rhsm',
+              product = 'jboss',
+              product_version = ('1.2', '2.0'),
+              role = 'node',
+              repoid = 'jb-ews-2-for-rhel-6-server-rpms',
+              key_pkg = 'openshift-origin-cartridge-jbossews'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'jboss',
+              product_version = ('1.2', '2.0'),
+              role = 'node-eap',
+              repoid = 'jb-eap-6-for-rhel-6-server-rpms',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repositories += [
+    # RHSM 1.2 repos
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'node',
+              repoid = 'rhel-server-ose-1.2-node-6-rpms',
+              key_pkg = 'rubygem-openshift-origin-node'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'broker',
+              repoid = 'rhel-server-ose-1.2-infra-6-rpms',
+              key_pkg = 'openshift-origin-broker'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'client',
+              repoid = 'rhel-server-ose-1.2-rhc-6-rpms',
+              key_pkg = 'rhc'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'node-eap',
+              repoid = 'rhel-server-ose-1.2-jbosseap-6-rpms',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repositories += [
+    # RHSM 2.0 repos
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'node',
+              repoid = 'rhel-server-ose-2.0-node-6-rpms',
+              key_pkg = 'rubygem-openshift-origin-node'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'broker',
+              repoid = 'rhel-server-ose-2.0-infra-6-rpms',
+              key_pkg = 'openshift-origin-broker'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'client',
+              repoid = 'rhel-server-ose-2.0-rhc-6-rpms',
+              key_pkg = 'rhc'),
+    RepoTuple(subscription = 'rhsm',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'node-eap',
+              repoid = 'rhel-server-ose-2.0-jbosseap-6-rpms',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repositories += [
+    # RHN Common
+    RepoTuple(subscription = 'rhn',
+              product = 'rhel',
+              product_version = ('1.2', '2.0'),
+              role = 'base',
+              repoid = 'rhel-x86_64-server-6',
+              key_pkg = None),
+    RepoTuple(subscription = 'rhn',
+              product = 'jboss',
+              product_version = ('1.2', '2.0'),
+              role = 'node',
+              repoid = 'jb-ews-2-x86_64-server-6-rpm',
+              key_pkg = 'openshift-origin-cartridge-jbossews'),
+    RepoTuple(subscription = 'rhn',
+              product = 'jboss',
+              product_version = ('1.2', '2.0'),
+              role = 'node-eap',
+              repoid = 'jbappplatform-6-x86_64-server-6-rpm',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repositories += [
+    # RHN 1.2 repos
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'node',
+              repoid = 'rhel-x86_64-server-6-ose-1.2-node',
+              key_pkg = 'rubygem-openshift-origin-node'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'broker',
+              repoid = 'rhel-x86_64-server-6-ose-1.2-infrastructure',
+              key_pkg = 'openshift-origin-broker'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'client',
+              repoid = 'rhel-x86_64-server-6-ose-1.2-rhc',
+              key_pkg = 'rhc'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '1.2',
+              role = 'node-eap',
+              repoid = 'rhel-x86_64-server-6-ose-1.2-jbosseap',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repositories += [
+    # RHN 2.0 repos
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'node',
+              repoid = 'rhel-x86_64-server-6-ose-2.0-node',
+              key_pkg = 'rubygem-openshift-origin-node'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'broker',
+              repoid = 'rhel-x86_64-server-6-ose-2.0-infrastructure',
+              key_pkg = 'openshift-origin-broker'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'client',
+              repoid = 'rhel-x86_64-server-6-ose-2.0-rhc',
+              key_pkg = 'rhc'),
+    RepoTuple(subscription = 'rhn',
+              product = 'ose',
+              product_version = '2.0',
+              role = 'node-eap',
+              repoid = 'rhel-x86_64-server-6-ose-2.0-jbosseap',
+              key_pkg = 'openshift-origin-cartridge-jbosseap'),
+]
+
+repo_cache = {}
+
+def _repo_tuple_match(repo, match_attr, match_val):
+    # Could do this on one line, but this is more readable
+    attr = getattr(repo, match_attr, None)
+    if match_val == attr:
+        return True
+    return hasattr(attr, '__iter__') and match_val in attr
+
+def find_repos(**kwargs):
+    global repo_cache
+    if len(repo_cache) > 512:
+        # Try to keep the repo_cache from growing infinitely
+        # (Guessing 512 is too big is cheaper than calculating the actual mem footprint)
+        repo_cache = {}
+    hkey = tuple(sorted(kwargs.items()))
+    if None == repo_cache.get(hkey, None):
+        repos = copy(repositories)
+        for kk, vv in kwargs.items():
+            # print kk, vv
+            repos = [repo for repo in repos if _repo_tuple_match(repo, kk, vv)]
+            # print repos
+            if not repos:
+                break
+        repos = tuple(repos)
+        repo_cache[hkey] = repos
+        return repos
+    return repo_cache[hkey]
+
+def find_repoids(**kwargs):
+    return [repo.repoid for repo in find_repos(**kwargs)]
+
+def find_repos_by_repoid(repoids):
+    if hasattr(repoids, '__iter__'):
+        res = []
+        for r_id in repoids:
+            res += find_repos(repoid = r_id)
+        return tuple(set(res)) # make unique
+    return find_repos(repoid = repoids)
+
+if __name__ == '__main__':
+    print "find_repos(subscription = 'rhsm'):"
+    for xx in find_repos(subscription = 'rhsm'):
+        print xx
+    print ""
+    print "find_repos(product_version = '1.2'):"
+    for xx in find_repos(product_version = '1.2'):
+        print xx
+    print ""
+    print "find_repos(product_version = '1.2', role = 'node'):"
+    for xx in find_repos(product_version = '1.2', role = 'node'):
+        print xx
+    print ""
+    print "find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):"
+    for xx in find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):
+        print xx
+    print ""
+    print "find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):"
+    for xx in find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):
+        print xx
+    print ""
+    print "find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):"
+    for xx in find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):
+        print xx


### PR DESCRIPTION
This commit adds the repo_db module, which provides functions for
resolving repoids or lists of repoids against lists of "blessed" repos
and their expected or assigned attributes. For example, you can use
the enabled repos + installed packages on a system to guess the
version (by comparing against repoid and key_pkg attrs) and then use
that to verify the version and roles specified by a user.

oo-admin-check-sources.py has been rewritten to use repo_db, and also
changes the RHSM/RHN entitlement handling. Now "hybrid" systems aren't
supported, but rather for systems with both RHSM and RHN
subscriptions, RHSM is preferred unless all OpenShift channels are
provided by RHN.

This revision also adds version detection, so theoretically OpenShift
Enterprise 2.0 should be supported.
