### PR TITLE
<openshift.ks> node self-reports request for pub ssh key / bug 1054898

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1672,7 +1672,7 @@ configure_access_keys_on_broker()
   # location on httpd:
   cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
   # The node install script can retrieve this or it can be performed manually:
-  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub >> /root/.ssh/authorized_keys
+  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
   service httpd start
 }
@@ -1768,7 +1768,7 @@ install_rsync_pub_key()
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
   # Get key hosted on broker machine
-  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub" \
+  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}" \
     >> /root/.ssh/authorized_keys \
     || echo "WARNING: could not install rsync_id_rsa.pub key; please do it manually."
   chmod 644 /root/.ssh/authorized_keys

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2178,7 +2178,7 @@ configure_access_keys_on_broker()
   # location on httpd:
   cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
   # The node install script can retrieve this or it can be performed manually:
-  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub >> /root/.ssh/authorized_keys
+  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
   service httpd start
 }
@@ -2274,7 +2274,7 @@ install_rsync_pub_key()
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
   # Get key hosted on broker machine
-  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub" \
+  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}" \
     >> /root/.ssh/authorized_keys \
     || echo "WARNING: could not install rsync_id_rsa.pub key; please do it manually."
   chmod 644 /root/.ssh/authorized_keys

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2227,7 +2227,7 @@ configure_access_keys_on_broker()
   # location on httpd:
   cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
   # The node install script can retrieve this or it can be performed manually:
-  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub >> /root/.ssh/authorized_keys
+  #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
   service httpd start
 }
@@ -2323,7 +2323,7 @@ install_rsync_pub_key()
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
   # Get key hosted on broker machine
-  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub" \
+  wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}" \
     >> /root/.ssh/authorized_keys \
     || echo "WARNING: could not install rsync_id_rsa.pub key; please do it manually."
   chmod 644 /root/.ssh/authorized_keys


### PR DESCRIPTION
Updated 'wget' URL (used by the node to pull the broker's public key) to include a parameter containing the node hostname.  The idea is to allow the broker to accumulate knowledge of nodes configured in this way.  That information may be used down the line for streamlined registration of nodes with the broker system.

Luke Meyer: incorporated change into .sh and amz versions.
https://bugzilla.redhat.com/show_bug.cgi?id=1054898
