### PR TITLE
installer: fix node quotacheck for non-/ geardata

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -792,17 +792,18 @@ configure_quotas_on_node()
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
-    # Enable user quotas for the device housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/\\+[[:blank:]]}/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
-
-    # Remount to get quotas enabled immediately.
+    # Enable user quotas for the filesystem housing /var/lib/openshift.
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    # Remount to enable quotas immediately.
     mount -o remount "${geardata_mnt}"
 
+    # External mounts, esp. at /var/lib/openshift, may often be created
+    # with an incorrect context and quotacheck hits SElinux denials.
+    restorecon "${geardata_mnt}"
     # Generate user quota info for the mount point.
     quotacheck -cmug "${geardata_mnt}"
-
-    # fix up selinux perms
-    restorecon "${geardata_mnt}"aquota.user
+    # fix up selinux label on created quota file
+    restorecon "${geardata_mnt}"/aquota.user
 
     # (re)enable quotas
     quotaon "${geardata_mnt}"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1486,17 +1486,18 @@ configure_quotas_on_node()
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
-    # Enable user quotas for the device housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/\\+[[:blank:]]}/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
-
-    # Remount to get quotas enabled immediately.
+    # Enable user quotas for the filesystem housing /var/lib/openshift.
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    # Remount to enable quotas immediately.
     mount -o remount "${geardata_mnt}"
 
+    # External mounts, esp. at /var/lib/openshift, may often be created
+    # with an incorrect context and quotacheck hits SElinux denials.
+    restorecon "${geardata_mnt}"
     # Generate user quota info for the mount point.
     quotacheck -cmug "${geardata_mnt}"
-
-    # fix up selinux perms
-    restorecon "${geardata_mnt}"aquota.user
+    # fix up selinux label on created quota file
+    restorecon "${geardata_mnt}"/aquota.user
 
     # (re)enable quotas
     quotaon "${geardata_mnt}"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1532,17 +1532,18 @@ configure_quotas_on_node()
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
-    # Enable user quotas for the device housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/\\+[[:blank:]]}/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
-
-    # Remount to get quotas enabled immediately.
+    # Enable user quotas for the filesystem housing /var/lib/openshift.
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    # Remount to enable quotas immediately.
     mount -o remount "${geardata_mnt}"
 
+    # External mounts, esp. at /var/lib/openshift, may often be created
+    # with an incorrect context and quotacheck hits SElinux denials.
+    restorecon "${geardata_mnt}"
     # Generate user quota info for the mount point.
     quotacheck -cmug "${geardata_mnt}"
-
-    # fix up selinux perms
-    restorecon "${geardata_mnt}"aquota.user
+    # fix up selinux label on created quota file
+    restorecon "${geardata_mnt}"/aquota.user
 
     # (re)enable quotas
     quotaon "${geardata_mnt}"


### PR DESCRIPTION
Bug 1138889 - quota config broken if /var/lib/openshift is a mount point
https://bugzilla.redhat.com/show_bug.cgi?id=1138889
- Fixed faulty sed regex for adding usrquota to /etc/fstab.
- If the mount point had an incorrect selinux label, quotacheck
  could fail due to selinux denials, so run restorecon first.
- Finally, the restorecon of the quota file failed unless the
  mount point is /, so added a / to make it work.
