### PR TITLE
<check-sources> Clean up long lines, unpythonic names

### DIFF
--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -57,13 +57,15 @@ class OpenShiftAdminCheckSources:
         else:
             self.opts.subscription = self.opts.subscription.lower()
         if self.opts.repo_config:
-            self.rdb = repo_db.RepoDB(file(self.opts.repo_config), user_repos_only=self.opts.user_repos_only)
+            self.rdb = repo_db.RepoDB(file(self.opts.repo_config),
+                                      user_repos_only=self.opts.user_repos_only)
         else:
             self.rdb = repo_db.RepoDB()
 
     def _setup_logger(self):
         self.opts.loglevel = logging.INFO
-        self.logger = logging.getLogger() # TODO: log to file if specified, with requested severity
+        # TODO: log to file if specified, with requested severity
+        self.logger = logging.getLogger()
         self.logger.setLevel(self.opts.loglevel)
         ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(self.opts.loglevel)
@@ -71,7 +73,7 @@ class OpenShiftAdminCheckSources:
         self.logger.addHandler(ch)
         # if self.opts.logfile:
         #     self.logger.addHandler(logfilehandler)
-        
+
     def required_repos(self):
         """Return a list of RepoTuples that match the specified role,
         subscription type and oo-version
@@ -79,10 +81,12 @@ class OpenShiftAdminCheckSources:
         """
         # Include the base RHEL repo in the required repos
         roles = self.opts.role + ['base']
-        return flatten([self.rdb.find_repos(subscription = self.opts.subscription,
-                                           role = rr,
-                                           product_version = self.opts.oo_version)
-                        for rr in roles])
+        sub = self.opts.subscription
+        o_ver = self.opts.oo_version
+        return flatten([self.rdb.find_repos(subscription=sub,
+                                            role=role,
+                                            product_version=o_ver)
+                        for role in roles])
 
     def required_repoids(self):
         """Return a list of repoids as Strings that match the specified role,
@@ -124,13 +128,13 @@ class OpenShiftAdminCheckSources:
                    Default: None
         """
 
-        kwargs = {'subscription': self.opts.subscription, 'product_version': self.opts.oo_version}
+        kwargs = {'subscription': self.opts.subscription,
+                  'product_version': self.opts.oo_version}
         if product:
             kwargs['product'] = product
-        req_repos = self.required_repos()
         if enabled:
             if required:
-                return [repo for repo in self.required_repos() 
+                return [repo for repo in self.required_repos()
                         if repo.repoid in self.oscs.enabled_repoids()
                         and (not product or repo.product == product)]
             return [repo for repo in self.rdb.find_repos(**kwargs)
@@ -142,11 +146,14 @@ class OpenShiftAdminCheckSources:
 
     def _sub(self, subscription):
         self.opts.subscription = subscription
-        self.logger.info('Detected OpenShift Enterprise repository subscription managed by %s.'%SUBS_NAME[self.opts.subscription])
+        self.logger.info('Detected OpenShift Enterprise repository'
+                         'subscription managed by %s.' %
+                         SUBS_NAME[self.opts.subscription])
 
     def _oo_ver(self, version):
         self.opts.oo_version = version
-        self.logger.info('Detected installed OpenShift Enterprise version %s'%self.opts.oo_version)
+        self.logger.info('Detected installed OpenShift Enterprise'
+                         'version %s' % self.opts.oo_version)
 
     def _sub_ver(self, subscription, version = None):
         if self.opts.subscription == UNKNOWN and not self.opts.oo_version:
@@ -166,7 +173,8 @@ class OpenShiftAdminCheckSources:
                 self._oo_ver(version)
                 return True
         if self.opts.subscription != UNKNOWN and self.opts.oo_version:
-            if subscription == self.opts.subscription and (not version or version == self.opts.oo_version):
+            if (subscription == self.opts.subscription and
+                (not version or version == self.opts.oo_version)):
                 return True
         return False
 
@@ -181,40 +189,63 @@ class OpenShiftAdminCheckSources:
             # Short-circuit guess if user specifies sub and ver
             return True
         matches = self.rdb.find_repos_by_repoid(self.oscs.all_repoids())
-        rhsm_ose_2_0 = [xx for xx in matches
-                        if xx in self.rdb.find_repos(subscription = 'rhsm', product_version = '2.0', product = 'ose')]
-        rhn_ose_2_0 = [xx for xx in matches
-                       if xx in self.rdb.find_repos(subscription = 'rhn', product_version = '2.0', product = 'ose')]
-        rhsm_ose_1_2 = [xx for xx in matches
-                        if xx in self.rdb.find_repos(subscription = 'rhsm', product_version = '1.2', product = 'ose')]
-        rhn_ose_1_2 = [xx for xx in matches
-                       if xx in self.rdb.find_repos(subscription = 'rhn', product_version = '1.2', product = 'ose')]
-        rhsm_2_0_avail = [xx for xx in rhsm_ose_2_0 if xx.repoid in self.oscs.enabled_repoids()]
-        rhn_2_0_avail = [xx for xx in rhn_ose_2_0 if xx.repoid in self.oscs.enabled_repoids()]
-        rhsm_1_2_avail = [xx for xx in rhsm_ose_1_2 if xx.repoid in self.oscs.enabled_repoids()]
-        rhn_1_2_avail = [xx for xx in rhn_ose_1_2 if xx.repoid in self.oscs.enabled_repoids()]
-        rhsm_2_0_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhsm_2_0_avail])
-        rhn_2_0_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhn_2_0_avail])
-        rhsm_1_2_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhsm_1_2_avail])
-        rhn_1_2_pkgs = filter(None, [self.oscs.verify_package(xx.key_pkg, source=xx.repoid) for xx in rhn_1_2_avail])
+        rhsm_ose_2_0 = [repo for repo in matches if
+                        repo in self.rdb.find_repos(subscription = 'rhsm',
+                                                  product_version = '2.0',
+                                                  product = 'ose')]
+        rhn_ose_2_0 = [repo for repo in matches if
+                       repo in self.rdb.find_repos(subscription = 'rhn',
+                                                 product_version = '2.0',
+                                                 product = 'ose')]
+        rhsm_ose_1_2 = [repo for repo in matches if
+                        repo in self.rdb.find_repos(subscription = 'rhsm',
+                                                  product_version = '1.2',
+                                                  product = 'ose')]
+        rhn_ose_1_2 = [repo for repo in matches if
+                       repo in self.rdb.find_repos(subscription = 'rhn',
+                                                 product_version = '1.2',
+                                                 product = 'ose')]
+        rhsm_2_0_avail = [repo for repo in rhsm_ose_2_0 if repo.repoid in
+                          self.oscs.enabled_repoids()]
+        rhn_2_0_avail = [repo for repo in rhn_ose_2_0 if repo.repoid in
+                         self.oscs.enabled_repoids()]
+        rhsm_1_2_avail = [repo for repo in rhsm_ose_1_2 if repo.repoid in
+                          self.oscs.enabled_repoids()]
+        rhn_1_2_avail = [repo for repo in rhn_ose_1_2 if repo.repoid in
+                         self.oscs.enabled_repoids()]
+        rhsm_2_0_pkgs = filter(None,
+                               [self.oscs.verify_package(repo.key_pkg,
+                                                         source=repo.repoid)
+                                for repo in rhsm_2_0_avail])
+        rhn_2_0_pkgs = filter(None,
+                              [self.oscs.verify_package(repo.key_pkg,
+                                                        source=repo.repoid)
+                               for repo in rhn_2_0_avail])
+        rhsm_1_2_pkgs = filter(None,
+                               [self.oscs.verify_package(repo.key_pkg,
+                                                         source=repo.repoid)
+                                for repo in rhsm_1_2_avail])
+        rhn_1_2_pkgs = filter(None,
+                              [self.oscs.verify_package(repo.key_pkg,
+                                                        source=repo.repoid)
+                               for repo in rhn_1_2_avail])
         # This if ladder detects the subscription type and version
         # based on available OSE repos and which repos provide
         # installed packages. Maybe there's a better way?
-        if (
-                (rhsm_2_0_pkgs and self._sub_ver('rhsm', '2.0'))
-                or (rhn_2_0_pkgs and self._sub_ver('rhn', '2.0'))
-                or (rhsm_1_2_pkgs and self._sub_ver('rhsm', '1.2'))
-                or (rhn_1_2_pkgs and self._sub_ver('rhn', '1.2'))
-                or (rhsm_2_0_avail and self._sub_ver('rhsm', '2.0'))
-                or (rhn_2_0_avail and self._sub_ver('rhn', '2.0'))
-                or (rhsm_1_2_avail and self._sub_ver('rhsm', '1.2'))
-                or (rhn_1_2_avail and self._sub_ver('rhn', '1.2'))
-        ):
+        if ((rhsm_2_0_pkgs and self._sub_ver('rhsm', '2.0')) or
+            (rhn_2_0_pkgs and self._sub_ver('rhn', '2.0')) or
+            (rhsm_1_2_pkgs and self._sub_ver('rhsm', '1.2')) or
+            (rhn_1_2_pkgs and self._sub_ver('rhn', '1.2')) or
+            (rhsm_2_0_avail and self._sub_ver('rhsm', '2.0')) or
+            (rhn_2_0_avail and self._sub_ver('rhn', '2.0')) or
+            (rhsm_1_2_avail and self._sub_ver('rhsm', '1.2')) or
+            (rhn_1_2_avail and self._sub_ver('rhn', '1.2')) ):
             return True
         # This section detects just the subscription type if the
         # version has been specified or couldn't be determined by the
         # preceding logic.
-        for fxn_rcheck, sub in [(self.oscs.repo_is_rhsm, 'rhsm'), (self.oscs.repo_is_rhn, 'rhn')]:
+        for fxn_rcheck, sub in [(self.oscs.repo_is_rhsm, 'rhsm'),
+                                (self.oscs.repo_is_rhn, 'rhn')]:
             if self.opts.subscription == UNKNOWN:
                 for repoid in self.oscs.all_repoids():
                     if fxn_rcheck(repoid) and self._sub_ver(sub):
@@ -227,38 +258,58 @@ class OpenShiftAdminCheckSources:
     def check_version_conflict(self):
         """Determine if repositories for multiple versions of OpenShift have
         been wrongly enabled, and advice or fix accordingly.
-
         """
         matches = self.rdb.find_repos_by_repoid(self.oscs.enabled_repoids())
-        conflicts = filter(lambda xx: 
-                           (not hasattr(xx.product_version, '__iter__')
-                            and xx.product_version != self.opts.oo_version), matches)
+        conflicts = filter(lambda repo:
+                           not hasattr(repo.product_version, '__iter__') and
+                           not (repo.product_version == self.opts.oo_version),
+                           matches)
         if conflicts:
             self.problem = True
             if self.opts.fix:
-                for ii in conflicts:
-                    if self.oscs.disable_repo(ii.repoid):
-                        self.logger.warning('Disabled repository %s'%ii.repoid)
+                for repo in conflicts:
+                    if self.oscs.disable_repo(repo.repoid):
+                        self.logger.warning('Disabled repository %s' %
+                                            repo.repoid)
             else:
-                rhsm_conflicts = [repo.repoid for repo in conflicts if self.oscs.repo_is_rhsm(repo.repoid)]
-                rhn_conflicts = [repo.repoid for repo in conflicts if self.oscs.repo_is_rhn(repo.repoid)]
-                other_conflicts = [repo.repoid for repo in conflicts if not (repo.repoid in rhsm_conflicts or repo.repoid in rhn_conflicts)]
-                types = ""
+                rhsm_conflicts = [repo.repoid for repo in conflicts if
+                                  self.oscs.repo_is_rhsm(repo.repoid)]
+                rhn_conflicts = [repo.repoid for repo in conflicts if
+                                 self.oscs.repo_is_rhn(repo.repoid)]
+                other_conflicts = [repo.repoid for repo in conflicts if
+                                   not (repo.repoid in rhsm_conflicts or
+                                        repo.repoid in rhn_conflicts)]
                 if rhsm_conflicts:
-                    self.logger.error("The following Red Hat Subscription Manager-managed OpenShift Enterprise repositories conflict with the detected or specified product version.")
-                    self.logger.error("To prevent package conflicts, disable these repositories by running these commands:")
+                    self.logger.error('The following OpenShift Enterprise '
+                                      'repositories conflict with the '
+                                      'detected or specified product version.')
+                    self.logger.error('To prevent package conflicts, disable '
+                                      'these repositories by running these '
+                                      'commands:')
                     for repoid in rhsm_conflicts:
-                        self.logger.error("    # subscription-manager repos --disable=%s"%repoid)
+                        self.logger.error('    # subscription-manager repos '
+                                          '--disable=%s' % repoid)
                 if rhn_conflicts:
-                    self.logger.error("The following RHN Classic or RHN Satellite-managed OpenShift Enterprise repositories conflict with the detected or specified product version.")
-                    self.logger.error('To prevent package conflicts, disable these repositories by making the following modifications to /etc/yum/pluginconf.d/rhnplugin.conf')
+                    self.logger.error('The following RHN Classic or RHN '
+                                      'Satellite-managed OpenShift Enterprise '
+                                      'repositories conflict with the '
+                                      'detected or specified product version.')
+                    self.logger.error('To prevent package conflicts, disable '
+                                      'these repositories by making the '
+                                      'following modifications to '
+                                      '/etc/yum/pluginconf.d/rhnplugin.conf')
                     for repoid in rhn_conflicts:
-                        self.logger.error("    Set enabled=0 in the [%s] section"%repoid)
+                        self.logger.error('    Set enabled=0 in the [%s] '
+                                          'section' % repoid)
                 if other_conflicts:
-                    self.logger.error("The following Yum repositories conflict with the detected or specified product version.")
-                    self.logger.error("Disable these repositories by running these commands:")
+                    self.logger.error('The following Yum repositories conflict '
+                                      'with the detected or specified product '
+                                      'version.')
+                    self.logger.error('Disable these repositories by running '
+                                      'these commands:')
                     for repoid in other_conflicts:
-                        self.logger.error("    # yum-config-manager --disable %s"%repoid)
+                        self.logger.error('    # yum-config-manager '
+                                          '--disable %s' % repoid)
             return False
         return True
 
@@ -274,13 +325,16 @@ class OpenShiftAdminCheckSources:
             if not self.oscs.verify_package('yum-plugin-priorities'):
                 self.problem = True
                 if self.oscs.package_available('yum-plugin-priorities'):
-                    self.logger.error('Required package yum-plugin-priorities is not installed. Install the package with the following command:')
+                    self.logger.error('Required package yum-plugin-priorities '
+                                      'is not installed. Install the package '
+                                      'with the following command:')
                     self.logger.error('# yum install yum-plugin-priorities')
                 else:
-                    self.logger.error('Required package yum-plugin-priorities is not available.')
+                    self.logger.error('Required package yum-plugin-priorities '
+                                      'is not available.')
                 return False
-        except Errors.RepoError, e:
-            raise UnrecoverableYumError, e
+        except Errors.RepoError as exc:
+            raise UnrecoverableYumError(exc)
         return True
 
     def _get_pri(self, repoid):
@@ -289,52 +343,66 @@ class OpenShiftAdminCheckSources:
     def _limit_pri(self, repolist, minpri=False):
         """Determine the highest or lowest priority for the provided repos,
         depending on minpri value
-
         """
         res = -1
         c_fxn, p_limit = max, 0
         if minpri:
             c_fxn, p_limit = min, 99
-        res = c_fxn(chain((self._get_pri(repoid) for repoid in repolist), [p_limit]))
+        res = c_fxn(chain((self._get_pri(repoid) for
+                           repoid in repolist), [p_limit]))
         return res
 
     def _set_pri(self, repoid, priority):
         self.problem = True
         if not self.pri_header:
             self.pri_header = True
-            self.logger.info('Resolving repository/channel/subscription priority conflicts')
+            self.logger.info('Resolving repository/channel/subscription '
+                             'priority conflicts')
         if self.opts.fix:
-            self.logger.warning("Setting priority for repository %s to %d"%(repoid, priority))
+            self.logger.warning('Setting priority for repository %s to %d' %
+                                (repoid, priority))
             self.oscs.set_repo_priority(repoid, priority)
         else:
             if not self.pri_resolve_header:
                 self.pri_resolve_header = True
                 if self.oscs.repo_is_rhn(repoid):
-                    self.logger.error("To resolve conflicting repositories, update /etc/yum/pluginconf.d/rhnplugin.conf with the following changes:")
+                    self.logger.error('To resolve conflicting repositories, '
+                                      'update '
+                                      '/etc/yum/pluginconf.d/rhnplugin.conf '
+                                      'with the following changes:')
                 else:
-                    self.logger.error("To resolve conflicting repositories, update repo priority by running:")
-            # TODO: in the next version this should read "# subscription-manager override --repo=%s --add=priority:%d"
+                    self.logger.error('To resolve conflicting repositories, '
+                                      'update repo priority by running:')
+            # TODO: in the next version this should read
+            #'# subscription-manager override --repo=%s --add=priority:%d'
             if self.oscs.repo_is_rhn(repoid):
-                self.logger.error("    Set priority=%d in the [%s] section"%(priority, repoid))
+                self.logger.error('    Set priority=%d in the [%s] section' %
+                                  (priority, repoid))
             else:
-                self.logger.error("# yum-config-manager --setopt=%s.priority=%d %s --save"%(repoid, priority, repoid))
+                self.logger.error('# yum-config-manager '
+                                  '--setopt=%s.priority=%d %s --save' %
+                                  (repoid, priority, repoid))
 
     def _commit_resolved_pris(self):
-        for repoid, pri in sorted(self.resolved_repos.items(), key=lambda (kk, vv): vv):
+        for repoid, pri in sorted(self.resolved_repos.items(),
+                                  key = lambda (kk, vv): vv):
             if not self.committed_resolved_repos.get(repoid, None) == pri:
                 self._set_pri(repoid, pri)
         self.committed_resolved_repos = self.resolved_repos.copy()
 
 
     def _check_valid_pri(self, repos):
-        # bad_repos = [(xx, self.oscs.repo_priority(xx)) for xx in repos if self.oscs.repo_priority(xx) >= 99]
-        bad_repos = [(repoid, self._get_pri(repoid)) for repoid in repos if self._get_pri(repoid) >= 99]
+        bad_repos = [(repoid, self._get_pri(repoid)) for
+                     repoid in repos if self._get_pri(repoid) >= 99]
         if bad_repos:
             self.problem = True
-            self.logger.error('The calculated priorities for the following repoids are too large (>= 99)')
+            self.logger.error('The calculated priorities for the following '
+                              'repoids are too large (>= 99)')
             for repoid, pri in bad_repos:
                 self.logger.error('    %s'%repoid)
-            self.logger.error('Please re-run this script with the --fix argument to set an appropriate priority, or update the system priorities by hand')
+            self.logger.error('Please re-run this script with the --fix '
+                              'argument to set an appropriate priority, '
+                              'or update the system priorities by hand')
             return False
         return True
 
@@ -388,9 +456,12 @@ class OpenShiftAdminCheckSources:
         """
         res = True
         self.logger.info('Checking channel/repository priorities')
-        ose_scl = self.blessed_repoids(enabled=True, required=True, product='ose')
-        ose_scl += self.blessed_repoids(enabled=True, required=True, product='rhscl')
-        jboss = self.blessed_repoids(enabled=True, required=True, product='jboss')
+        ose_scl = self.blessed_repoids(enabled=True, required=True,
+                                       product='ose')
+        ose_scl += self.blessed_repoids(enabled=True, required=True,
+                                        product='rhscl')
+        jboss = self.blessed_repoids(enabled=True, required=True,
+                                     product='jboss')
         rhel = self.blessed_repoids(enabled=True, product='rhel')
         if rhel:
             res &= self.verify_rhel_priorities(ose_scl, rhel)
@@ -399,38 +470,42 @@ class OpenShiftAdminCheckSources:
                 res &= self.verify_jboss_priorities(ose_scl, jboss, rhel)
             else:
                 res &= self.verify_jboss_priorities(ose_scl, jboss)
-        # for repoid, pri in sorted(self.resolved_repos.items(), key=lambda (kk, vv): vv):
-        #     self._set_pri(repoid, pri)
         self._commit_resolved_pris()
         return res
 
     def check_disabled_repos(self):
         """Check if any required repositories are disabled, and fix or advise
         accordingly
-
         """
-        disabled_repos = list(set(self.blessed_repoids(required = True)).intersection(self.oscs.disabled_repoids()))
+        disabled_repos = list(set(self.blessed_repoids(required = True))
+                              .intersection(self.oscs.disabled_repoids()))
         if disabled_repos:
             self.problem = True
             if self.opts.fix:
-                for ii in disabled_repos:
-                    if self.oscs.enable_repo(ii):
-                        self.logger.warning('Enabled repository %s'%ii)
+                for repo in disabled_repos:
+                    if self.oscs.enable_repo(repo):
+                        self.logger.warning('Enabled repository %s'%repo)
             else:
-                self.logger.error("The required OpenShift Enterprise repositories are disabled:")
-                for ii in disabled_repos:
-                    self.logger.error("    %s"%ii)
+                self.logger.error('The required OpenShift Enterprise '
+                                  'repositories are disabled:')
+                for repo in disabled_repos:
+                    self.logger.error('    %s'%repo)
                 if self.opts.subscription == RHN:
-                    self.logger.error('Make the following modifications to /etc/yum/pluginconf.d/rhnplugin.conf')
+                    self.logger.error('Make the following modifications '
+                                      'to /etc/yum/pluginconf.d/rhnplugin.conf')
                 else:
-                    self.logger.error("Enable these repositories by running these commands:")
+                    self.logger.error('Enable these repositories by running '
+                                      'these commands:')
                 for repoid in disabled_repos:
                     if self.opts.subscription == RHN:
-                        self.logger.error("    Set enabled=1 in the [%s] section"%repoid)
+                        self.logger.error('    Set enabled=1 in the [%s] '
+                                          'section' % repoid)
                     elif self.opts.subscription == RHSM:
-                        self.logger.error("# subscription-manager repos --enable=%s"%repoid)
+                        self.logger.error('# subscription-manager repos '
+                                          '--enable=%s' % repoid)
                     else:
-                        self.logger.error("# yum-config-manager --enable %s"%repoid)
+                        self.logger.error('# yum-config-manager --enable %s' %
+                                          repoid)
             return False
         return True
 
@@ -439,13 +514,20 @@ class OpenShiftAdminCheckSources:
         accordingly
 
         """
-        missing_repos = [repo for repo in self.blessed_repoids(required = True) if repo not in self.oscs.all_repoids()]
+        missing_repos = [repo for repo in
+                         self.blessed_repoids(required = True)
+                         if repo not in self.oscs.all_repoids()]
         if missing_repos:
             self.problem = True
-            self.logger.error("The required OpenShift Enterprise repositories are missing:")
-            for ii in missing_repos:
-                self.logger.error("    %s"%ii)
-            self.logger.error('Please verify that an OpenShift Enterprise subscription is attached to this system using either RHN Classic or Red Hat Subscription Manager by following the instructions here: %s'%ATTACH_ENTITLEMENTS_URL)
+            self.logger.error('The required OpenShift Enterprise repositories '
+                              'are missing:')
+            for repo in missing_repos:
+                self.logger.error('    %s'%repo)
+            self.logger.error('Please verify that an OpenShift Enterprise '
+                              'subscription is attached to this system using '
+                              'either RHN Classic or Red Hat Subscription '
+                              'Manager by following the instructions here: %s' %
+                              ATTACH_ENTITLEMENTS_URL)
             return False
         return True
 
@@ -466,7 +548,7 @@ class OpenShiftAdminCheckSources:
             self.resolved_repos[repoid] = new_pri
             res = False
         return res
-        
+
 
     def find_package_conflicts(self):
         """Search for packages from non-blessed repositories which could
@@ -478,29 +560,40 @@ class OpenShiftAdminCheckSources:
         """
         res = True
         self.pri_resolve_header = False
-        all_blessed_repos = self.rdb.find_repoids(product_version = self.opts.oo_version)
-        enabled_ose_scl_repos = self.blessed_repoids(enabled = True, required = True, product = 'ose')
-        enabled_ose_scl_repos += self.blessed_repoids(enabled = True, required = True, product = 'rhscl')
-        enabled_jboss_repos = self.blessed_repoids(enabled = True, required = True, product = 'jboss')
-        rhel6_repos = self.blessed_repoids(enabled = True, product='rhel')
+        all_blessed_repos = self.rdb.find_repoids(
+            product_version=self.opts.oo_version)
+        enabled_ose_scl_repos = self.blessed_repoids(enabled=True,
+                                                     required=True,
+                                                     product='ose')
+        enabled_ose_scl_repos += self.blessed_repoids(enabled=True,
+                                                      required=True,
+                                                      product='rhscl')
+        enabled_jboss_repos = self.blessed_repoids(enabled=True,
+                                                   required=True,
+                                                   product='jboss')
+        rhel6_repos = self.blessed_repoids(enabled=True, product='rhel')
         # if not rhel6_repo[0] in self.oscs.enabled_repoids():
         #     rhel6_repo = []
-        required_repos = enabled_ose_scl_repos + rhel6_repos + enabled_jboss_repos
+        required_repos = (enabled_ose_scl_repos + rhel6_repos +
+                          enabled_jboss_repos)
         if not self._check_valid_pri(required_repos):
             return False
         for repoid in required_repos:
             try:
-                ose_pkgs = self.oscs.packages_for_repo(repoid, disable_priorities = True)
+                ose_pkgs = self.oscs.packages_for_repo(repoid,
+                                                       disable_priorities=True)
                 ose_pkg_names = sorted(set([xx.name for xx in ose_pkgs]))
-                other_pkg_matches = [xx for xx in self.oscs.all_packages_matching(ose_pkg_names, True) if xx.repoid not in all_blessed_repos]
-                conflicts = sorted(set([xx.repoid for xx in other_pkg_matches]))
-                for ii in conflicts:
-                    res &= self.verify_repo_priority(ii, required_repos)
-            except KeyError as ke:
+                matches = [xx for xx in
+                           self.oscs.all_packages_matching(ose_pkg_names, True)
+                           if xx.repoid not in all_blessed_repos]
+                conflicts = sorted(set([xx.repoid for xx in matches]))
+                for repo in conflicts:
+                    res &= self.verify_repo_priority(repo, required_repos)
+            except KeyError:
                 self.logger.error('Repository %s not enabled'%repoid)
                 res = False
-            except Errors.RepoError, e:
-                raise UnrecoverableYumError, e
+            except Errors.RepoError as repo_err:
+                raise UnrecoverableYumError(repo_err)
         # for repoid, pri in self.resolved_repos.iteritems():
         #     if not old_resolved_repos.get(repoid, None) == pri:
         #         self._set_pri(repoid, pri)
@@ -509,40 +602,51 @@ class OpenShiftAdminCheckSources:
 
     def _set_exclude(self, repo):
         if self.opts.fix:
-            self.logger.error('    %s: %s'%(repo.repoid, ' '.join(repo.exclude)))
+            self.logger.error('    %s: %s' %
+                              (repo.repoid, ' '.join(repo.exclude)))
             self.oscs.merge_excludes(repo.repoid, list(repo.exclude))
         else:
             exc = ' '.join(repo.exclude)
             if self.opts.subscription == RHN or self.opts.subscription == RHSM:
-                self.logger.error('Add the following line to the [%s] section:'%(repo.repoid))
+                self.logger.error('Add the following to the [%s] section:' %
+                                  (repo.repoid))
                 self.logger.error('    exclude=%s'%exc)
             else:
-                repofile = self.oscs.yb.repos.repos[repo.repoid].repofile
+                repofile = self.oscs.yum_base.repos.repos[repo.repoid].repofile
                 if repofile:
-                    self.logger.error('In file %s, Add the following line to the [%s] section'%(repofile, repo.repoid))
+                    self.logger.error('In file %s, Add the following to the '
+                                      '[%s] section' % (repofile, repo.repoid))
                     self.logger.error('    exclude=%s'%exc)
                 else: # Man, I don't know
-                    self.logger.error("# yum-config-manager --setopt=%s.exclude=%d %s --save"%(repo.repoid, exc, repo.repoid))
+                    self.logger.error('# yum-config-manager '
+                                      '--setopt=%s.exclude=%d %s --save' %
+                                      (repo.repoid, exc, repo.repoid))
 
     def set_excludes(self):
         """Set any excludes configured for the required repositories
         """
-        need_exclude = [repo for repo in self.required_repos()
-                        if repo.exclude and repo.repoid in self.oscs.all_repoids()]
+        need_exclude = [repo for repo in self.required_repos() if
+                        repo.exclude and repo.repoid in
+                        self.oscs.all_repoids()]
         if need_exclude:
             self.problem = True
             if self.opts.fix:
-                self.logger.error('Setting package exclusions for the following repositories:')
+                self.logger.error('Setting package exclusions for the '
+                                  'following repositories:')
             else:
-                self.logger.error('The following repositories need package exclusions set:')
-                for ii in need_exclude:
-                    self.logger.error('    %s'%ii.repoid)
+                self.logger.error('The following repositories need package '
+                                  'exclusions set:')
+                for repo in need_exclude:
+                    self.logger.error('    %s'%repo.repoid)
                 if self.opts.subscription == RHN:
-                    self.logger.error('Make the following modifications to /etc/yum/pluginconf.d/rhnplugin.conf')
+                    self.logger.error('Make the following modifications to '
+                                      '/etc/yum/pluginconf.d/rhnplugin.conf')
                 elif self.opts.subscription == RHSM:
-                    self.logger.error('Make the following modifications to /etc/yum.repos.d/redhat.repo')
+                    self.logger.error('Make the following modifications to '
+                                      '/etc/yum.repos.d/redhat.repo')
                 else:
-                    self.logger.error('Modify the repositories by running these commands:')
+                    self.logger.error('Modify the repositories by running '
+                                      'these commands:')
             for repo in need_exclude:
                 self._set_exclude(repo)
             return False
@@ -553,33 +657,39 @@ class OpenShiftAdminCheckSources:
         key packages
 
         """
-        self.logger.warning('No roles have been specified. Attempting to guess the roles for this system...')
+        self.logger.warning('No roles have been specified. Attempting to '
+                            'guess the roles for this system...')
         self.opts.role = []
-        for rr in VALID_ROLES:
+        for role in VALID_ROLES:
             # get uniquified list of packages that coorespond to only one role
-            check_pkgs = list(set([repo.key_pkg for repo in self.rdb.find_repos(role=rr) if not hasattr(repo.role, '__iter__')]))
+            check_pkgs = list(set([repo.key_pkg for repo in
+                                   self.rdb.find_repos(role=role) if
+                                   not hasattr(repo.role, '__iter__')]))
             if filter(self.oscs.verify_package, check_pkgs):
-                self.opts.role.append(rr)
+                self.opts.role.append(role)
         if not self.opts.role:
             self.logger.error('No roles could be detected.')
             self.problem = True
             return False
-        self.logger.warning('If the roles listed below are incorrect or incomplete, please re-run this script with the appropriate --role arguments')
-        self.logger.warning('\n'.join(('    %s'%role for role in self.opts.role)))
+        self.logger.warning('If the roles listed below are incorrect or '
+                            'incomplete, please re-run this script with the '
+                            'appropriate --role arguments')
+        self.logger.warning('\n'.join(('    %s' %
+                                       role for role in self.opts.role)))
         return True
 
     def validate_roles(self):
         """Check supplied roles against VALID_ROLES.
 
         TODO: This probably isn't necessary any longer
-
         """
         if not self.opts.role:
             return True
         for role in self.opts.role:
             if not role in VALID_ROLES:
                 self.problem = True
-                self.logger.error('You have specified an invalid role: %s is not one of %s'%(role, VALID_ROLES))
+                self.logger.error('You have specified an invalid role: %s '
+                                  'is not one of %s' % (role, VALID_ROLES))
                 self.opt_parser.print_help()
                 return False
         return True
@@ -592,7 +702,9 @@ class OpenShiftAdminCheckSources:
         """
         if self.opts.oo_version:
             if not self.opts.oo_version in VALID_OO_VERSIONS:
-                self.logger.error('You have specified an invalid version: %s is not one of %s'%(self.opts.oo_version, VALID_OO_VERSIONS))
+                self.logger.error('You have specified an invalid version: '
+                                  '%s is not one of %s' %
+                                  (self.opts.oo_version, VALID_OO_VERSIONS))
                 self.opt_parser.print_help()
                 return False
         return True
@@ -611,7 +723,9 @@ class OpenShiftAdminCheckSources:
                 self.opts.role.append('node')
             if 'node' in self.opts.role and not 'node-eap' in self.opts.role:
                 # self.problem = True
-                self.logger.warning('If this system will be providing the JBossEAP cartridge, re-run this command with the --role=node-eap argument')
+                self.logger.warning('If this system will be providing the '
+                                    'JBossEAP cartridge, re-run this '
+                                    'command with the --role=node-eap argument')
 
     def run_checks(self):
         if not self.validate_roles():
@@ -621,9 +735,15 @@ class OpenShiftAdminCheckSources:
             self.problem = True
             if self.opts.subscription == UNKNOWN:
                 self.logger.error('Could not determine subscription type.')
-                self.logger.error('Please attach an OpenShift Enterprise subscription to this system using either RHN Classic or Red Hat Subscription Manager by following the instructions here: %s'%ATTACH_ENTITLEMENTS_URL)
+                self.logger.error('Please attach an OpenShift Enterprise '
+                                  'subscription to this system using either '
+                                  'RHN Classic or Red Hat Subscription '
+                                  'Manager by following the instructions '
+                                  'here: %s' % ATTACH_ENTITLEMENTS_URL)
             if not self.opts.oo_version:
-                self.logger.error('Could not determine product version. Please re-run this script with the --oo-version argument.')
+                self.logger.error('Could not determine product version. '
+                                  'Please re-run this script with the '
+                                  '--oo-version argument.')
             return False
         print ""
         if not (self.check_version_conflict() or self.opts.report_all):
@@ -633,7 +753,8 @@ class OpenShiftAdminCheckSources:
         if not (self.check_missing_repos() or self.opts.report_all):
             return False
         if self.opts.role:
-            if not (self.verify_yum_plugin_priorities() or self.opts.report_all):
+            if not (self.verify_yum_plugin_priorities() or
+                    self.opts.report_all):
                 self.logger.warning('Skipping yum priorities verification')
                 return False
             if not (self.verify_priorities() or self.opts.report_all):
@@ -643,7 +764,8 @@ class OpenShiftAdminCheckSources:
             if not (self.set_excludes() or self.opts.report_all):
                 return False
         else:
-            self.logger.warning('Please specify at least one role for this system with the --role command')
+            self.logger.warning('Please specify at least one role for this '
+                                'system with the --role command')
             self.problem = True
             return False
         if not self.problem:
@@ -662,10 +784,13 @@ class OpenShiftAdminCheckSources:
         try:
             self.run_checks()
             if not self.opts.fix and self.problem:
-                self.logger.info('Please re-run this tool after making any recommended repairs to this system')
+                self.logger.info('Please re-run this tool after making '
+                                 'any recommended repairs to this system')
             return not self.problem
         except UnrecoverableYumError, e:
-            self.logger.critical('An unrecoverable error prevents further checks from being run. Re-run this tool after the problem has been repaired:')
+            self.logger.critical('An unrecoverable error prevents further '
+                                 'checks from being run. Re-run this tool '
+                                 'after the problem has been repaired:')
             print ''
             self.logger.critical(e)
             return 255
@@ -673,44 +798,81 @@ class OpenShiftAdminCheckSources:
 if __name__ == "__main__":
     ROLE_HELP = 'OpenShift component role(s) this system will fulfill.'
     OO_VERSION_HELP = 'Version of OpenShift Enterprise in use on this system.'
-    SUBSCRIPTION_HELP = 'Subscription management system which provides the OpenShift Enterprise repositories/channels.'
+    SUBSCRIPTION_HELP = ('Subscription management system which provides the '
+                         'OpenShift Enterprise repositories/channels.')
     FIX_HELP = 'Attempt to repair the first problem found.'
     FIX_ALL_HELP = 'Attempt to repair all problems found.'
-    REPORT_ALL_HELP = 'Report all problems (default is to halt after first problem report.)'
-    REPO_CONF_HELP = 'Load blessed repository data from the specified file instead of built-in values'
-    USER_REPOS_HELP = 'Requires --repo-config. Blend the repository data loaded via --repo-config with the built-in values'
+    REPORT_ALL_HELP = ('Report all problems (default is to halt after first '
+                       'problem report.)')
+    REPO_CONF_HELP = ('Load blessed repository data from the specified file '
+                      'instead of built-in values')
+    USER_REPOS_HELP = ('Requires --repo-config. Blend the repository data '
+                       'loaded via --repo-config with the built-in values')
 
     # TODO: This is getting unwieldy - time for a wrapper?
     try:
         import argparse
         opt_parser = argparse.ArgumentParser()
-        opt_parser.add_argument('-r', '--role', default=None, choices=VALID_ROLES, action='append', help=ROLE_HELP)
-        opt_parser.add_argument('-o', '--oo_version', '--oo-version', default=None, choices=VALID_OO_VERSIONS, dest='oo_version', help=OO_VERSION_HELP)
-        opt_parser.add_argument('-s', '--subscription-type', default=None, choices=VALID_SUBS, dest='subscription', help=SUBSCRIPTION_HELP)
-        opt_parser.add_argument('-f', '--fix', action='store_true', default=False, help=FIX_HELP)
-        opt_parser.add_argument('-a', '--fix-all', action='store_true', default=False, dest='fix_all', help=FIX_ALL_HELP)
-        opt_parser.add_argument('-p', '--report-all', action='store_true', default=False, dest='report_all', help=REPORT_ALL_HELP)
-        opt_parser.add_argument('-c', '--repo-config', default=None, type=str, help=REPO_CONF_HELP)
-        # opt_parser.add_argument('-u', '--blend-user-repos', action='store_true', default=True, dest='user_repos_only', help=USER_REPOS_HELP)
+        opt_parser.add_argument('-r', '--role', default=None,
+                                choices=VALID_ROLES, action='append',
+                                help=ROLE_HELP)
+        opt_parser.add_argument('-o', '--oo_version', '--oo-version',
+                                default=None,
+                                choices=VALID_OO_VERSIONS,
+                                dest='oo_version',
+                                help=OO_VERSION_HELP)
+        opt_parser.add_argument('-s', '--subscription-type',
+                                default=None, choices=VALID_SUBS,
+                                dest='subscription',
+                                help=SUBSCRIPTION_HELP)
+        opt_parser.add_argument('-f', '--fix', action='store_true',
+                                default=False, help=FIX_HELP)
+        opt_parser.add_argument('-a', '--fix-all',
+                                action='store_true', default=False,
+                                dest='fix_all', help=FIX_ALL_HELP)
+        opt_parser.add_argument('-p', '--report-all',
+                                action='store_true', default=False,
+                                dest='report_all',
+                                help=REPORT_ALL_HELP)
+        opt_parser.add_argument('-c', '--repo-config', default=None,
+                                type=str, help=REPO_CONF_HELP)
+        # opt_parser.add_argument('-u', '--blend-user-repos',
+        #                         action='store_true', default=True,
+        #                         dest='user_repos_only',
+        #                         help=USER_REPOS_HELP)
         opts = opt_parser.parse_args()
     except ImportError:
         import optparse
-        ROLE_HELP += ' One or more of: %s'%VALID_ROLES
-        OO_VERSION_HELP += ' One of: %s'%VALID_OO_VERSIONS
-        SUBSCRIPTION_HELP += ' One of: %s'%VALID_SUBS
+        ROLE_HELP += ' One or more of: %s' % VALID_ROLES
+        OO_VERSION_HELP += ' One of: %s' % VALID_OO_VERSIONS
+        SUBSCRIPTION_HELP += ' One of: %s' % VALID_SUBS
         opt_parser = optparse.OptionParser()
-        opt_parser.add_option('-r', '--role', default=None, choices=VALID_ROLES, action='append', help=ROLE_HELP)
-        opt_parser.add_option('-o', '--oo_version', '--oo-version', default=None, choices=VALID_OO_VERSIONS, dest='oo_version', help=OO_VERSION_HELP)
-        opt_parser.add_option('-s', '--subscription-type', default=None, choices=VALID_SUBS, dest='subscription', help=SUBSCRIPTION_HELP)
-        opt_parser.add_option('-f', '--fix', action='store_true', default=False, help=FIX_HELP)
-        opt_parser.add_option('-a', '--fix-all', action='store_true', default=False, dest='fix_all', help=FIX_ALL_HELP)
-        opt_parser.add_option('-p', '--report-all', action='store_true', default=False, dest='report_all', help=REPORT_ALL_HELP)
-        opt_parser.add_option('-c', '--repo-config', default=None, type='string', help=REPO_CONF_HELP)
-        # opt_parser.add_option('-u', '--blend-user-repos', action='store_true', default=True, dest='user_repos_only', help=USER_REPOS_HELP)
+        opt_parser.add_option('-r', '--role', default=None,
+                              choices=VALID_ROLES, action='append',
+                              help=ROLE_HELP)
+        opt_parser.add_option('-o', '--oo_version', '--oo-version',
+                              default=None, choices=VALID_OO_VERSIONS,
+                              dest='oo_version', help=OO_VERSION_HELP)
+        opt_parser.add_option('-s', '--subscription-type',
+                              default=None, choices=VALID_SUBS,
+                              dest='subscription',
+                              help=SUBSCRIPTION_HELP)
+        opt_parser.add_option('-f', '--fix', action='store_true',
+                              default=False, help=FIX_HELP)
+        opt_parser.add_option('-a', '--fix-all', action='store_true',
+                              default=False, dest='fix_all', help=FIX_ALL_HELP)
+        opt_parser.add_option('-p', '--report-all',
+                              action='store_true', default=False,
+                              dest='report_all', help=REPORT_ALL_HELP)
+        opt_parser.add_option('-c', '--repo-config', default=None,
+                              type='string', help=REPO_CONF_HELP)
+        # opt_parser.add_option('-u', '--blend-user-repos',
+        #                       action='store_true', default=True,
+        #                       dest='user_repos_only',
+        #                       help=USER_REPOS_HELP)
         (opts, args) = opt_parser.parse_args()
     opts.user_repos_only = True
     oacs = OpenShiftAdminCheckSources(opts, opt_parser)
     if not oacs.main():
         sys.exit(1)
     sys.exit(0)
-    

--- a/admin/check-sources/repo_db.py
+++ b/admin/check-sources/repo_db.py
@@ -5,7 +5,8 @@ from iniparse import INIConfig
 from iniparse.config import Undefined
 import re
 
-RepoTuple = namedtuple('RepoTuple', 'subscription, product, product_version, role, repoid, key_pkg, exclude')
+RepoTuple = namedtuple('RepoTuple', 'subscription, product, product_version, '
+                       'role, repoid, key_pkg, exclude')
 
 repo_ini = """# RHSM Common
 
@@ -204,10 +205,10 @@ def ini_defined(val):
 def parse_multivalue(val):
     if ini_defined(val):
         if val:
-            rv = tuple(re.split(', ', val))
-            if len(rv) == 1:
-                return rv[0]
-            return rv
+            res = tuple(re.split(', ', val))
+            if len(res) == 1:
+                return res[0]
+            return res
     else:
         return None
     return val
@@ -243,30 +244,43 @@ class RepoDB:
     def populate_db(self):
         for repoid in list(self.cfg):
             repocfg = self.cfg[repoid]
-            rt = RepoTuple(
-                subscription =    parse_multivalue(getattr(repocfg, 'subscription', None)),
-                product =         parse_multivalue(getattr(repocfg, 'product', None)),
-                product_version = parse_multivalue(getattr(repocfg, 'product_version', None)),
-                role =            parse_multivalue(getattr(repocfg, 'role', None)),
-                repoid =          repoid,
-                key_pkg =         parse_multivalue(getattr(repocfg, 'key_pkg', None)),
-                exclude =         parse_exclude(getattr(repocfg, 'exclude', None)))
-            if not rt in self.repositories:
-                self.repositories.append(rt)
+            rtpl = RepoTuple( subscription =
+                              parse_multivalue(getattr(repocfg,
+                                                       'subscription', None)),
+                              product =
+                              parse_multivalue(getattr(repocfg, 'product',
+                                                       None)),
+                              product_version =
+                              parse_multivalue(getattr(repocfg,
+                                                       'product_version',
+                                                       None)),
+                              role =
+                              parse_multivalue(getattr(repocfg, 'role', None)),
+                              repoid = repoid,
+                              key_pkg =
+                              parse_multivalue(getattr(repocfg, 'key_pkg',
+                                                       None)),
+                              exclude =
+                              parse_exclude(getattr(repocfg, 'exclude', None)))
+            if not rtpl in self.repositories:
+                self.repositories.append(rtpl)
 
     def find_repos(self, **kwargs):
-        """Return (and cache) tuple of RepoTuples that match the criteria specified
+        """Return (and cache) tuple of RepoTuples that match the criteria
+        specified
         """
         if len(self.repo_cache) > 512:
             # Try to keep the repo_cache from growing infinitely
-            # (Guessing 512 is too big is cheaper than calculating the actual mem footprint)
+            # (Guessing 512 is too big is cheaper than calculating the actual
+            # mem footprint)
             self.repo_cache = {}
         hkey = tuple(sorted(kwargs.items()))
         if None == self.repo_cache.get(hkey, None):
             repos = copy(self.repositories)
-            for kk, vv in kwargs.items():
-                # print kk, vv
-                repos = [repo for repo in repos if _repo_tuple_match(repo, kk, vv)]
+            for key, val in kwargs.items():
+                # print key, val
+                repos = [repo for repo in repos if
+                         _repo_tuple_match(repo, key, val)]
                 # print repos
                 if not repos:
                     break
@@ -294,27 +308,33 @@ class RepoDB:
 
 
 if __name__ == '__main__':
-    rd = RepoDB()
+    rdb = RepoDB()
     print "find_repos(subscription = 'rhsm'):"
-    for xx in rd.find_repos(subscription = 'rhsm'):
+    for xx in rdb.find_repos(subscription = 'rhsm'):
         print xx
     print ""
     print "find_repos(product_version = '1.2'):"
-    for xx in rd.find_repos(product_version = '1.2'):
+    for xx in rdb.find_repos(product_version = '1.2'):
         print xx
     print ""
     print "find_repos(product_version = '1.2', role = 'node'):"
-    for xx in rd.find_repos(product_version = '1.2', role = 'node'):
+    for xx in rdb.find_repos(product_version = '1.2', role = 'node'):
         print xx
     print ""
     print "find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):"
-    for xx in rd.find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):
+    for xx in \
+        rdb.find_repos_by_repoid('rhel-x86_64-server-6-ose-2.0-infrastructure'):
         print xx
     print ""
-    print "find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):"
-    for xx in rd.find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure', 'jbappplatform-6-x86_64-server-6-rpm']):
+    print ("find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure'"
+           ", 'jbappplatform-6-x86_64-server-6-rpm']):")
+    for xx in \
+        rdb.find_repos_by_repoid(['rhel-x86_64-server-6-ose-2.0-infrastructure',
+                                  'jbappplatform-6-x86_64-server-6-rpm']):
         print xx
     print ""
-    print "find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):"
-    for xx in rd.find_repoids(subscription = 'rhn', role = 'node-eap', product_version = '1.2'):
+    print ("find_repoids(subscription = 'rhn', role = 'node-eap', "
+           "product_version = '1.2'):")
+    for xx in rdb.find_repoids(subscription='rhn', role='node-eap',
+                               product_version='1.2'):
         print xx


### PR DESCRIPTION
First big pass with pylint to bring code close to PEP 8 style. Should
be no logical changes other than `OpenShiftCheckSources._init_yumbase`
returning the yumbase object instead of setting `self.yum_base`
directly.
