### PR TITLE
install: mod-rewrite frontend deprecation notice

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -707,7 +707,14 @@
 #
 # Node httpd proxy frontend. Valid options are vhost and mod_rewrite.
 # mod_rewrite is intended for nodes with thousands of gears (mostly idle).
-# vhost is not as scalable but more extensible.
+# vhost is not as scalable but more extensible and under typical usage,
+# more performant.
+# NOTE: While mod_rewrite is the default for OSE 2.1, vhost will
+# be the default in OSE 2.2 and mod_rewrite will be considered
+# deprecated. It is not recommended to deploy nodes with different
+# frontends within the same deployment, as moving gears between
+# these nodes may be problematic. Consult http://red.ht/1sau3Tq for
+# directions on how to change the frontend for an existing node host.
 #CONF_NODE_APACHE_FRONTEND=mod_rewrite
 #
 # enable_sni_proxy / CONF_ENABLE_SNI_PROXY

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -706,7 +706,14 @@
 #
 # Node httpd proxy frontend. Valid options are vhost and mod_rewrite.
 # mod_rewrite is intended for nodes with thousands of gears (mostly idle).
-# vhost is not as scalable but more extensible.
+# vhost is not as scalable but more extensible and under typical usage,
+# more performant.
+# NOTE: While mod_rewrite is the default for OSE 2.1, vhost will
+# be the default in OSE 2.2 and mod_rewrite will be considered
+# deprecated. It is not recommended to deploy nodes with different
+# frontends within the same deployment, as moving gears between
+# these nodes may be problematic. Consult http://red.ht/1sau3Tq for
+# directions on how to change the frontend for an existing node host.
 #CONF_NODE_APACHE_FRONTEND=mod_rewrite
 #
 # enable_sni_proxy / CONF_ENABLE_SNI_PROXY


### PR DESCRIPTION
Since 2.2 will deprecate the use of mod-rewrite, inserting a small
notice under 2.1 openshift.{sh,ks} parameter.
