### PR TITLE
<install> Changes for activemq-5.9.0 update - enterprise 1.2

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1295,25 +1295,16 @@ $networkConnectors
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
+        If enabling the web console, you should make sure to require 
+        authentication in jetty.xml and configure the admin/user
+        passwords in jetty-realm.properties.
+
         <import resource="jetty.xml"/>
     -->
 
 </beans>
 <!-- END SNIPPET: example -->
 EOF
-
-  # secure the ActiveMQ console
-  sed -i -e '/name="authenticate"/s/false/true/' /etc/activemq/jetty.xml
-
-  # only add the host property if it's not already there
-  # (so you can run the script multiple times)
-  grep '<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml > /dev/null
-  if [ $? -ne 0 ]; then
-    sed -i -e '/name="port"/a<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml
-  fi
-
-  sed -i -e "/admin:/s/admin,/${activemq_admin_password},/" /etc/activemq/jetty-realm.properties
-
 
   # Allow connections to ActiveMQ.
   $lokkit --port=61613:tcp

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1770,25 +1770,16 @@ $networkConnectors
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
+        If enabling the web console, you should make sure to require 
+        authentication in jetty.xml and configure the admin/user
+        passwords in jetty-realm.properties.
+
         <import resource="jetty.xml"/>
     -->
 
 </beans>
 <!-- END SNIPPET: example -->
 EOF
-
-  # secure the ActiveMQ console
-  sed -i -e '/name="authenticate"/s/false/true/' /etc/activemq/jetty.xml
-
-  # only add the host property if it's not already there
-  # (so you can run the script multiple times)
-  grep '<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml > /dev/null
-  if [ $? -ne 0 ]; then
-    sed -i -e '/name="port"/a<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml
-  fi
-
-  sed -i -e "/admin:/s/admin,/${activemq_admin_password},/" /etc/activemq/jetty-realm.properties
-
 
   # Allow connections to ActiveMQ.
   $lokkit --port=61613:tcp

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1819,25 +1819,16 @@ $networkConnectors
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
+        If enabling the web console, you should make sure to require 
+        authentication in jetty.xml and configure the admin/user
+        passwords in jetty-realm.properties.
+
         <import resource="jetty.xml"/>
     -->
 
 </beans>
 <!-- END SNIPPET: example -->
 EOF
-
-  # secure the ActiveMQ console
-  sed -i -e '/name="authenticate"/s/false/true/' /etc/activemq/jetty.xml
-
-  # only add the host property if it's not already there
-  # (so you can run the script multiple times)
-  grep '<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml > /dev/null
-  if [ $? -ne 0 ]; then
-    sed -i -e '/name="port"/a<property name="host" value="127.0.0.1" />' /etc/activemq/jetty.xml
-  fi
-
-  sed -i -e "/admin:/s/admin,/${activemq_admin_password},/" /etc/activemq/jetty-realm.properties
-
 
   # Allow connections to ActiveMQ.
   $lokkit --port=61613:tcp


### PR DESCRIPTION
Updated to remove jetty and jetty realm configuration changes.  Also cherry-picked in the change to disable loading jetty.xml in the activemq config
