### PR TITLE
openshift.ks - add "EXTRA" repo vars for testing

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -38,11 +38,15 @@ configure_repos()
   # functions.
 
   # Make need_${repo}_repo return false by default.
-  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews; do
+  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews extra; do
       eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
+
+  if [ -n "${CONF_JBOSSEWS_EXTRA_REPO}${CONF_JBOSSEAP_EXTRA_REPO}${CONF_RHEL_OPTIONAL_REPO}${CONF_RHSCL_EXTRA_REPO}" ]; then
+    need_extra_repo() { :; }
+  fi
 
   if activemq || broker || datastore || named; then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
@@ -105,6 +109,7 @@ configure_yum_repos()
     eval "need_${repo}_repo && configure_${repo}_repo"
   done
   configure_ose_yum_repos
+  configure_extra_repos
   yum clean metadata
   yum_install_or_exit openshift-enterprise-release
 }
@@ -246,9 +251,75 @@ YUM
   fi
 }
 
+configure_extra_repos()
+{
+  extra_repo_file=/etc/yum.repos.d/ose_extra.repo
+  if [ -e "${extra_repo_file}" ]; then
+      echo > "${extra_repo_file}"
+  fi
+
+  if [ "${rhel_extra_repo}x" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhel_extra]
+name=rhel_extra
+baseurl=${rhel_extra_repo}
+enabled=1
+gpgcheck=0
+sslverify=false
+priority=20
+sslverify=false
+exclude=tomcat6*
+
+YUM
+  fi
+
+  if [ "x${jbosseap_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbosseap_extra]
+name=jbosseap_extra
+baseurl=${jbosseap_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+sslverify=false
+
+YUM
+
+  fi
+
+  if [ "x${jbossews_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbossews_extra]
+name=jbossews_extra
+baseurl=${jbossews_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+sslverify=false
+
+YUM
+
+  fi
+
+  if [ "x${rhscl_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhscl_extra]
+name=rhscl_extra
+baseurl=${rhscl_extra_repo}
+enabled=1
+priority=10
+gpgcheck=0
+sslverify=false
+
+YUM
+
+  fi
+}
+
 configure_subscription()
 {
    configure_ose_yum_repos # if requested
+   need_extra_repo && configure_extra_repos
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
@@ -265,6 +336,7 @@ configure_subscription()
    # wrong channel before yum-validator does its work. So, install it afterward.
    yum_install_or_exit openshift-enterprise-release
    configure_ose_yum_repos # refresh if overwritten by validator
+   need_extra_repo && configure_extra_repos
 }
 
 configure_rhn_channels()
@@ -2055,8 +2127,12 @@ set_defaults()
   # There a no defaults for these. Customers should be using
   # subscriptions via RHN. Internally we use private systems.
   rhel_repo="${CONF_RHEL_REPO%/}"
+  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
   jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
+  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
+  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
   rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
+  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
   rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
   # Where to find the OpenShift repositories; just the base part before
   # splitting out into Infrastructure/Node/etc.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -205,9 +205,13 @@
 #     none - install sources are already set up when the script executes (DEFAULT)
 #     yum - set up yum repos based on config
 #       rhel_repo / CONF_RHEL_REPO -- see below
+#       rhel_extra_repo / CONF_RHEL_EXTRA_REPO -- see below
 #       rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO -- see below
 #       jboss_repo_base / CONF_JBOSS_REPO_BASE -- see below
+#       jbosseap_extra_repo / CONF_JBOSSEAP_EXTRA_REPO -- see below
+#       jbossews_extra_repo / CONF_JBOSSEWS_EXTRA_REPO -- see below
 #       rhscl_repo_base / CONF_RHSCL_REPO_BASE -- see below
+#       rhscl_extra_repo / CONF_RHSCL_EXTRA_REPO -- see below
 #       ose_repo_base / CONF_OSE_REPO_BASE -- see below
 #       ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
 #     rhsm - use subscription-manager
@@ -298,6 +302,12 @@
 #   The URL for a RHEL 6 yum repository used with the "yum" install method.
 #   Should end in /6Server/x86_64/os/
 
+# rhel_extra_repo / CONF_RHEL_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular RHEL channels/repos at the
+#   same priority. The value of this option sets the "baseurl" setting
+#   for the defined repo. Useful for testing prerelease content
+
 # rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO
 #   The URL for a RHEL 6 Optional yum repository used with the "yum" install method.
 #   (only used if CONF_OPTIONAL_REPO is true)
@@ -307,9 +317,30 @@
 #   The base URL for the JBoss repositories used with the "yum"
 #   install method - the part before jbeap/jbews - ends in /6Server/x86_64
 
+# jbosseap_extra_repo / CONF_JBOSSEAP_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular JBoss channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
+
+# jbossews_extra_repo / CONF_JBOSSEWS_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular JBoss channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
+
 # rhscl_repo_base / CONF_RHSCL_REPO_BASE
 #   The base URL for the SCL repositories used with the "yum"
 #   install method - the part before rhscl - ends in /6Server/x86_64
+
+# rhscl_extra_repo / CONF_RHSCL_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular RHSCL channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
 
 # ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
 #   If defined, will define yum repos under the yum,rhsm,rhn install methods.
@@ -616,11 +647,15 @@ configure_repos()
   # functions.
 
   # Make need_${repo}_repo return false by default.
-  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews; do
+  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews extra; do
       eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
+
+  if [ -n "${CONF_JBOSSEWS_EXTRA_REPO}${CONF_JBOSSEAP_EXTRA_REPO}${CONF_RHEL_OPTIONAL_REPO}${CONF_RHSCL_EXTRA_REPO}" ]; then
+    need_extra_repo() { :; }
+  fi
 
   if activemq || broker || datastore || named; then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
@@ -683,6 +718,7 @@ configure_yum_repos()
     eval "need_${repo}_repo && configure_${repo}_repo"
   done
   configure_ose_yum_repos
+  configure_extra_repos
   yum clean metadata
   yum_install_or_exit openshift-enterprise-release
 }
@@ -818,9 +854,71 @@ YUM
   fi
 }
 
+configure_extra_repos()
+{
+  extra_repo_file=/etc/yum.repos.d/ose_extra.repo
+  if [ -e "${extra_repo_file}" ]; then
+      echo > "${extra_repo_file}"
+  fi
+
+  if [ "${rhel_extra_repo}x" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhel_extra]
+name=rhel_extra
+baseurl=${rhel_extra_repo}
+enabled=1
+gpgcheck=0
+priority=20
+sslverify=false
+exclude=tomcat6*
+
+YUM
+  fi
+
+  if [ "x${jbosseap_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbosseap_extra]
+name=jbosseap_extra
+baseurl=${jbosseap_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+
+YUM
+
+  fi
+
+  if [ "x${jbossews_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbossews_extra]
+name=jbossews_extra
+baseurl=${jbossews_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+
+YUM
+
+  fi
+
+  if [ "x${rhscl_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhscl_extra]
+name=rhscl_extra
+baseurl=${rhscl_extra_repo}
+enabled=1
+priority=10
+gpgcheck=0
+
+YUM
+
+  fi
+}
+
 configure_subscription()
 {
    configure_ose_yum_repos # if requested
+   need_extra_repo && configure_extra_repos
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
@@ -837,6 +935,7 @@ configure_subscription()
    # wrong channel before yum-validator does its work. So, install it afterward.
    yum_install_or_exit openshift-enterprise-release
    configure_ose_yum_repos # refresh if overwritten by validator
+   need_extra_repo && configure_extra_repos
 }
 
 configure_rhn_channels()
@@ -2627,8 +2726,12 @@ set_defaults()
   # There a no defaults for these. Customers should be using
   # subscriptions via RHN. Internally we use private systems.
   rhel_repo="${CONF_RHEL_REPO%/}"
+  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
   jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
+  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
+  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
   rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
+  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
   rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
   # Where to find the OpenShift repositories; just the base part before
   # splitting out into Infrastructure/Node/etc.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -204,9 +204,13 @@
 #     none - install sources are already set up when the script executes (DEFAULT)
 #     yum - set up yum repos based on config
 #       rhel_repo / CONF_RHEL_REPO -- see below
+#       rhel_extra_repo / CONF_RHEL_EXTRA_REPO -- see below
 #       rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO -- see below
 #       jboss_repo_base / CONF_JBOSS_REPO_BASE -- see below
+#       jbosseap_extra_repo / CONF_JBOSSEAP_EXTRA_REPO -- see below
+#       jbossews_extra_repo / CONF_JBOSSEWS_EXTRA_REPO -- see below
 #       rhscl_repo_base / CONF_RHSCL_REPO_BASE -- see below
+#       rhscl_extra_repo / CONF_RHSCL_EXTRA_REPO -- see below
 #       ose_repo_base / CONF_OSE_REPO_BASE -- see below
 #       ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
 #     rhsm - use subscription-manager
@@ -297,6 +301,12 @@
 #   The URL for a RHEL 6 yum repository used with the "yum" install method.
 #   Should end in /6Server/x86_64/os/
 
+# rhel_extra_repo / CONF_RHEL_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular RHEL channels/repos at the
+#   same priority. The value of this option sets the "baseurl" setting
+#   for the defined repo. Useful for testing prerelease content
+
 # rhel_optional_repo / CONF_RHEL_OPTIONAL_REPO
 #   The URL for a RHEL 6 Optional yum repository used with the "yum" install method.
 #   (only used if CONF_OPTIONAL_REPO is true)
@@ -306,9 +316,30 @@
 #   The base URL for the JBoss repositories used with the "yum"
 #   install method - the part before jbeap/jbews - ends in /6Server/x86_64
 
+# jbosseap_extra_repo / CONF_JBOSSEAP_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular JBoss channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
+
+# jbossews_extra_repo / CONF_JBOSSEWS_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular JBoss channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
+
 # rhscl_repo_base / CONF_RHSCL_REPO_BASE
 #   The base URL for the SCL repositories used with the "yum"
 #   install method - the part before rhscl - ends in /6Server/x86_64
+
+# rhscl_extra_repo / CONF_RHSCL_EXTRA_REPO
+#   If set, will define a yum repo under the yum,rhsm,rhn install
+#   methods. This will parallel the regular RHSCL channels/repos at
+#   the same priority. The value of this option sets the "baseurl"
+#   setting for the defined repo. Useful for testing prerelease
+#   content
 
 # ose_extra_repo_base / CONF_OSE_EXTRA_REPO_BASE -- see below
 #   If defined, will define yum repos under the yum,rhsm,rhn install methods.
@@ -661,11 +692,15 @@ configure_repos()
   # functions.
 
   # Make need_${repo}_repo return false by default.
-  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews; do
+  for repo in optional infra node jbosseap_cartridge client_tools jbosseap jbossews extra; do
       eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
+
+  if [ -n "${CONF_JBOSSEWS_EXTRA_REPO}${CONF_JBOSSEAP_EXTRA_REPO}${CONF_RHEL_OPTIONAL_REPO}${CONF_RHSCL_EXTRA_REPO}" ]; then
+    need_extra_repo() { :; }
+  fi
 
   if activemq || broker || datastore || named; then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
@@ -728,6 +763,7 @@ configure_yum_repos()
     eval "need_${repo}_repo && configure_${repo}_repo"
   done
   configure_ose_yum_repos
+  configure_extra_repos
   yum clean metadata
   yum_install_or_exit openshift-enterprise-release
 }
@@ -863,9 +899,71 @@ YUM
   fi
 }
 
+configure_extra_repos()
+{
+  extra_repo_file=/etc/yum.repos.d/ose_extra.repo
+  if [ -e "${extra_repo_file}" ]; then
+      echo > "${extra_repo_file}"
+  fi
+
+  if [ "${rhel_extra_repo}x" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhel_extra]
+name=rhel_extra
+baseurl=${rhel_extra_repo}
+enabled=1
+gpgcheck=0
+priority=20
+sslverify=false
+exclude=tomcat6*
+
+YUM
+  fi
+
+  if [ "x${jbosseap_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbosseap_extra]
+name=jbosseap_extra
+baseurl=${jbosseap_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+
+YUM
+
+  fi
+
+  if [ "x${jbossews_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[jbossews_extra]
+name=jbossews_extra
+baseurl=${jbossews_extra_repo}
+enabled=1
+priority=30
+gpgcheck=0
+
+YUM
+
+  fi
+
+  if [ "x${rhscl_extra_repo}" != "x" ]; then
+    cat <<YUM >> "${extra_repo_file}"
+[rhscl_extra]
+name=rhscl_extra
+baseurl=${rhscl_extra_repo}
+enabled=1
+priority=10
+gpgcheck=0
+
+YUM
+
+  fi
+}
+
 configure_subscription()
 {
    configure_ose_yum_repos # if requested
+   need_extra_repo && configure_extra_repos
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
@@ -882,6 +980,7 @@ configure_subscription()
    # wrong channel before yum-validator does its work. So, install it afterward.
    yum_install_or_exit openshift-enterprise-release
    configure_ose_yum_repos # refresh if overwritten by validator
+   need_extra_repo && configure_extra_repos
 }
 
 configure_rhn_channels()
@@ -2672,8 +2771,12 @@ set_defaults()
   # There a no defaults for these. Customers should be using
   # subscriptions via RHN. Internally we use private systems.
   rhel_repo="${CONF_RHEL_REPO%/}"
+  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
   jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
+  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
+  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
   rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
+  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
   rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
   # Where to find the OpenShift repositories; just the base part before
   # splitting out into Infrastructure/Node/etc.


### PR DESCRIPTION
This adds options for setting up additional repos for jbosseap,
jbossews, rhscl and rhel so we can test alpha/beta packages for channels
we depend on.

enterprise #cherry-pick
enterprise card 237
https://trello.com/c/No7fswfn/237-5-confirm-rhscl-1-2-compatibility

Conflicts:
    enterprise/install-scripts/amazon/openshift-amz.sh
    enterprise/install-scripts/generic/openshift.sh
    enterprise/install-scripts/openshift.ks
