### PR TITLE
<oo-admin-yum-validator> Always stop if ver/sub can't be detected

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -735,8 +735,7 @@ class OpenShiftYumValidator(object):
         if not self.validate_roles():
             return False
         self.massage_roles()
-        # if not self.guess_ose_version_and_subscription():
-        if not (self.detect_prod_version_and_sub() or self.opts.report_all):
+        if not self.detect_prod_version_and_sub():
             self.problem = True
             if self.opts.subscription == UNKNOWN:
                 self.logger.error('Could not determine subscription type.')


### PR DESCRIPTION
This reverts a change from 55341cae - If the version or subscription
aren't specified and can't be guessed, `oo-admin-yum-validator` should
always stop, even if `--report-all` or `--fix-all` are specified.
