### PR TITLE
<check-sources> Add user-specified repository data - "expert mode"

### DIFF
--- a/admin/check-sources/README.md
+++ b/admin/check-sources/README.md
@@ -30,7 +30,10 @@ Make sure that this directory is in your load path for Python, either by setting
       -a, --fix-all         Attempt to repair all problems found.
       -p, --report-all      Report all problems (default is to halt after first
                             problem report.)
-
+      -c REPO_CONFIG, --repo-config=REPO_CONFIG
+                            Load blessed repository data from the specified file
+                            instead of built-in values
+                        
 ## Contributing
 
 1. Fork it

--- a/admin/check-sources/repo_db.py
+++ b/admin/check-sources/repo_db.py
@@ -1,176 +1,186 @@
 #!/usr/bin/python -tt
 from collections import namedtuple
 from copy import copy
+from iniparse import INIConfig
+import re
 
 RepoTuple = namedtuple('RepoTuple', 'subscription, product, product_version, role, repoid, key_pkg')
 
-repositories = [
-    # RHSM Common
-    RepoTuple(subscription = 'rhsm',
-              product = 'rhel',
-              product_version = ('1.2', '2.0'),
-              role = 'base',
-              repoid = 'rhel-6-server-rpms',
-              key_pkg = None),
-    RepoTuple(subscription = 'rhsm',
-              product = 'jboss',
-              product_version = ('1.2', '2.0'),
-              role = 'node',
-              repoid = 'jb-ews-2-for-rhel-6-server-rpms',
-              key_pkg = 'openshift-origin-cartridge-jbossews'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'jboss',
-              product_version = ('1.2', '2.0'),
-              role = 'node-eap',
-              repoid = 'jb-eap-6-for-rhel-6-server-rpms',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'rhscl',
-              product_version = ('1.2', '2.0'),
-              role = ('node', 'broker'),
-              repoid = 'rhel-server-rhscl-6-rpms',
-              key_pkg = 'ruby193'),
-]
+repo_ini = """# RHSM Common
 
-repositories += [
-    # RHSM 1.2 repos
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'node',
-              repoid = 'rhel-server-ose-1.2-node-6-rpms',
-              key_pkg = 'rubygem-openshift-origin-node'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'broker',
-              repoid = 'rhel-server-ose-1.2-infra-6-rpms',
-              key_pkg = 'openshift-origin-broker'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'client',
-              repoid = 'rhel-server-ose-1.2-rhc-6-rpms',
-              key_pkg = 'rhc'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'node-eap',
-              repoid = 'rhel-server-ose-1.2-jbosseap-6-rpms',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-]
+[rhel-6-server-rpms]
+subscription = rhsm
+product = rhel
+product_version = 1.2, 2.0
+role = base
+key_pkg = None
 
-repositories += [
-    # RHSM 2.0 repos
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'node',
-              repoid = 'rhel-6-server-ose-2.0-node-rpms',
-              key_pkg = 'rubygem-openshift-origin-node'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'broker',
-              repoid = 'rhel-6-server-ose-2.0-infra-rpms',
-              key_pkg = 'openshift-origin-broker'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'client',
-              repoid = 'rhel-6-server-ose-2.0-rhc-rpms',
-              key_pkg = 'rhc'),
-    RepoTuple(subscription = 'rhsm',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'node-eap',
-              repoid = 'rhel-6-server-ose-2.0-jbosseap-rpms',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-]
+[jb-ews-2-for-rhel-6-server-rpms]
+subscription = rhsm
+product = jboss
+product_version = 1.2, 2.0
+role = node
+key_pkg = openshift-origin-cartridge-jbossews
 
-repositories += [
-    # RHN Common
-    RepoTuple(subscription = 'rhn',
-              product = 'rhel',
-              product_version = ('1.2', '2.0'),
-              role = 'base',
-              repoid = 'rhel-x86_64-server-6',
-              key_pkg = None),
-    RepoTuple(subscription = 'rhn',
-              product = 'jboss',
-              product_version = ('1.2', '2.0'),
-              role = 'node',
-              repoid = 'jb-ews-2-x86_64-server-6-rpm',
-              key_pkg = 'openshift-origin-cartridge-jbossews'),
-    RepoTuple(subscription = 'rhn',
-              product = 'jboss',
-              product_version = ('1.2', '2.0'),
-              role = 'node-eap',
-              repoid = 'jbappplatform-6-x86_64-server-6-rpm',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-    RepoTuple(subscription = 'rhn',
-              product = 'rhscl',
-              product_version = ('1.2', '2.0'),
-              role = ('node', 'broker'),
-              repoid = 'rhel-x86_64-server-6-rhscl-1',
-              key_pkg = 'ruby193'),
-]
+[jb-eap-6-for-rhel-6-server-rpms]
+subscription = rhsm
+product = jboss
+product_version = 1.2, 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
 
-repositories += [
-    # RHN 1.2 repos
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'node',
-              repoid = 'rhel-x86_64-server-6-ose-1.2-node',
-              key_pkg = 'rubygem-openshift-origin-node'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'broker',
-              repoid = 'rhel-x86_64-server-6-ose-1.2-infrastructure',
-              key_pkg = 'openshift-origin-broker'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'client',
-              repoid = 'rhel-x86_64-server-6-ose-1.2-rhc',
-              key_pkg = 'rhc'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '1.2',
-              role = 'node-eap',
-              repoid = 'rhel-x86_64-server-6-ose-1.2-jbosseap',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-]
+[rhel-server-rhscl-6-rpms]
+subscription = rhsm
+product = rhscl
+product_version = 1.2, 2.0
+role = node, broker
+key_pkg = ruby193
+# RHSM 1.2 repos
 
-repositories += [
-    # RHN 2.0 repos
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'node',
-              repoid = 'rhel-x86_64-server-6-ose-2.0-node',
-              key_pkg = 'rubygem-openshift-origin-node'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'broker',
-              repoid = 'rhel-x86_64-server-6-ose-2.0-infrastructure',
-              key_pkg = 'openshift-origin-broker'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'client',
-              repoid = 'rhel-x86_64-server-6-ose-2.0-rhc',
-              key_pkg = 'rhc'),
-    RepoTuple(subscription = 'rhn',
-              product = 'ose',
-              product_version = '2.0',
-              role = 'node-eap',
-              repoid = 'rhel-x86_64-server-6-ose-2.0-jbosseap',
-              key_pkg = 'openshift-origin-cartridge-jbosseap'),
-]
+[rhel-server-ose-1.2-node-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-server-ose-1.2-infra-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-server-ose-1.2-rhc-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-server-ose-1.2-jbosseap-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHSM 2.0 repos
+
+[rhel-6-server-ose-2.0-node-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-6-server-ose-2.0-infra-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-6-server-ose-2.0-rhc-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = client
+key_pkg = rhc
+
+[rhel-6-server-ose-2.0-jbosseap-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHN Common
+
+[rhel-x86_64-server-6]
+subscription = rhn
+product = rhel
+product_version = 1.2, 2.0
+role = base
+key_pkg = None
+
+[jb-ews-2-x86_64-server-6-rpm]
+subscription = rhn
+product = jboss
+product_version = 1.2, 2.0
+role = node
+key_pkg = openshift-origin-cartridge-jbossews
+
+[jbappplatform-6-x86_64-server-6-rpm]
+subscription = rhn
+product = jboss
+product_version = 1.2, 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+[rhel-x86_64-server-6-rhscl-1]
+subscription = rhn
+product = rhscl
+product_version = 1.2, 2.0
+role = node, broker
+key_pkg = ruby193
+# RHN 1.2 repos
+
+[rhel-x86_64-server-6-ose-1.2-node]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-1.2-infrastructure]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-1.2-rhc]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-1.2-jbosseap]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHN 2.0 repos
+
+[rhel-x86_64-server-6-ose-2.0-node]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-2.0-infrastructure]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-2.0-rhc]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-2.0-jbosseap]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+"""
 
 repo_cache = {}
 
@@ -181,66 +191,109 @@ def _repo_tuple_match(repo, match_attr, match_val):
         return True
     return hasattr(attr, '__iter__') and match_val in attr
 
-def find_repos(**kwargs):
-    """Return (and cache) tuple of RepoTuples that match the criteria specified
-    """
-    global repo_cache
-    if len(repo_cache) > 512:
-        # Try to keep the repo_cache from growing infinitely
-        # (Guessing 512 is too big is cheaper than calculating the actual mem footprint)
-        repo_cache = {}
-    hkey = tuple(sorted(kwargs.items()))
-    if None == repo_cache.get(hkey, None):
-        repos = copy(repositories)
-        for kk, vv in kwargs.items():
-            # print kk, vv
-            repos = [repo for repo in repos if _repo_tuple_match(repo, kk, vv)]
-            # print repos
-            if not repos:
-                break
-        repos = tuple(repos)
-        repo_cache[hkey] = repos
-        return repos
-    return repo_cache[hkey]
+def parse_multivalue(val):
+    if val:
+        rv = tuple(re.split(', ', val))
+        if len(rv) == 1:
+            return rv[0]
+        return rv
+    return val
 
-def find_repoids(**kwargs):
-    """Return list of repoids for cooresponding results from find_repos
+class RepoDB:
+    repositories = []
+    repo_cache = {}
 
-    """
-    return [repo.repoid for repo in find_repos(**kwargs)]
+    def __init__(self, *args, **kwargs):
+        if not (args or kwargs):
+            self._load_defaults()
+        else:
+            try:
+                if not kwargs['user_repos_only']:
+                    self._load_defaults()
+                del(kwargs['user_repos_only'])
+            except KeyError:
+                self._load_defaults()
+            self.cfg = INIConfig(*args, **kwargs)
+        self.populate_db()
 
-def find_repos_by_repoid(repoids):
-    """Return tuple of RepoTuples which match the list of repoids provided
+    def _load_defaults(self):
+        from cStringIO import StringIO
+        self.cfg = INIConfig(StringIO(repo_ini))
+        self.populate_db()
 
-    """
-    if hasattr(repoids, '__iter__'):
-        res = []
-        for r_id in repoids:
-            res += find_repos(repoid = r_id)
-        return tuple(set(res)) # make unique
-    return find_repos(repoid = repoids)
+    def populate_db(self):
+        for ii in list(self.cfg):
+            rt = RepoTuple(
+                subscription =    parse_multivalue(self.cfg[ii]['subscription']),
+                product =         parse_multivalue(self.cfg[ii]['product']),
+                product_version = parse_multivalue(self.cfg[ii]['product_version']),
+                role =            parse_multivalue(self.cfg[ii]['role']),
+                repoid =          ii,
+                key_pkg =         parse_multivalue(self.cfg[ii]['key_pkg']))
+            if not rt in self.repositories:
+                self.repositories.append(rt)
+
+    def find_repos(self, **kwargs):
+        """Return (and cache) tuple of RepoTuples that match the criteria specified
+        """
+        if len(self.repo_cache) > 512:
+            # Try to keep the repo_cache from growing infinitely
+            # (Guessing 512 is too big is cheaper than calculating the actual mem footprint)
+            self.repo_cache = {}
+        hkey = tuple(sorted(kwargs.items()))
+        if None == self.repo_cache.get(hkey, None):
+            repos = copy(self.repositories)
+            for kk, vv in kwargs.items():
+                # print kk, vv
+                repos = [repo for repo in repos if _repo_tuple_match(repo, kk, vv)]
+                # print repos
+                if not repos:
+                    break
+            repos = tuple(repos)
+            self.repo_cache[hkey] = repos
+            return repos
+        return self.repo_cache[hkey]
+
+    def find_repoids(self, **kwargs):
+        """Return list of repoids for cooresponding results from find_repos
+
+        """
+        return [repo.repoid for repo in self.find_repos(**kwargs)]
+
+    def find_repos_by_repoid(self, repoids):
+        """Return tuple of RepoTuples which match the list of repoids provided
+
+        """
+        if hasattr(repoids, '__iter__'):
+            res = []
+            for r_id in repoids:
+                res += self.find_repos(repoid = r_id)
+            return tuple(set(res)) # make unique
+        return self.find_repos(repoid = repoids)
+
 
 if __name__ == '__main__':
+    rd = RepoDB()
     print "find_repos(subscription = 'rhsm'):"
-    for xx in find_repos(subscription = 'rhsm'):
+    for xx in rd.find_repos(subscription = 'rhsm'):
         print xx
     print ""
     print "find_repos(product_version = '1.2'):"
-    for xx in find_repos(product_version = '1.2'):
+    for xx in rd.find_repos(product_version = '1.2'):
         print xx
     print ""
     print "find_repos(product_version = '1.2', role = 'node'):"
-    for xx in find_repos(product_version = '1.2', role = 'node'):
+    for xx in rd.find_repos(product_version = '1.2', role = 'node'):
         print xx
     print ""
     print "find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):"
-    for xx in find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):
+    for xx in rd.find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):
         print xx
     print ""
     print "find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):"
-    for xx in find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):
+    for xx in rd.find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):
         print xx
     print ""
     print "find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):"
-    for xx in find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):
+    for xx in rd.find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):
         print xx

--- a/admin/check-sources/repos.ini
+++ b/admin/check-sources/repos.ini
@@ -1,0 +1,174 @@
+# RHSM Common
+
+[rhel-6-server-rpms]
+subscription = rhsm
+product = rhel
+product_version = 1.2, 2.0
+role = base
+key_pkg = None
+
+[jb-ews-2-for-rhel-6-server-rpms]
+subscription = rhsm
+product = jboss
+product_version = 1.2, 2.0
+role = node
+key_pkg = openshift-origin-cartridge-jbossews
+
+[jb-eap-6-for-rhel-6-server-rpms]
+subscription = rhsm
+product = jboss
+product_version = 1.2, 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+[rhel-server-rhscl-6-rpms]
+subscription = rhsm
+product = rhscl
+product_version = 1.2, 2.0
+role = node, broker
+key_pkg = ruby193
+# RHSM 1.2 repos
+
+[rhel-server-ose-1.2-node-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-server-ose-1.2-infra-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-server-ose-1.2-rhc-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-server-ose-1.2-jbosseap-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHSM 2.0 repos
+
+[rhel-6-server-ose-2.0-node-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-6-server-ose-2.0-infra-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-6-server-ose-2.0-rhc-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = client
+key_pkg = rhc
+
+[rhel-6-server-ose-2.0-jbosseap-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHN Common
+
+[rhel-x86_64-server-6]
+subscription = rhn
+product = rhel
+product_version = 1.2, 2.0
+role = base
+key_pkg = None
+
+[jb-ews-2-x86_64-server-6-rpm]
+subscription = rhn
+product = jboss
+product_version = 1.2, 2.0
+role = node
+key_pkg = openshift-origin-cartridge-jbossews
+
+[jbappplatform-6-x86_64-server-6-rpm]
+subscription = rhn
+product = jboss
+product_version = 1.2, 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+[rhel-x86_64-server-6-rhscl-1]
+subscription = rhn
+product = rhscl
+product_version = 1.2, 2.0
+role = node, broker
+key_pkg = ruby193
+# RHN 1.2 repos
+
+[rhel-x86_64-server-6-ose-1.2-node]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-1.2-infrastructure]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-1.2-rhc]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-1.2-jbosseap]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+# RHN 2.0 repos
+
+[rhel-x86_64-server-6-ose-2.0-node]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-2.0-infrastructure]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-2.0-rhc]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-2.0-jbosseap]
+subscription = rhn
+product = ose
+product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap


### PR DESCRIPTION
Updated `repo_db` to provide `RepoDB` class, refactored
`oo-admin-check-sources` to use the new class instead of module
methods.

Added `--repo-config` option, so users can now specify their own
ini-formatted repository configurations

Added ability to "blend" provided repo config with built-in values,
but concealed from user for now (might not be necessary)
