### PR TITLE
Update openshift.sh

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1040,7 +1040,7 @@ install_cartridges()
   # When dependencies are missing, e.g. JBoss subscriptions,
   # still install as much as possible.
   #install_pkgs="${install_pkgs} --skip-broken"
-
+  parse_cartridges
   yum_install_or_exit "${install_pkgs}"
 }
 


### PR DESCRIPTION
In install_cartridges() function $install_pkgs was blank. yum install was failing due to no packages passed to install. 

Calling parse_cartridges in install_cartridges function solved the issue.
