### PR TITLE
oo-admin-yum-validator: Fix string in guess_ose

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -675,7 +675,7 @@ class OpenShiftYumValidator(object):
                                           for pkg in present_pkgs])
                 # Peek ahead to see if we're possibly running an OSE install
                 for repo in pkg_repos:
-                    if not self.opts.product or repo.product == ose:
+                    if not self.opts.product or repo.product == 'ose':
                         self.opts.product = repo.product
         if not self.opts.role:
             self.logger.error('No roles could be detected.')


### PR DESCRIPTION
Put quotation marks around the string literal 'ose' in the `guess_role` method to avoid a `NameError` exception and a backtrace.

This commit fixes bug 1112883.
