### PR TITLE
yum-validator: Cherry-pick upstream OSE 2.1 config

### DIFF
--- a/admin/yum-validator/etc/repos.ini
+++ b/admin/yum-validator/etc/repos.ini
@@ -3,7 +3,7 @@
 [rhel-6-server-rpms]
 subscription = rhsm
 product = rhel
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = base
 key_pkg = None
 exclude = tomcat6*
@@ -11,7 +11,7 @@ exclude = tomcat6*
 [jb-ews-2-for-rhel-6-server-rpms]
 subscription = rhsm
 product = jboss
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node
 key_pkg = openshift-origin-cartridge-jbossews
 exclude = httpd, httpd-tools, mod_ssl
@@ -19,7 +19,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [jb-eap-6-for-rhel-6-server-rpms]
 subscription = rhsm
 product = jboss
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
@@ -27,7 +27,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [rhel-server-rhscl-6-rpms]
 subscription = rhsm
 product = rhscl
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node, broker
 key_pkg = ruby193
 # RHSM 1.2 repos
@@ -59,8 +59,8 @@ product = ose
 product_version = 1.2
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
-# RHSM 2.0 repos
 
+# RHSM 2.0 repos
 [rhel-6-server-ose-2.0-node-rpms]
 subscription = rhsm
 product = ose
@@ -88,12 +88,41 @@ product = ose
 product_version = 2.0
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
-# RHN Common
 
+# RHSM 2.1 repos
+[rhel-6-server-ose-2.1-node-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-6-server-ose-2.1-infra-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-6-server-ose-2.1-rhc-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = client
+key_pkg = rhc
+
+[rhel-6-server-ose-2.1-jbosseap-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+# RHN Common
 [rhel-x86_64-server-6]
 subscription = rhn
 product = rhel
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = base
 key_pkg = None
 exclude = tomcat6*
@@ -101,7 +130,7 @@ exclude = tomcat6*
 [jb-ews-2-x86_64-server-6-rpm]
 subscription = rhn
 product = jboss
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node
 key_pkg = openshift-origin-cartridge-jbossews
 exclude = httpd, httpd-tools, mod_ssl
@@ -109,7 +138,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [jbappplatform-6-x86_64-server-6-rpm]
 subscription = rhn
 product = jboss
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
@@ -117,11 +146,11 @@ exclude = httpd, httpd-tools, mod_ssl
 [rhel-x86_64-server-6-rhscl-1]
 subscription = rhn
 product = rhscl
-product_version = 1.2, 2.0
+product_version = 1.2, 2.0, 2.1
 role = node, broker
 key_pkg = ruby193
-# RHN 1.2 repos
 
+# RHN 1.2 repos
 [rhel-x86_64-server-6-ose-1.2-node]
 subscription = rhn
 product = ose
@@ -149,8 +178,8 @@ product = ose
 product_version = 1.2
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
-# RHN 2.0 repos
 
+# RHN 2.0 repos
 [rhel-x86_64-server-6-ose-2.0-node]
 subscription = rhn
 product = ose
@@ -176,5 +205,34 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 2.0
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
+# RHN 2.1 repos
+[rhel-x86_64-server-6-ose-2.1-node]
+subscription = rhn
+product = ose
+product_version = 2.1
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-x86_64-server-6-ose-2.1-infrastructure]
+subscription = rhn
+product = ose
+product_version = 2.1
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-x86_64-server-6-ose-2.1-rhc]
+subscription = rhn
+product = ose
+product_version = 2.1
+role = client
+key_pkg = rhc
+
+[rhel-x86_64-server-6-ose-2.1-jbosseap]
+subscription = rhn
+product = ose
+product_version = 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap


### PR DESCRIPTION
Pull in changes to `repos.ini` for enterprise 2.1 release
