### PR TITLE
openshift.ks: Don't update DOMAIN_SUFFIX

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1496,10 +1496,6 @@ configure_controller()
     echo "Warning: broker authentication salt is empty!"
   fi
 
-  # Configure the console with the correct domain
-  sed -i -e "s/^DOMAIN_SUFFIX=.*$/DOMAIN_SUFFIX=${domain}/" \
-      /etc/openshift/console.conf
-
   # Configure the broker with the correct domain name, and use random salt
   # to the data store (the host running MongoDB).
   sed -i -e "s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/" \

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2002,10 +2002,6 @@ configure_controller()
     echo "Warning: broker authentication salt is empty!"
   fi
 
-  # Configure the console with the correct domain
-  sed -i -e "s/^DOMAIN_SUFFIX=.*$/DOMAIN_SUFFIX=${domain}/" \
-      /etc/openshift/console.conf
-
   # Configure the broker with the correct domain name, and use random salt
   # to the data store (the host running MongoDB).
   sed -i -e "s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/" \

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2051,10 +2051,6 @@ configure_controller()
     echo "Warning: broker authentication salt is empty!"
   fi
 
-  # Configure the console with the correct domain
-  sed -i -e "s/^DOMAIN_SUFFIX=.*$/DOMAIN_SUFFIX=${domain}/" \
-      /etc/openshift/console.conf
-
   # Configure the broker with the correct domain name, and use random salt
   # to the data store (the host running MongoDB).
   sed -i -e "s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/" \


### PR DESCRIPTION
The DOMAIN_SUFFIX setting in /etc/openshift/console.conf no longer exists, so don't bother trying to update it.

This commit fixes bug 1056897.
