### PR TITLE
<check-sources> Bug 1023374 - detect and fix/advise repo version conflicts

### DIFF
--- a/admin/check-sources/check_sources.py
+++ b/admin/check-sources/check_sources.py
@@ -196,6 +196,20 @@ class OpenShiftCheckSources:
         except RepoError:
             return False
 
+    def disable_repo(self, repoid):
+        """Disable the repository for the given repoid
+
+        Return false if the repoid doesn't identify a subscribed repository.
+        """
+        try:
+            repo = self._resolve_repoid(repoid)
+            if repo.isEnabled():
+                repo.disable()
+            self._set_save_repo_attr(repo, 'enabled', False)
+            return True
+        except RepoError:
+            return False
+
     def order_repos_by_priority(self, enabled=True):
         """Returns a list of repos ordered by priority
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1023374

Added logic to check for enabled repos with versions different from
detected or specified `oo_version`. Also added `disable_repo` method
to `check_sources.py` so mismatched repos can be disabled.

Bonus: Added "No problems were detected!" so humans can tell that
their repos pass muster.
