### PR TITLE
openshift.ks: Fix logic in configure_rhn_channels

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -285,7 +285,7 @@ configure_rhn_channels()
 
   # Enable the node or infrastructure channel to enable installing the release RPM
   repos=('rhel-x86_64-server-6-rhscl-1')
-  if [ ! need_node_repo ] || need_infra_repo ; then
+  if ! need_node_repo || need_infra_repo ; then
     repos+=('rhel-x86_64-server-6-ose-2.0-infrastructure')
   fi
   need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.0-node' 'jb-ews-2-x86_64-server-6-rpm')

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -791,7 +791,7 @@ configure_rhn_channels()
 
   # Enable the node or infrastructure channel to enable installing the release RPM
   repos=('rhel-x86_64-server-6-rhscl-1')
-  if [ ! need_node_repo ] || need_infra_repo ; then
+  if ! need_node_repo || need_infra_repo ; then
     repos+=('rhel-x86_64-server-6-ose-2.0-infrastructure')
   fi
   need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.0-node' 'jb-ews-2-x86_64-server-6-rpm')

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -840,7 +840,7 @@ configure_rhn_channels()
 
   # Enable the node or infrastructure channel to enable installing the release RPM
   repos=('rhel-x86_64-server-6-rhscl-1')
-  if [ ! need_node_repo ] || need_infra_repo ; then
+  if ! need_node_repo || need_infra_repo ; then
     repos+=('rhel-x86_64-server-6-ose-2.0-infrastructure')
   fi
   need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.0-node' 'jb-ews-2-x86_64-server-6-rpm')


### PR DESCRIPTION
Fix a syntax error in configure_rhn_channels that would cause it to fail to enable the infrastructure repository in the situation where we are installing the host as neither a broker nor a node (i.e., if we are installing only ActiveMQ, MongoDB, or BIND).

This commit fixes bug 1056895.
