### PR TITLE
<oo-admin-yum-validator> Bug 1034623, don't halt on sub/ver detection when --report-all is set

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -733,7 +733,7 @@ class OpenShiftYumValidator(object):
             return False
         self.massage_roles()
         # if not self.guess_ose_version_and_subscription():
-        if not self.detect_prod_version_and_sub():
+        if not (self.detect_prod_version_and_sub() or self.opts.report_all):
             self.problem = True
             if self.opts.subscription == UNKNOWN:
                 self.logger.error('Could not determine subscription type.')


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1034623

Result of `detect_prod_version_and_sub` wasn't being `or`-ed with
`report-all`
