### PR TITLE
oo-install: Call parse_cartridges action

### DIFF
--- a/oo-install/workflows/enterprise_deploy/launcher.rb
+++ b/oo-install/workflows/enterprise_deploy/launcher.rb
@@ -9,7 +9,7 @@ COMPONENT_INSTALL_ORDER = %w[ named datastore activemq broker node ]
 INSTALL_STEPS = %w[ . prepare install configure define_hosts ]
 INSTALL_STATES = %w[ new prepared installed completed completed validated broken ]
 INSTALL_ACTIONS = %w[ .
-                      init_message,validate_preflight,configure_repos
+                      init_message,validate_preflight,parse_cartridges,configure_repos
                       install_rpms
                       configure_host,configure_openshift
                       register_named_entries


### PR DESCRIPTION
Add parse_cartridges to INSTALL_ACTIONS in the launcher.

After commit e6cd65df01ee1cbdf837d49b4a199506a240d95f which added the CONF_CARTRIDGES option to openshift.ks/openshift.sh, it is necessary to invoke the parse_cartridges action before calling configure_repos and install_cartridges.

This commit fixes bug 1060235.
