### PR TITLE
<openshift.ks> enable puddles and extras

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -102,16 +102,31 @@ configure_yum_repos()
 {
 #  configure_rhel_repo
 
-  for repo in optional infra node jbosseap_cartridge jbosseap jbossews client_tools rhscl; do
+  for repo in optional jbosseap jbossews rhscl; do
     eval "need_${repo}_repo && configure_${repo}_repo"
   done
+  configure_ose_yum_repos
   yum clean metadata
   yum_install_or_exit openshift-enterprise-release
 }
 
+configure_ose_yum_repos()
+{ # define plain yum repos if the parameters are given
+  # this can be useful even if the main subscription is via RHN
+  for repo in infra node jbosseap_cartridge client_tools; do
+    if [ "$ose_repo_base" != "" ]; then
+      layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+      eval "need_${repo}_repo && def_ose_yum_repo $ose_repo_base $layout $repo"
+    fi
+    if [ "$ose_extra_repo_base" != "" ]; then
+      eval "need_${repo}_repo && def_ose_yum_repo $ose_extra_repo_base extra $repo"
+    fi
+  done
+}
+
 configure_rhel_repo()
 {
-  # In order for the %post section to succeed, it must have a way of 
+  # In order for the %post section to succeed, it must have a way of
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
@@ -148,70 +163,27 @@ YUM
 fi
 }
 
-ose_yum_repo_url()
+def_ose_yum_repo()
 {
-    channel=$1 #one of: RHOSE-CLIENT-2.0,RHOSE-INFRA-2.0,RHOSE-NODE-2.0,RHOSE-JBOSSEAP-2.0
-    if is_true "$CONF_CDN_LAYOUT"
-    then # use the release CDN layout for OSE URLs
-      declare -A map
-      map=([RHOSE-CLIENT-2.0]=ose-rhc [RHOSE-INFRA-2.0]=ose-infra [RHOSE-NODE-2.0]=ose-node [RHOSE-JBOSSEAP-2.0]=ose-jbosseap)
-      echo "$ose_repo_base/${map[$channel]}/2.0/os"
-    else # use the nightly puddle URLs
-      echo "$ose_repo_base/$channel/x86_64/os/"
-    fi
-}
+  repo_base=$1
+  layout=$2  # one of: puddle, extra, cdn
+  channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
 
-configure_client_tools_repo()
-{
-  cat > /etc/yum.repos.d/openshift-client.repo <<YUM
-[openshift_client]
-name=OpenShift Client
-baseurl=$(ose_yum_repo_url RHOSE-CLIENT-2.0)
-enabled=1
-gpgcheck=0
-sslverify=false
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_infra_repo()
-{
-  cat > /etc/yum.repos.d/openshift-infrastructure.repo <<YUM
-[openshift_infrastructure]
-name=OpenShift Infrastructure
-baseurl=$(ose_yum_repo_url RHOSE-INFRA-2.0)
-enabled=1
-gpgcheck=0
-sslverify=false
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_node_repo()
-{
-  cat > /etc/yum.repos.d/openshift-node.repo <<YUM
-[openshift_node]
-name=OpenShift Node
-baseurl=$(ose_yum_repo_url RHOSE-NODE-2.0)
-enabled=1
-gpgcheck=0
-sslverify=false
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_jbosseap_cartridge_repo()
-{
-  cat > /etc/yum.repos.d/openshift-jboss.repo <<YUM
-[openshift_jbosseap]
-name=OpenShift JBossEAP
-baseurl=$(ose_yum_repo_url RHOSE-JBOSSEAP-2.0)
+  declare -A map
+  case $layout in
+  puddle | extra)
+    map=([client_tools]=RHOSE-CLIENT-2.0 [infra]=RHOSE-INFRA-2.0 [node]=RHOSE-NODE-2.0 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.0)
+    url="$repo_base/${map[$channel]}/x86_64/os/"
+    ;;
+  cdn | * )
+    map=([client_tools]=ose-rhc [infra]=ose-infra [node]=ose-node [jbosseap_cartridge]=ose-jbosseap)
+    url="$repo_base/${map[$channel]}/2.0/os"
+    ;;
+  esac
+  cat > "/etc/yum.repos.d/openshift-${channel}-${layout}.repo" <<YUM
+[openshift_${channel}_${layout}]
+name=OpenShift $channel $layout
+baseurl=$url
 enabled=1
 gpgcheck=0
 sslverify=false
@@ -277,6 +249,7 @@ YUM
 
 configure_subscription()
 {
+   configure_ose_yum_repos # if requested
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
@@ -292,6 +265,7 @@ configure_subscription()
    # however it turns out the ruby dependencies can sometimes be pulled in from the
    # wrong channel before yum-validator does its work. So, install it afterward.
    yum_install_or_exit openshift-enterprise-release
+   configure_ose_yum_repos # refresh if overwritten by validator
 }
 
 configure_rhn_channels()
@@ -1937,6 +1911,7 @@ is_false()
 #   nameservers
 #   node_hostname
 #   ose_repo_base
+#   ose_extra_repo_base
 #
 # This function makes use of variables that may be set by parse_kernel_cmdline
 # based on the content of /proc/cmdline or may be hardcoded by modifying
@@ -1959,7 +1934,8 @@ is_false()
 #   CONF_NODE_HOSTNAME
 #   CONF_NODE_IP_ADDR
 #   CONF_NODE_APACHE_FRONTEND
-#   CONF_REPOS_BASE
+#   CONF_OSE_REPO_BASE
+#   CONF_OSE_ERRATA_BASE
 set_defaults()
 {
   # By default, we run do_all_actions, which performs all the steps of
@@ -2026,6 +2002,7 @@ set_defaults()
   elif [ "${rhel_repo}" == "${ose_repo_base}/os" ]; then # OSE same repo base as RHEL?
     CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
   fi
+  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
   # no need to waste time checking both subscription plugins if using one
   disable_plugin=""

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -161,11 +161,12 @@
 #   Choose from the following ways to provide packages:
 #     none - install sources are already set up when the script executes (DEFAULT)
 #     yum - set up yum repos based on config
-#       ose_repo_base / CONF_OSE_REPO_BASE -- see below
 #       rhel_repo / CONF_RHEL_REPO -- see below
+#       rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO -- see below
 #       jboss_repo_base / CONF_JBOSS_REPO_BASE -- see below
 #       rhscl_repo_base / CONF_RHSCL_REPO_BASE -- see below
-#       rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO -- see below
+#       ose_repo_base / CONF_OSE_REPO_BASE -- see below
+#       ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
 #     rhsm - use subscription-manager
 #       rhn_user / CONF_RHN_USER
 #       rhn_pass / CONF_RHN_PASS
@@ -230,21 +231,21 @@
 # The nightly OSE build repositories use a different layout from CDN.
 # If the location of these is different from the CDN base and CONF_CDN_LAYOUT
 # is not set, then this layout is defined:
-# <ose_repo_base>/Client/x86_64/os
-# <ose_repo_base>/Infrastructure/x86_64/os
-# <ose_repo_base>/JBoss_EAP6_Cartridge/x86_64/os
-# <ose_repo_base>/Node/x86_64/os
+# <ose_repo_base>/RHOSE-CLIENT-2.0/x86_64/os
+# <ose_repo_base>/RHOSE-INFRA-2.0/x86_64/os
+# <ose_repo_base>/RHOSE-JBOSSEAP-2.0/x86_64/os
+# <ose_repo_base>/RHOSE-NODE-2.0/x86_64/os
 
 # cdn_repo_base / CONF_CDN_REPO_BASE
 #   Default base URL for all repositories used for the "yum" install method (see above).
-#CONF_CDN_REPO_BASE=http://.../6Server/x86_64
+#CONF_CDN_REPO_BASE=https://.../6Server/x86_64
 
 # ose_repo_base / CONF_OSE_REPO_BASE
-#   The base URL for the OpenShift repositories used for the "yum"
-#   install method - the part before Infrastructure/Node/etc.
+#   If defined, will define yum repos under the yum,rhsm,rhn install methods.
+#   The base URL for the OpenShift yum repositories - the part before RHOSE-*
 #   Note that if this is the same as CONF_CDN_REPO_BASE, then the
 #   CDN format will be used instead, e.g. x86_64/ose-node/1.2/os
-#CONF_OSE_REPO_BASE="https://mirror.openshift.com/pub/origin-server/nightly/enterprise/<latest>"
+#CONF_OSE_REPO_BASE="https://.../6Server/x86_64"
 
 # rhel_repo / CONF_RHEL_REPO
 #   The URL for a RHEL 6 yum repository used with the "yum" install method.
@@ -263,6 +264,11 @@
 #   The base URL for the SCL repositories used with the "yum"
 #   install method - the part before rhscl - ends in /6Server/x86_64
 
+# ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
+#   If defined, will define yum repos under the yum,rhsm,rhn install methods.
+#   These parallel the regular OSE channels/repos at the same priority and use
+#   the same (non-CDN) layout as ose_repo_base. These are intended to supply RPMs
+#   that augment or update the contents of the normal channels/repos.
 
 # # # # # # # # # # # domains, DNS, hostnames, and IPs # # # # # # # # # # # # # # # # #
 #
@@ -608,16 +614,31 @@ configure_yum_repos()
 {
   configure_rhel_repo
 
-  for repo in optional infra node jbosseap_cartridge jbosseap jbossews client_tools rhscl; do
+  for repo in optional jbosseap jbossews rhscl; do
     eval "need_${repo}_repo && configure_${repo}_repo"
   done
+  configure_ose_yum_repos
   yum clean metadata
   yum_install_or_exit openshift-enterprise-release
 }
 
+configure_ose_yum_repos()
+{ # define plain yum repos if the parameters are given
+  # this can be useful even if the main subscription is via RHN
+  for repo in infra node jbosseap_cartridge client_tools; do
+    if [ "$ose_repo_base" != "" ]; then
+      layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+      eval "need_${repo}_repo && def_ose_yum_repo $ose_repo_base $layout $repo"
+    fi
+    if [ "$ose_extra_repo_base" != "" ]; then
+      eval "need_${repo}_repo && def_ose_yum_repo $ose_extra_repo_base extra $repo"
+    fi
+  done
+}
+
 configure_rhel_repo()
 {
-  # In order for the %post section to succeed, it must have a way of 
+  # In order for the %post section to succeed, it must have a way of
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
@@ -652,67 +673,27 @@ YUM
 fi
 }
 
-ose_yum_repo_url()
+def_ose_yum_repo()
 {
-    channel=$1 #one of: RHOSE-CLIENT-2.0,RHOSE-INFRA-2.0,RHOSE-NODE-2.0,RHOSE-JBOSSEAP-2.0
-    if is_true "$CONF_CDN_LAYOUT"
-    then # use the release CDN layout for OSE URLs
-      declare -A map
-      map=([RHOSE-CLIENT-2.0]=ose-rhc [RHOSE-INFRA-2.0]=ose-infra [RHOSE-NODE-2.0]=ose-node [RHOSE-JBOSSEAP-2.0]=ose-jbosseap)
-      echo "$ose_repo_base/${map[$channel]}/2.0/os"
-    else # use the nightly puddle URLs
-      echo "$ose_repo_base/$channel/x86_64/os/"
-    fi
-}
+  repo_base=$1
+  layout=$2  # one of: puddle, extra, cdn
+  channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
 
-configure_client_tools_repo()
-{
-  cat > /etc/yum.repos.d/openshift-client.repo <<YUM
-[openshift_client]
-name=OpenShift Client
-baseurl=$(ose_yum_repo_url RHOSE-CLIENT-2.0)
-enabled=1
-gpgcheck=0
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_infra_repo()
-{
-  cat > /etc/yum.repos.d/openshift-infrastructure.repo <<YUM
-[openshift_infrastructure]
-name=OpenShift Infrastructure
-baseurl=$(ose_yum_repo_url RHOSE-INFRA-2.0)
-enabled=1
-gpgcheck=0
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_node_repo()
-{
-  cat > /etc/yum.repos.d/openshift-node.repo <<YUM
-[openshift_node]
-name=OpenShift Node
-baseurl=$(ose_yum_repo_url RHOSE-NODE-2.0)
-enabled=1
-gpgcheck=0
-priority=10
-sslverify=false
-
-YUM
-}
-
-configure_jbosseap_cartridge_repo()
-{
-  cat > /etc/yum.repos.d/openshift-jboss.repo <<YUM
-[openshift_jbosseap]
-name=OpenShift JBossEAP
-baseurl=$(ose_yum_repo_url RHOSE-JBOSSEAP-2.0)
+  declare -A map
+  case $layout in
+  puddle | extra)
+    map=([client_tools]=RHOSE-CLIENT-2.0 [infra]=RHOSE-INFRA-2.0 [node]=RHOSE-NODE-2.0 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.0)
+    url="$repo_base/${map[$channel]}/x86_64/os/"
+    ;;
+  cdn | * )
+    map=([client_tools]=ose-rhc [infra]=ose-infra [node]=ose-node [jbosseap_cartridge]=ose-jbosseap)
+    url="$repo_base/${map[$channel]}/2.0/os"
+    ;;
+  esac
+  cat > "/etc/yum.repos.d/openshift-${channel}-${layout}.repo" <<YUM
+[openshift_${channel}_${layout}]
+name=OpenShift $channel $layout
+baseurl=$url
 enabled=1
 gpgcheck=0
 priority=10
@@ -774,6 +755,7 @@ YUM
 
 configure_subscription()
 {
+   configure_ose_yum_repos # if requested
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
@@ -789,6 +771,7 @@ configure_subscription()
    # however it turns out the ruby dependencies can sometimes be pulled in from the
    # wrong channel before yum-validator does its work. So, install it afterward.
    yum_install_or_exit openshift-enterprise-release
+   configure_ose_yum_repos # refresh if overwritten by validator
 }
 
 configure_rhn_channels()
@@ -2434,6 +2417,7 @@ is_false()
 #   nameservers
 #   node_hostname
 #   ose_repo_base
+#   ose_extra_repo_base
 #
 # This function makes use of variables that may be set by parse_kernel_cmdline
 # based on the content of /proc/cmdline or may be hardcoded by modifying
@@ -2456,7 +2440,8 @@ is_false()
 #   CONF_NODE_HOSTNAME
 #   CONF_NODE_IP_ADDR
 #   CONF_NODE_APACHE_FRONTEND
-#   CONF_REPOS_BASE
+#   CONF_OSE_REPO_BASE
+#   CONF_OSE_ERRATA_BASE
 set_defaults()
 {
   # By default, we run do_all_actions, which performs all the steps of
@@ -2523,6 +2508,7 @@ set_defaults()
   elif [ "${rhel_repo}" == "${ose_repo_base}/os" ]; then # OSE same repo base as RHEL?
     CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
   fi
+  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
   # no need to waste time checking both subscription plugins if using one
   disable_plugin=""


### PR DESCRIPTION
Can now define parameters such that the script will configure plain old
yum repos for OSE puddles and extras, even when using an RHN subscription.
The extras repos can be used for testing errata.
