### PR TITLE
Add LC_CTYPE when detecting host_type to deal with UTF-8

### DIFF
--- a/oo-install/lib/installer/host_instance.rb
+++ b/oo-install/lib/installer/host_instance.rb
@@ -149,7 +149,7 @@ module Installer
     def host_type
       @host_type ||=
         begin
-          type_output = exec_on_host!('cat /etc/redhat-release')
+          type_output = exec_on_host!('LC_CTYPE=en_US.utf8 cat /etc/redhat-release')
           type_result = :other
           if type_output[:exit_code] == 0
             if type_output[:stdout].match(/^Fedora/)


### PR DESCRIPTION
The `oo-install` script fails on Fedora 19 because of the Fedora release name (thanks Fedora! :-)

```
irb(main):002:0> s = `cat /etc/redhat-release`
=> "Fedora release 19 (Schr\xC3\xB6dinger\xE2\x80\x99s Cat)\n"
irb(main):003:0> s.match /^Fedora/
ArgumentError: invalid byte sequence in US-ASCII
    from (irb):3:in `match'
    from (irb):3:in `match'
    from (irb):3
    from /usr/bin/irb:12:in `<main>'
irb(main):004:0> 
```

The oo-install failure is:

```
Checking example.com:
/tmp/oo-install-20131118-2143/lib/installer/host_instance.rb:155:in `match': invalid byte sequence in US-ASCII (ArgumentError)
    from /tmp/oo-install-20131118-2143/lib/installer/host_instance.rb:155:in `match'
    from /tmp/oo-install-20131118-2143/lib/installer/host_instance.rb:155:in `host_type
```
