### PR TITLE
<oo-admin-check-sources.py> Bug 1023359, detect disabled RHEL channel and language tweaks

### DIFF
--- a/admin/check-sources/check_sources.py
+++ b/admin/check-sources/check_sources.py
@@ -280,6 +280,10 @@ class OpenShiftCheckSources:
             return self._yb_no_pri().pkgSack.returnPackages(repoid=repoid)
         return self.yb.pkgSack.returnPackages(repoid=repoid)
 
+    def package_available(self, name):
+        sg = self.yb.searchGenerator(['name'], [name])
+        return next((pkg for pkg in sg if pkg[0].name == name), None)
+
     def verify_package(self, name, version=None, release=None, source=None):
         """Verifies that the named package matches the provided criteria
 


### PR DESCRIPTION
Updated required_repos routine to include RHEL base channel in
results, fixing 1023359.

Replaced both vague and overly-specific RHSM and RHN subscription
advice with link to KB article. The article has instructions for
attaching RHSM or RHN subscriptions for broker and node
systems. Instructions for OSE 2.0 will be included when they are
available.

Made available package detection more efficient by switching to
YumBase.searchGenerator()
