### PR TITLE
<oo-admin-yum-validator> Bug 1031081, Replace y-c-m advice with "by hand" advice

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -368,14 +368,22 @@ class OpenShiftYumValidator(object):
                                       'update '
                                       '/etc/yum/pluginconf.d/rhnplugin.conf '
                                       'with the following changes:')
+                elif self.oscs.repo_is_rhsm(repoid):
+                    self.logger.error('To resolve conflicting repositories, '
+                                      'update /etc/yum.repos.d/redhat.repo '
+                                      'with the following changes:')
                 else:
                     self.logger.error('To resolve conflicting repositories, '
                                       'update repo priority by running:')
-            # TODO: in the next version this should read
-            #'# subscription-manager override --repo=%s --add=priority:%d'
             if self.oscs.repo_is_rhn(repoid):
                 self.logger.error('    Set priority=%d in the [%s] section' %
                                   (priority, repoid))
+            elif self.oscs.repo_is_rhsm(repoid):
+                # TODO: when the next version of sub-man is released
+                # this should read
+                # '# subscription-manager override --repo=%s --add=priority:%d'
+                self.logger.error('    Set priority=%d in the [%s] section' %
+                                  (priority, repoid))                
             else:
                 self.logger.error('# yum-config-manager '
                                   '--setopt=%s.priority=%d %s --save' %


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1031081

Replaced `yum-config-manager` dependent advice for RHSM with by-hand
instructions, since the `--setopt` argument in `yum-config-manager`
doesn't work with dotted repoids. The `--enable` and `--disable` args
still work for dotted repoids, so that advice remains for the
plain-old-yum case
