### PR TITLE
remove redundant openshift-origin-cartridge-jbosseap from cart list

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1007,11 +1007,6 @@ install_cartridges()
       carts="$carts openshift-origin-cartridge-jbosseap"
     fi
 
-    # JBossEAP support.
-    # Note: Be sure to subscribe to the JBossEAP entitlements during the
-    # base install or in configure_jbosseap_repo.
-    carts="$carts openshift-origin-cartridge-jbosseap"
-
     # Jenkins server for continuous integration.
     carts="$carts openshift-origin-cartridge-jenkins"
 


### PR DESCRIPTION
We check $CONF_NO_JBOSSEAP before adding jbosseap to the cart list but then add it anyway.
