### PR TITLE
Conditionally loop over metapkgs

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -527,14 +527,17 @@ parse_cartridges()
     fi
   done
 
-  for metapkg in ${meta[@]}
-  do
-    if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
-    then
+  if metapkgs_optional || metapkgs_recommended
+  then
+    for metapkg in ${meta[@]}
+    do
+      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
-    fi
-  done
+      fi
+    done
+  fi
 
   # Set CONF_NO_JBOSSEAP=0 if $pkgs includes the JBossEAP cartridges,
   # CONF_NO_JBOSSEAP=1 otherwise, so that configure_repos will enable

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1102,14 +1102,17 @@ parse_cartridges()
     fi
   done
 
-  for metapkg in ${meta[@]}
-  do
-    if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
-    then
+  if metapkgs_optional || metapkgs_recommended
+  then
+    for metapkg in ${meta[@]}
+    do
+      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
-    fi
-  done
+      fi
+    done
+  fi
 
   # Set CONF_NO_JBOSSEAP=0 if $pkgs includes the JBossEAP cartridges,
   # CONF_NO_JBOSSEAP=1 otherwise, so that configure_repos will enable

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1151,14 +1151,17 @@ parse_cartridges()
     fi
   done
 
-  for metapkg in ${meta[@]}
-  do
-    if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
-    then
+  if metapkgs_optional || metapkgs_recommended
+  then
+    for metapkg in ${meta[@]}
+    do
+      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
-    fi
-  done
+      fi
+    done
+  fi
 
   # Set CONF_NO_JBOSSEAP=0 if $pkgs includes the JBossEAP cartridges,
   # CONF_NO_JBOSSEAP=1 otherwise, so that configure_repos will enable


### PR DESCRIPTION
Added check to prevent looping over the metapkgs in `parse_cartridges`
when `CONF_METAPKGS=none`
