### PR TITLE
openshift.ks: Stop using lokkit

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1624,7 +1624,7 @@ configure_datastore()
     echo 'The data store needs to be accessible externally.'
 
     echo 'Configuring the firewall to allow connections to mongod...'
-    $lokkit --port=27017:tcp
+    firewall_allow[mongodb]=tcp:27017
 
     echo 'Configuring mongod to listen on all interfaces...'
     set_mongodb bind_ip 0.0.0.0
@@ -1647,6 +1647,8 @@ configure_datastore()
 
 
 # Open up services required on the node for apps and developers.
+#
+# Note: This function must only be run after configure_firewall.
 configure_port_proxy()
 {
   chkconfig openshift-iptables-port-proxy on
@@ -1670,12 +1672,12 @@ enable_services_on_node()
   # will produce errors.  Anyway, we only need the configuration
   # activated after Anaconda reboots, so --nostart makes sense in any case.
 
-  $lokkit --service=https
-  $lokkit --service=http
+  firewall_allow[https]=tcp:443
+  firewall_allow[http]=tcp:80
 
   # Allow connections to openshift-node-web-proxy
-  $lokkit --port=8000:tcp
-  $lokkit --port=8443:tcp
+  firewall_allow[ws]=tcp:8000
+  firewall_allow[wss]=tcp:8443
 
   chkconfig httpd on
   chkconfig network on
@@ -1694,8 +1696,8 @@ enable_services_on_broker()
   # will produce errors.  Anyway, we only need the configuration
   # activated after Anaconda reboots, so --nostart makes sense.
 
-  $lokkit --service=https
-  $lokkit --service=http
+  firewall_allow[https]=tcp:443
+  firewall_allow[http]=tcp:80
 
   chkconfig httpd on
   chkconfig network on
@@ -2033,8 +2035,8 @@ $networkConnectors
 EOF
 
   # Allow connections to ActiveMQ.
-  $lokkit --port=61613:tcp
-  allow_openwire && $lokkit --port=61616:tcp
+  firewall_allow[stomp]=tcp:61613
+  allow_openwire && firewall_allow[openwire]=tcp:61616
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -2130,7 +2132,7 @@ EOF
   configure_hosts_dns
 
   # Configure named to start on boot.
-  $lokkit --service=dns
+  firewall_allow[dns]=tcp:53,udp:53
   chkconfig named on
 
   # Start named so we can perform some updates immediately.
@@ -3172,7 +3174,7 @@ install_rpms()
   yum $disable_plugin update -y || abort_install
   # Install a few packages missing from a minimal RHEL install required by the
   # installer script itself.
-  yum_install_or_exit ntp ntpdate lokkit wget
+  yum_install_or_exit ntp ntpdate wget
 
   # install what we need for various components
   named && install_named_pkgs
@@ -3203,10 +3205,59 @@ configure_host()
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
 
+  # Reset the firewall to disable lokkit and initialise iptables configuration.
+  configure_firewall
+
   # all hosts should enable ssh access
-  $lokkit --service=ssh
+  firewall_allow[ssh]=tcp:22
 
   echo "OpenShift: Completed configuring host."
+}
+
+configure_firewall()
+{
+  # Disable lokkit.
+  conf='/etc/sysconfig/system-config-firewall'
+  [[ "$(< "$conf")" != --disabled ]] &&
+    mv "$conf" "${conf}.bak"
+  echo '--disabled' > "$conf"
+
+  # Configure iptables.
+cat > /etc/sysconfig/iptables <<'EOF'
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+COMMIT
+EOF
+
+  # Load the configuration on reboot.
+  chkconfig iptables on
+}
+
+# Note: This function must be run after configure_firewall.
+configure_firewall_add_rules()
+{
+  rules="$(
+    for svc in ${firewall_allow[@]}
+    do
+      for rule in ${svc//,/ }
+      do
+        prot="${rule%%:*}"
+        port="${rule##*:}"
+        printf ' \\\n-A INPUT -m state --state NEW -m %s -p %s --dport %s -j ACCEPT' "$prot" "$prot" "$port"
+      done
+    done
+  )"
+
+  # Insert the rules specified by ${firewall_allow[@]} before the first
+  # REJECT rule in the INPUT chain.
+  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" /etc/sysconfig/iptables
 }
 
 configure_openshift()
@@ -3248,6 +3299,8 @@ configure_openshift()
   node && broker && fix_broker_routing
   node && install_rsync_pub_key
 
+  configure_firewall_add_rules
+
   sysctl -p
   restorecon -rv /etc/openshift
 
@@ -3259,6 +3312,9 @@ configure_openshift()
 restart_services()
 {
   echo "OpenShift: Begin restarting services."
+
+  service iptables restart
+
   # named is already started in configure_named.
   named && service named restart
 
@@ -3380,19 +3436,14 @@ ks)
   # parse_kernel_cmdline is only needed for kickstart and not if this %post
   # section is extracted and executed on a running system.
   parse_kernel_cmdline
-  # during a kickstart a live lokkit fails
-  lokkit="lokkit --nostart"
   ;;
 vm)
   # no args to parse; they are directly inserted by make.
-  # during a kickstart a live lokkit fails
-  lokkit="lokkit --nostart"
   ;;
 *)
   # parse_cmdline is only needed for shell scripts generated by extracting
   # this %post section.
   parse_cmdline "$@"
-  lokkit="lokkit" # normally...
   ;;
 esac
 
@@ -3400,6 +3451,10 @@ declare -A passwords
 PASSWORDS_TO_DISPLAY=false
 RESTART_NEEDED=false
 RESTART_COMPLETED=false
+
+# Initialize associative array to which firewall rules can be added (see
+# configure_firewall_add_rules).  This must be declared here for scoping.
+declare -A firewall_allow
 
 set_defaults
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1670,7 +1670,7 @@ configure_datastore()
     echo 'The data store needs to be accessible externally.'
 
     echo 'Configuring the firewall to allow connections to mongod...'
-    $lokkit --port=27017:tcp
+    firewall_allow[mongodb]=tcp:27017
 
     echo 'Configuring mongod to listen on all interfaces...'
     set_mongodb bind_ip 0.0.0.0
@@ -1693,6 +1693,8 @@ configure_datastore()
 
 
 # Open up services required on the node for apps and developers.
+#
+# Note: This function must only be run after configure_firewall.
 configure_port_proxy()
 {
   chkconfig openshift-iptables-port-proxy on
@@ -1716,12 +1718,12 @@ enable_services_on_node()
   # will produce errors.  Anyway, we only need the configuration
   # activated after Anaconda reboots, so --nostart makes sense in any case.
 
-  $lokkit --service=https
-  $lokkit --service=http
+  firewall_allow[https]=tcp:443
+  firewall_allow[http]=tcp:80
 
   # Allow connections to openshift-node-web-proxy
-  $lokkit --port=8000:tcp
-  $lokkit --port=8443:tcp
+  firewall_allow[ws]=tcp:8000
+  firewall_allow[wss]=tcp:8443
 
   chkconfig httpd on
   chkconfig network on
@@ -1740,8 +1742,8 @@ enable_services_on_broker()
   # will produce errors.  Anyway, we only need the configuration
   # activated after Anaconda reboots, so --nostart makes sense.
 
-  $lokkit --service=https
-  $lokkit --service=http
+  firewall_allow[https]=tcp:443
+  firewall_allow[http]=tcp:80
 
   chkconfig httpd on
   chkconfig network on
@@ -2079,8 +2081,8 @@ $networkConnectors
 EOF
 
   # Allow connections to ActiveMQ.
-  $lokkit --port=61613:tcp
-  allow_openwire && $lokkit --port=61616:tcp
+  firewall_allow[stomp]=tcp:61613
+  allow_openwire && firewall_allow[openwire]=tcp:61616
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -2176,7 +2178,7 @@ EOF
   configure_hosts_dns
 
   # Configure named to start on boot.
-  $lokkit --service=dns
+  firewall_allow[dns]=tcp:53,udp:53
   chkconfig named on
 
   # Start named so we can perform some updates immediately.
@@ -3218,7 +3220,7 @@ install_rpms()
   yum $disable_plugin update -y || abort_install
   # Install a few packages missing from a minimal RHEL install required by the
   # installer script itself.
-  yum_install_or_exit ntp ntpdate lokkit wget
+  yum_install_or_exit ntp ntpdate wget
 
   # install what we need for various components
   named && install_named_pkgs
@@ -3249,10 +3251,59 @@ configure_host()
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
 
+  # Reset the firewall to disable lokkit and initialise iptables configuration.
+  configure_firewall
+
   # all hosts should enable ssh access
-  $lokkit --service=ssh
+  firewall_allow[ssh]=tcp:22
 
   echo "OpenShift: Completed configuring host."
+}
+
+configure_firewall()
+{
+  # Disable lokkit.
+  conf='/etc/sysconfig/system-config-firewall'
+  [[ "$(< "$conf")" != --disabled ]] &&
+    mv "$conf" "${conf}.bak"
+  echo '--disabled' > "$conf"
+
+  # Configure iptables.
+cat > /etc/sysconfig/iptables <<'EOF'
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+-A INPUT -p icmp -j ACCEPT
+-A INPUT -i lo -j ACCEPT
+-A INPUT -j REJECT --reject-with icmp-host-prohibited
+-A FORWARD -j REJECT --reject-with icmp-host-prohibited
+COMMIT
+EOF
+
+  # Load the configuration on reboot.
+  chkconfig iptables on
+}
+
+# Note: This function must be run after configure_firewall.
+configure_firewall_add_rules()
+{
+  rules="$(
+    for svc in ${firewall_allow[@]}
+    do
+      for rule in ${svc//,/ }
+      do
+        prot="${rule%%:*}"
+        port="${rule##*:}"
+        printf ' \\\n-A INPUT -m state --state NEW -m %s -p %s --dport %s -j ACCEPT' "$prot" "$prot" "$port"
+      done
+    done
+  )"
+
+  # Insert the rules specified by ${firewall_allow[@]} before the first
+  # REJECT rule in the INPUT chain.
+  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" /etc/sysconfig/iptables
 }
 
 configure_openshift()
@@ -3294,6 +3345,8 @@ configure_openshift()
   node && broker && fix_broker_routing
   node && install_rsync_pub_key
 
+  configure_firewall_add_rules
+
   sysctl -p
   restorecon -rv /etc/openshift
 
@@ -3305,6 +3358,9 @@ configure_openshift()
 restart_services()
 {
   echo "OpenShift: Begin restarting services."
+
+  service iptables restart
+
   # named is already started in configure_named.
   named && service named restart
 
@@ -3426,19 +3482,14 @@ ks)
   # parse_kernel_cmdline is only needed for kickstart and not if this %post
   # section is extracted and executed on a running system.
   parse_kernel_cmdline
-  # during a kickstart a live lokkit fails
-  lokkit="lokkit --nostart"
   ;;
 vm)
   # no args to parse; they are directly inserted by make.
-  # during a kickstart a live lokkit fails
-  lokkit="lokkit --nostart"
   ;;
 *)
   # parse_cmdline is only needed for shell scripts generated by extracting
   # this %post section.
   parse_cmdline "$@"
-  lokkit="lokkit" # normally...
   ;;
 esac
 
@@ -3446,6 +3497,10 @@ declare -A passwords
 PASSWORDS_TO_DISPLAY=false
 RESTART_NEEDED=false
 RESTART_COMPLETED=false
+
+# Initialize associative array to which firewall rules can be added (see
+# configure_firewall_add_rules).  This must be declared here for scoping.
+declare -A firewall_allow
 
 set_defaults
 


### PR DESCRIPTION
Declare `firewall_allow` as an associative array at the bottom of openshift.ks.  Set protocol:port rules (e.g., udp:53) in this associative array wherever previously lokkit was used.

Add `configure_firewall` function, which disables lokkit and writes a basic ruleset to `/etc/sysconfig/iptables`.

Add `configure_firewall_add_rules`, which iterates over `${firewall_allow[@]}` and adds ACCEPT rules to `/etc/sysconfig/iptables` for the rules defined in `${firewall_allow[@]}`.

`configure_host`: Call `configure_firewall`.

`configure_openshift`: Call `configure_firewall_add_rules`.

`restart_services`: Restart the iptables service to pick up rules added to `/etc/sysconfig/iptables`.

This commit fixes bug 1067794.
