### PR TITLE
<oo-admin-check-sources> Bug 1023391 - repo priority and package conflicts checks are skipped when no role is specified or determinable

### DIFF
--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -363,11 +363,11 @@ class OpenShiftAdminCheckSources:
         self.check_missing_repos()
         if not yum_plugin_priorities:
             self.logger.warning('Skipping yum priorities verification')
-            if not self.opts.role:
-                self.logger.warning('Please specify at least one role for this system with the --role command')
-        else:
+        if self.opts.role:
             self.verify_priorities()
             self.find_package_conflicts()
+        else:
+            self.logger.warning('Please specify at least one role for this system with the --role command')
         if not self.opts.fix:
             self.logger.info('Please re-run this tool after making any recommended repairs to this system')
         # oacs.do_report()


### PR DESCRIPTION
Updated `main()` method logic to exclude repo priority and package
conflicts checks when no role can be determined. Also guaranteed that
the `--role` option advice is emitted whenever the role can't be
determined.
