### PR TITLE
 openshift.ks: Run restorecon on /etc/openshift 

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -725,7 +725,7 @@ configure_selinux_policy_on_node()
 
 
   restorecon -rv /var/run
-  restorecon -rv /var/lib/openshift /etc/openshift/node.conf /etc/httpd/conf.d/openshift
+  restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
 }
 
 configure_pam_on_node()
@@ -2623,6 +2623,7 @@ configure_openshift()
   node && install_rsync_pub_key
 
   sysctl -p
+  restorecon -rv /etc/openshift
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1351,7 +1351,7 @@ configure_selinux_policy_on_node()
 
 
   restorecon -rv /var/run
-  restorecon -rv /var/lib/openshift /etc/openshift/node.conf /etc/httpd/conf.d/openshift
+  restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
 }
 
 configure_pam_on_node()
@@ -3249,6 +3249,7 @@ configure_openshift()
   node && install_rsync_pub_key
 
   sysctl -p
+  restorecon -rv /etc/openshift
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1397,7 +1397,7 @@ configure_selinux_policy_on_node()
 
 
   restorecon -rv /var/run
-  restorecon -rv /var/lib/openshift /etc/openshift/node.conf /etc/httpd/conf.d/openshift
+  restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
 }
 
 configure_pam_on_node()
@@ -3295,6 +3295,7 @@ configure_openshift()
   node && install_rsync_pub_key
 
   sysctl -p
+  restorecon -rv /etc/openshift
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true


### PR DESCRIPTION
Run `restorecon -rv /etc/openshift` at the end of `configure_openshift`.

Delete `/etc/openshift/node.conf` from a `restorecon` command in `configure_selinux_policy_on_node` because the previous change will take care of `/etc/openshift/node.conf`.

This commit fixes bug 1110424.
