### PR TITLE
Bug 1109052 fix replication for routing plugin bug 1132208 configure activemq redelivery bug 1132209 always set routing plugin user and  pass

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2702,8 +2702,8 @@ set_defaults()
   broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
-  broker && routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  broker && assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
+  routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
+  assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3401,8 +3401,8 @@ set_defaults()
   broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
-  broker && routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  broker && assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
+  routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
+  assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3447,8 +3447,8 @@ set_defaults()
   broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
-  broker && routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  broker && assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
+  routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
+  assign_pass routing_plugin_pass "routinginfopassword" CONF_ROUTING_PLUGIN_PASS
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"


### PR DESCRIPTION
`openshift.ks`: Always set `routing_plugin_user`/`pass`

In `set_defaults`, always set the `routing_plugin_user` and `routing_plugin_pass` variables instead of setting them only when installing the "broker" component.  These variables are used when configuring ActiveMQ and so may be used even if the "broker" component is not being configured, and in any case, `set_defaults` should set variables unconditionally for simplicity.

This commit fixes bug 1110680.

`openshift.ks`: Configure ActiveMQ redelivery

Modify `configure_activemq` to configure redelivery for the `routinginfo` queue, which may be used by the ActiveMQ routing plug-in.

This commit fixes bug 1132208.

`openshift.ks`: Fix replication for routing plug-in

Fix `configure_routing_plugin` to configure the routing plug-in with all ActiveMQ replicants instead of only the first.

This commit fixes bug 1109052.

`openshift.ks`: Improve descriptions for replication

Clarify that ports may be specified for `CONF_DATASTORE_REPLICANTS` and must not be specified for `CONF_ACTIVEMQ_REPLICANTS`.

`openshift.ks`, `configure_activemq`: Mark vars local

Declare `networkConnectors` and `authenticationUser_amq` as local variables.
