### PR TITLE
<install> Set default BIND key algorithm to MD5

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2137,8 +2137,8 @@ set_defaults()
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
   bind_key="$CONF_BIND_KEY"
-  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-SHA256}"
-  bind_keysize="${CONF_BIND_KEYSIZE:-256}"
+  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-MD5}"
+  bind_keysize="${CONF_BIND_KEYSIZE:-512}"
   fi
 
   # Set $conf_valid_gear_sizes to $CONF_VALID_GEAR_SIZES

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -367,15 +367,18 @@
 #CONF_BIND_KEY=""
 
 # bind_keyalgorithm / CONF_BIND_KEYALGORITHM
+#   Default: HMAC-MD5
 #   Specify a key algorithm to use when generating a bind key. Or if specifying
 #   a bind_key, this should be set to the algorithm which was used when the
 #   bind_key was generated.
 #CONF_BIND_KEYALGORITHM="HMAC-SHA265"
 
 # bind_keysize / CONF_BIND_KEYSIZE
+#   Default: 512
 #   Specify a key size to use for generating a bind key. Or if specifying
 #   a bind_key, this should be set to the key size used when the bind_key was
-#   generated.
+#   generated.  Be sure to use a key size that is appropriate for the
+#   key algorithm.
 #CONF_BIND_KEYSIZE="256"
 
 # bind_krb_keytab / CONF_BIND_KRB_KEYTAB
@@ -2698,8 +2701,8 @@ set_defaults()
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
   bind_key="$CONF_BIND_KEY"
-  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-SHA256}"
-  bind_keysize="${CONF_BIND_KEYSIZE:-256}"
+  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-MD5}"
+  bind_keysize="${CONF_BIND_KEYSIZE:-512}"
   fi
 
   # Set $conf_valid_gear_sizes to $CONF_VALID_GEAR_SIZES

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -366,15 +366,18 @@
 #CONF_BIND_KEY=""
 
 # bind_keyalgorithm / CONF_BIND_KEYALGORITHM
+#   Default: HMAC-MD5
 #   Specify a key algorithm to use when generating a bind key. Or if specifying
 #   a bind_key, this should be set to the algorithm which was used when the
 #   bind_key was generated.
 #CONF_BIND_KEYALGORITHM="HMAC-SHA265"
 
 # bind_keysize / CONF_BIND_KEYSIZE
+#   Default: 512
 #   Specify a key size to use for generating a bind key. Or if specifying
 #   a bind_key, this should be set to the key size used when the bind_key was
-#   generated.
+#   generated.  Be sure to use a key size that is appropriate for the
+#   key algorithm.
 #CONF_BIND_KEYSIZE="256"
 
 # bind_krb_keytab / CONF_BIND_KRB_KEYTAB
@@ -2747,8 +2750,8 @@ set_defaults()
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
   bind_key="$CONF_BIND_KEY"
-  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-SHA256}"
-  bind_keysize="${CONF_BIND_KEYSIZE:-256}"
+  bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-MD5}"
+  bind_keysize="${CONF_BIND_KEYSIZE:-512}"
   fi
 
   # Set $conf_valid_gear_sizes to $CONF_VALID_GEAR_SIZES


### PR DESCRIPTION
Change the default settings for CONF_BIND_KEYALGORITHM and CONF_BIND_KEYSIZE to HMAC-MD5 (instead of HMAC-SHA256) and 512 (instead of 256), respectively, so that the DNSSEC key generation, BIND configuration, and dns-nsupdate plug-in configuration will use HMAC-MD5 (instead of HMAC-SHA256) by default.

OpenShift Enterprise 2.0 only supports the HMAC-MD5 algorithm for nsupdate.

This commit fixes bug 1066171.
