### PR TITLE
Update workflow for more sensible yum-plugin-priorities advice

### DIFF
--- a/admin/check-sources/check_sources.py
+++ b/admin/check-sources/check_sources.py
@@ -12,6 +12,7 @@ sys.path.insert(0,'/usr/share/yum-cli')
 from utils import YumUtilBase
 from iniparse import INIConfig
 from collections import namedtuple
+from optparse import OptionParser
 
 NAME = 'oo-admin-check-sources'
 VERSION = '0.1'
@@ -36,8 +37,14 @@ class OpenShiftCheckSources:
         self.yb.preconf.quiet = True
         self.yb.preconf.debuglevel = 0
         self.yb.preconf.plugin_types = (plugins.TYPE_CORE, plugins.TYPE_INTERACTIVE)
+        op = OptionParser()
+        self.yb.preconf.optparser = op
         self.yb.conf.cache = os.geteuid() != 0
         self.yb.conf.disable_excludes = []
+        opts, args = op.parse_args([])
+        # The yum security plugin will crap pants if the plugin
+        # cmdline isn't set up:
+        self.yb.plugins.setCmdLine(opts, args)
 
     def _yb_no_pri(self):
         npyb = YumUtilBase(NAME, VERSION, USAGE)

--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -157,8 +157,11 @@ class OpenShiftAdminCheckSources:
         """
         self.logger.info('Checking if yum-plugin-priorities is installed')
         if not self.oscs.verify_package('yum-plugin-priorities'):
-            self.logger.error('Required package yum-plugin-priorities is not installed. Install the package with the following command:')
-            self.logger.error('# yum install yum-plugin-priorities')
+            if list(self.oscs.yb.searchGenerator(['name'], ['yum-plugin-priorities'])):
+                self.logger.error('Required package yum-plugin-priorities is not installed. Install the package with the following command:')
+                self.logger.error('# yum install yum-plugin-priorities')
+            else:
+                self.logger.error('Required package yum-plugin-priorities is not available.')
             return False
         return True
 
@@ -364,6 +367,8 @@ class OpenShiftAdminCheckSources:
         self.check_missing_repos()
         if not yum_plugin_priorities:
             self.logger.warning('Skipping yum priorities verification')
+            if not self.opts.role:
+                self.logger.warning('Please specify at least one role for this system with the --role command')
         else:
             self.verify_priorities()
             self.find_package_conflicts()


### PR DESCRIPTION
oo-admin-check-sources.py now refrains from telling the user to
install yum-plugin-priorities until a repository is found that carries
the package. The package is provided by the OSE repos, so from a blank
system, the tool guides the user through the following steps:
- Initial run
  - `oo-admin-check-sources.py`
- Select a version of OpenShift
  - `oo-admin-check-sources.py -o 1.2`
- Select one or more system role(s)
  - `oo-admin-check-sources.py -o 1.2 -r node -r node-eap`
- Register a subscription that provides the needed repos
  - `subscription-manager attach --pool=xyz`
  - `oo-admin-check-sources.py -o 1.2 -r node -r node-eap`
- Enable the needed repos:
  - `subscription-manager repos --enable=repo_id`
  - `oo-admin-check-sources.py -o 1.2 -r node -r node-eap`
- Install yum-plugin-priorities
  - `yum install yum-plugin-priorities`
  - `oo-admin-check-sources.py -o 1.2 -r node -r node-eap`
- Set appropriate repository priorities
  - `oo-admin-check-sources.py -o 1.2 -r node -r node-eap --fix`

In order to perform the package search during the yum-plugin-priorities verification step, `_init_yumbase` in `check_sources.py` needed to be updated to set a command line in the `YumBase.plugins` object via  `setCmdLine`. This works around a missing attribute error in the yum security plugin.
