### PR TITLE
yum-validator: Add OSE 2.1 channel info to repos.ini

### DIFF
--- a/admin/yum-validator/etc/repos.ini
+++ b/admin/yum-validator/etc/repos.ini
@@ -3,15 +3,7 @@
 [rhel-6-server-rpms]
 subscription = rhsm
 product = rhel
-product_version = 1.2, 2.0, 2.0beta
-role = base
-key_pkg = None
-exclude = tomcat6*
-
-[rhel-6-server-beta-rpms]
-subscription = rhsm
-product = rhel
-product_version = 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = base
 key_pkg = None
 exclude = tomcat6*
@@ -19,7 +11,7 @@ exclude = tomcat6*
 [jb-ews-2-for-rhel-6-server-rpms]
 subscription = rhsm
 product = jboss
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node
 key_pkg = openshift-origin-cartridge-jbossews
 exclude = httpd, httpd-tools, mod_ssl
@@ -27,7 +19,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [jb-eap-6-for-rhel-6-server-rpms]
 subscription = rhsm
 product = jboss
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
@@ -35,7 +27,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [rhel-server-rhscl-6-rpms]
 subscription = rhsm
 product = rhscl
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node, broker
 key_pkg = ruby193
 
@@ -99,20 +91,42 @@ product_version = 2.0
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 
+# RHSM 2.1 repos
+
+[rhel-6-server-ose-2.1-node-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = node
+key_pkg = rubygem-openshift-origin-node
+
+[rhel-6-server-ose-2.1-infra-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = broker
+key_pkg = openshift-origin-broker
+
+[rhel-6-server-ose-2.1-rhc-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = client
+key_pkg = rhc
+
+[rhel-6-server-ose-2.1-jbosseap-rpms]
+subscription = rhsm
+product = ose
+product_version = 2.1
+role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+
 # RHN Common
 
 [rhel-x86_64-server-6]
 subscription = rhn
 product = rhel
-product_version = 1.2, 2.0, 2.0beta
-role = base
-key_pkg = None
-exclude = tomcat6*
-
-[rhel-x86_64-server-6-beta]
-subscription = rhn
-product = rhel
-product_version = 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = base
 key_pkg = None
 exclude = tomcat6*
@@ -120,7 +134,7 @@ exclude = tomcat6*
 [jb-ews-2-x86_64-server-6-rpm]
 subscription = rhn
 product = jboss
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node
 key_pkg = openshift-origin-cartridge-jbossews
 exclude = httpd, httpd-tools, mod_ssl
@@ -128,7 +142,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [jbappplatform-6-x86_64-server-6-rpm]
 subscription = rhn
 product = jboss
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
@@ -136,7 +150,7 @@ exclude = httpd, httpd-tools, mod_ssl
 [rhel-x86_64-server-6-rhscl-1]
 subscription = rhn
 product = rhscl
-product_version = 1.2, 2.0, 2.0beta
+product_version = 1.2, 2.0, 2.1
 role = node, broker
 key_pkg = ruby193
 
@@ -200,63 +214,33 @@ product_version = 2.0
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 
-# RHSM 2.0beta repos
+# RHN 2.1 repos
 
-[rhel-6-server-ose-2-beta-node-rpms]
-subscription = rhsm
+[rhel-x86_64-server-6-ose-2.1-node]
+subscription = rhn
 product = ose
-product_version = 2.0beta
+product_version = 2.1
 role = node
 key_pkg = rubygem-openshift-origin-node
 
-[rhel-6-server-ose-2-beta-infra-rpms]
-subscription = rhsm
+[rhel-x86_64-server-6-ose-2.1-infrastructure]
+subscription = rhn
 product = ose
-product_version = 2.0beta
+product_version = 2.1
 role = broker
 key_pkg = openshift-origin-broker
 
-[rhel-6-server-ose-2-beta-rhc-rpms]
-subscription = rhsm
+[rhel-x86_64-server-6-ose-2.1-rhc]
+subscription = rhn
 product = ose
-product_version = 2.0beta
+product_version = 2.1
 role = client
 key_pkg = rhc
 
-[rhel-6-server-ose-2-beta-jbosseap-rpms]
-subscription = rhsm
-product = ose
-product_version = 2.0beta
-role = node-eap
-key_pkg = openshift-origin-cartridge-jbosseap
-
-# RHN 2.0beta repos
-
-[rhel-x86_64-server-6-ose-2-node-beta]
+[rhel-x86_64-server-6-ose-2.1-jbosseap]
 subscription = rhn
 product = ose
-product_version = 2.0beta
-role = node
-key_pkg = rubygem-openshift-origin-node
-
-[rhel-x86_64-server-6-ose-2-infrastructure-beta]
-subscription = rhn
-product = ose
-product_version = 2.0beta
-role = broker
-key_pkg = openshift-origin-broker
-
-[rhel-x86_64-server-6-ose-2-rhc-beta]
-subscription = rhn
-product = ose
-product_version = 2.0beta
-role = client
-key_pkg = rhc
-
-[rhel-x86_64-server-6-ose-2-jbosseap-beta]
-subscription = rhn
-product = ose
-product_version = 2.0beta
+product_version = 2.1
 role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 
@@ -302,5 +286,5 @@ key_pkg = None
 exclude = tomcat6*
 
 [preferences]
-preferred_version = 2.0
+preferred_version = 2.1
 preferred_subscription = rhsm


### PR DESCRIPTION
Bug 1097844
https://bugzilla.redhat.com/show_bug.cgi?id=1097844

Adds OSE 2.1 RHSM and RHN channel info to `repos.ini`, updates RHN/RHSM
common channel data with 2.1 version
