### PR TITLE
oo-install: Fix bail code for scp in run_on_host

### DIFF
--- a/oo-install/workflows/enterprise_deploy/launcher.rb
+++ b/oo-install/workflows/enterprise_deploy/launcher.rb
@@ -213,7 +213,7 @@ def run_on_host(host, step)
     }
   else
     puts "Copying deployment scripts to target #{host['ssh_host']}.\n"
-    bail = proc do |output|
+    bail = Proc.new do |output|
       localfile.delete # ensure it's gone before bailing
       return {
         :success => false,


### PR DESCRIPTION
Properly define the `bail` proc in `run_on_host` so that it actually does bail if the `scp` command fails, rather than continuing execution.

The semantics of procs defined using the `proc` keyword changed between Ruby 1.8.7 and Ruby 1.9.3.  In 1.8.7, a `return` statement in a proc defined using the `proc` keyword does not return from the caller, which is what is intended in the `bail` proc.  It is necessary to use `Proc.new` instead, which behaves as expected on both Ruby 1.8.7 and Ruby 1.9.3.

This commit fixes bug 1092108.
