### PR TITLE
oo-install: premature restart_services

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -531,8 +531,6 @@ install_broker_pkgs()
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Install node-specific packages.
@@ -566,8 +564,6 @@ install_node_pkgs()
   esac
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Remove abrt-addon-python if necessary

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1228,8 +1228,6 @@ install_broker_pkgs()
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Install node-specific packages.
@@ -1263,8 +1261,6 @@ install_node_pkgs()
   esac
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Remove abrt-addon-python if necessary

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1274,8 +1274,6 @@ install_broker_pkgs()
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Install node-specific packages.
@@ -1309,8 +1307,6 @@ install_node_pkgs()
   esac
 
   yum_install_or_exit $pkgs
-
-  RESTART_NEEDED=true
 }
 
 # Remove abrt-addon-python if necessary


### PR DESCRIPTION
Remove unneeded RESTART_REQUIRED=true; do not want to start services
before they are configured.

Bug 1122297 - premature restart_services blocks oo-install
https://bugzilla.redhat.com/show_bug.cgi?id=1122297
