### PR TITLE
 openshift.sh: Exit with 0 exit code 

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3408,4 +3408,5 @@ $RESTART_NEEDED && restart_services
 
 $PASSWORDS_TO_DISPLAY && display_passwords
 
+:
 

--- a/enterprise/install-scripts/generic/scriptify
+++ b/enterprise/install-scripts/generic/scriptify
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# Insert a shebang, delete the kickstart-specific portion,
+# and make sure that the last command returns true.
 sed -e '1i #!/bin/bash -x
 /^#Begin Kickstart Script/,/^set -x/ d
-/^%end/ d
+/^%end/ c:
 ' $1 > $2
 
 sed -i -e 's/^\s*environment=ks/environment=sh/' $2


### PR DESCRIPTION
Make the last command in `openshift.sh` return true.

If we reach the last command in `openshift.sh`, then that means that nothing called `abort_install` to terminate execution of `openshift.sh`, and so `openshift.sh` should exit with a zero exit code irrespective of the success of the previous command.
