### PR TITLE
subscription_type check is performed against symbol

### DIFF
--- a/oo-install/bin/oo-install
+++ b/oo-install/bin/oo-install
@@ -143,7 +143,7 @@ set_mode(options[:advanced_mode])
 
 # Instantiate the cli-provided subscription info in a subscription object
 cli_subscription = Installer::Subscription.new(@config)
-cli_subscription.subscription_type = options[:subscription_type]
+cli_subscription.subscription_type = options[:subscription_type].to_sym
 cli_subscription.rh_username = options[:rh_username]
 cli_subscription.rh_password = options[:rh_password]
 


### PR DESCRIPTION
```
./oo-install-ose -c oo-install-cfg.yml -e -s rhn -u $u -p $p -w enterprise_deploy
```

will fail with _Subscription type 'rhn' is not recognized_ because _case_ check is performed against :symbol in oo-install/lib/installer/subscription.rb:subscription_info but string is passed as argument. 
