### PR TITLE
<openshift.sh> Bug 1045597 - add missing "IN" token to zone decl.

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1408,7 +1408,7 @@ add_host_to_zone()
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
-    echo "${1%.${zone}}			A	$2" >> $nsdb
+    echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1914,7 +1914,7 @@ add_host_to_zone()
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
-    echo "${1%.${zone}}			A	$2" >> $nsdb
+    echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1963,7 +1963,7 @@ add_host_to_zone()
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
-    echo "${1%.${zone}}			A	$2" >> $nsdb
+    echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1045597

Though technically optional, including the "IN" token on the MX and NS
lines will be less surprising to see when you're debugging some issue.
