### PR TITLE
<install> Write EOL to /etc/ssh/sshd_config

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -759,7 +759,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH\n' >> /etc/ssh/sshd_config
 
   # Up the limits on the number of connections to a given node.
   sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1327,7 +1327,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH\n' >> /etc/ssh/sshd_config
 
   # Up the limits on the number of connections to a given node.
   sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1376,7 +1376,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH\n' >> /etc/ssh/sshd_config
 
   # Up the limits on the number of connections to a given node.
   sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config


### PR DESCRIPTION
In the configure_sshd_on_node function in openshift.ks/openshift.sh, be sure to write the \n EOL marker when adding the AcceptEnv setting.

After commit 24d469fd2f2aa0bcc0d430f7ee148598fdb29e23, configure_sshd_on_node writes a \n to sshd_config _before_ the line that the function adds, for the contingency that sshd_config already has an incomplete line lacking the EOL marker.  However, after that commit, the function wasn't writing the \n _of_ the line that the function adds.  This commit makes the function write both \n EOL markers.

This commit fixes bug 1068649.
