### PR TITLE
<check-sources> Bug 1028941 - Added 1.2 repos to beta2.ini

### DIFF
--- a/admin/check-sources/beta2.ini
+++ b/admin/check-sources/beta2.ini
@@ -68,6 +68,35 @@ product = ose
 product_version = 2.0
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
+# RHSM 1.2 repos
+
+[rhel-server-ose-1.2-node-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-server-ose-1.2-infra-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-server-ose-1.2-rhc-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-server-ose-1.2-jbosseap-6-rpms]
+subscription = rhsm
+product = ose
+product_version = 1.2
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
 # RHN Common
 
 [rhel-x86_64-server-6]
@@ -136,5 +165,35 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+# RHN 1.2 repos
+
+[rhel-x86_64-server-6-ose-1.2-node]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-1.2-infrastructure]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-1.2-rhc]
+subscription = rhn
+product = ose
+product_version = 1.2
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-1.2-jbosseap]
+subscription = rhn
+product = ose
+product_version = 1.2
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap

--- a/admin/check-sources/oo-admin-check-sources.py
+++ b/admin/check-sources/oo-admin-check-sources.py
@@ -409,7 +409,8 @@ class OpenShiftAdminCheckSources:
                 self.resolved_repos[repoid] = OSE_PRIORITY
                 res = False
             ose_pri = OSE_PRIORITY
-        if rhel_pri <= ose_pri or rhel_pri >= 99:
+        # Fix the rhel repos if any of them are at 99
+        if rhel_pri <= ose_pri or self._limit_pri(rhel6_repos) >= 99:
             for repoid in rhel6_repos:
                 self.resolved_repos[repoid] = RHEL_PRIORITY
             res = False


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1028941

The 1.2 repo data was missing from beta2.ini, so version conflicts
weren't being detected.

Long term fix for this is to refactor the version guessing and add the
2.0beta channels to the ini file with an unique version

Added fix RHEL for repos priorities if they are higher than OSE repos
or >= 99
