### PR TITLE
<openshift.ks> Override EXTERNAL_ETH_DEV in node.conf if needed

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1614,12 +1614,12 @@ register_named_entries()
 configure_network()
 {
   # Ensure interface is configured to come up on boot
-  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$interface
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$iface; then
-    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$iface
-    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$interface
   fi
 }
 
@@ -1637,9 +1637,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$iface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$iface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$iface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
+  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -1891,7 +1891,8 @@ configure_node()
   sed -i -e "s/^PUBLIC_IP=.*$/PUBLIC_IP=${node_ip_addr}/;
              s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/;
              s/^PUBLIC_HOSTNAME=.*$/PUBLIC_HOSTNAME=${hostname}/;
-             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/" \
+             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/;
+             s/^[# ]*EXTERNAL_ETH_DEV=.*$/EXTERNAL_ETH_DEV='${interface}'/" \
       /etc/openshift/node.conf
 
   sed -i -e "s/^node_profile=.*$/node_profile=${node_profile}/" \
@@ -2272,7 +2273,7 @@ set_defaults()
   nameservers="$(awk '/nameserver/ { printf "%s; ", $2 }' /etc/resolv.conf)"
 
   # Main interface to configure
-  iface="${CONF_INTERFACE:-eth0}"
+  interface="${CONF_INTERFACE:-eth0}"
 
   # Set $bind_krb_keytab and $bind_krb_principal to the values of
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -325,6 +325,12 @@
 #   The network domain under which app DNS entries will be placed.
 #CONF_DOMAIN="example.com"
 
+# interface / CONF_INTERFACE
+#   Default: eth0
+#   The network device to configure.  Used by configure_network, 
+#   configure_dns_resolution, and configure_node
+#CONF_INTERFACE="eth0"
+
 # hosts_domain / CONF_HOSTS_DOMAIN
 #   Default: hosts.example.com
 #   If specified and host DNS is to be created, this domain will be created
@@ -2233,12 +2239,12 @@ register_named_entries()
 configure_network()
 {
   # Ensure interface is configured to come up on boot
-  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$interface
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$iface; then
-    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$iface
-    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$interface
   fi
 }
 
@@ -2256,9 +2262,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$iface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$iface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$iface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
+  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -2510,7 +2516,8 @@ configure_node()
   sed -i -e "s/^PUBLIC_IP=.*$/PUBLIC_IP=${node_ip_addr}/;
              s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/;
              s/^PUBLIC_HOSTNAME=.*$/PUBLIC_HOSTNAME=${hostname}/;
-             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/" \
+             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/;
+             s/^[# ]*EXTERNAL_ETH_DEV=.*$/EXTERNAL_ETH_DEV='${interface}'/" \
       /etc/openshift/node.conf
 
   sed -i -e "s/^node_profile=.*$/node_profile=${node_profile}/" \
@@ -2891,7 +2898,7 @@ set_defaults()
   nameservers="$(awk '/nameserver/ { printf "%s; ", $2 }' /etc/resolv.conf)"
 
   # Main interface to configure
-  iface="${CONF_INTERFACE:-eth0}"
+  interface="${CONF_INTERFACE:-eth0}"
 
   # Set $bind_krb_keytab and $bind_krb_principal to the values of
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -324,6 +324,12 @@
 #   The network domain under which app DNS entries will be placed.
 #CONF_DOMAIN="example.com"
 
+# interface / CONF_INTERFACE
+#   Default: eth0
+#   The network device to configure.  Used by configure_network, 
+#   configure_dns_resolution, and configure_node
+#CONF_INTERFACE="eth0"
+
 # hosts_domain / CONF_HOSTS_DOMAIN
 #   Default: hosts.example.com
 #   If specified and host DNS is to be created, this domain will be created
@@ -2279,12 +2285,12 @@ register_named_entries()
 configure_network()
 {
   # Ensure interface is configured to come up on boot
-  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$interface
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$iface; then
-    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$iface
-    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$iface
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$interface
   fi
 }
 
@@ -2302,9 +2308,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$iface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$iface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$iface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
+  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -2556,7 +2562,8 @@ configure_node()
   sed -i -e "s/^PUBLIC_IP=.*$/PUBLIC_IP=${node_ip_addr}/;
              s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/;
              s/^PUBLIC_HOSTNAME=.*$/PUBLIC_HOSTNAME=${hostname}/;
-             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/" \
+             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/;
+             s/^[# ]*EXTERNAL_ETH_DEV=.*$/EXTERNAL_ETH_DEV='${interface}'/" \
       /etc/openshift/node.conf
 
   sed -i -e "s/^node_profile=.*$/node_profile=${node_profile}/" \
@@ -2937,7 +2944,7 @@ set_defaults()
   nameservers="$(awk '/nameserver/ { printf "%s; ", $2 }' /etc/resolv.conf)"
 
   # Main interface to configure
-  iface="${CONF_INTERFACE:-eth0}"
+  interface="${CONF_INTERFACE:-eth0}"
 
   # Set $bind_krb_keytab and $bind_krb_principal to the values of
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values


### PR DESCRIPTION
If CONF_INTERFACE/interface is specified override EXTERNAL_ETH_DEV in
node.conf.

refactor iface to interface to match variable/parameter naming
conventions
