### PR TITLE
installer: set better mcollective timeouts

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1290,10 +1290,15 @@ securityprovider=psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Broker will retry ActiveMQ connection, then report error
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_attempts = 6
 
 # Facts
 factsource = yaml
@@ -1331,10 +1336,16 @@ securityprovider = psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Node should retry connecting to ActiveMQ forever
+plugin.activemq.max_reconnect_attempts = 0
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_delay = 4.0
 
 # Facts
 factsource = yaml

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1989,10 +1989,15 @@ securityprovider=psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Broker will retry ActiveMQ connection, then report error
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_attempts = 6
 
 # Facts
 factsource = yaml
@@ -2030,10 +2035,16 @@ securityprovider = psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Node should retry connecting to ActiveMQ forever
+plugin.activemq.max_reconnect_attempts = 0
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_delay = 4.0
 
 # Facts
 factsource = yaml

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2035,10 +2035,15 @@ securityprovider=psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Broker will retry ActiveMQ connection, then report error
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_attempts = 6
 
 # Facts
 factsource = yaml
@@ -2076,10 +2081,16 @@ securityprovider = psk
 plugin.psk = asimplething
 
 connector = activemq
+$(generate_mcollective_pools_configuration)
+# For further options on heartbeats and timeouts, refer to
+# https://docs.puppetlabs.com/mcollective/reference/plugins/connector_activemq.html
 plugin.activemq.heartbeat_interval = 30
 plugin.activemq.max_hbread_fails = 2
 plugin.activemq.max_hbrlck_fails = 2
-$(generate_mcollective_pools_configuration)
+# Node should retry connecting to ActiveMQ forever
+plugin.activemq.max_reconnect_attempts = 0
+plugin.activemq.initial_reconnect_delay = 0.1
+plugin.activemq.max_reconnect_delay = 4.0
 
 # Facts
 factsource = yaml


### PR DESCRIPTION
Bug 1122872 - "oo-mco" does not timeout when no ActiveMQ available
https://bugzilla.redhat.com/show_bug.cgi?id=1122872

Bug 1065048 - broker does not handle activemq outages gracefully
https://bugzilla.redhat.com/show_bug.cgi?id=1065048

When ActiveMQ is down or unreachable, with the previous default settings,
broker tools that operate via mcollective simply hang indefinitely.
With these defaults, mcollective queries will fail with useful error
after 6.3 seconds of retries, and a link is given to display options if
an administrator would like to adjust the behavior.

Additionally, the node interval for retrying a connection to ActiveMQ
was decreased to 4 seconds instead of the default 30. This way, nodes
will be visible faster after ActiveMQ returns.
