### PR TITLE
openshift.ks: Don't restart services for kickstart

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2992,6 +2992,10 @@ do
   "$action"
 done
 
+# In the case of a kickstart, some services will not be able to start, and the
+# host will automatically reboot anyway after the kickstart script completes.
+[[ "$environment" = ks ]] && RESTART_NEEDED=false
+
 $RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
 
 $PASSWORDS_TO_DISPLAY && display_passwords

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3662,6 +3662,10 @@ do
   "$action"
 done
 
+# In the case of a kickstart, some services will not be able to start, and the
+# host will automatically reboot anyway after the kickstart script completes.
+[[ "$environment" = ks ]] && RESTART_NEEDED=false
+
 $RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
 
 $PASSWORDS_TO_DISPLAY && display_passwords

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3708,6 +3708,10 @@ do
   "$action"
 done
 
+# In the case of a kickstart, some services will not be able to start, and the
+# host will automatically reboot anyway after the kickstart script completes.
+[[ "$environment" = ks ]] && RESTART_NEEDED=false
+
 $RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
 
 $PASSWORDS_TO_DISPLAY && display_passwords


### PR DESCRIPTION
Check whether the script is being run as a kickstart script and, if so, do not restart services at the very end of the script.  Doing so is unnecessary because the host is about to reboot anyway once the kickstart script finishes its execution, it takes time, and it generates a bunch of error messages for services that cannot successfully start in a kickstart environment.

This commit fixes bug 1121293.
