### PR TITLE
<oo-admin-check-sources.py> Bug 1026793, Added catch block to find_package_conflicts

### DIFF
--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -500,6 +500,8 @@ class OpenShiftAdminCheckSources:
             except KeyError as ke:
                 self.logger.error('Repository %s not enabled'%repoid)
                 res = False
+            except Errors.RepoError, e:
+                raise UnrecoverableYumError, e
         # for repoid, pri in self.resolved_repos.iteritems():
         #     if not old_resolved_repos.get(repoid, None) == pri:
         #         self._set_pri(repoid, pri)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1026793

`YumBase` call in `OpenShiftCheckSources.packages_for_repo` raised an
uncaught `RepoError`. This condition was reachable on systems where a
broken repo config exists and `yum-plugin-priorities` is
installed. Added logic to catch the `RepoError` and bail out.
