### PR TITLE
install: uid params, move oo-gear-firewall later

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -798,8 +798,8 @@ configure_selinux_policy_on_node()
     echo boolean -m --on allow_polyinstantiation
 
     # Enable rules to keep gears from binding where they should not
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$last_port"
+    # Note: relies on node code loading, must load after node.conf has correct frontend configured
+    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$district_last_uid"
   ) | time semanage -i -
 
 
@@ -1242,8 +1242,7 @@ enable_services_on_node()
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"; then
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    firewall_allow[sni]="tcp:${sni_first_port}:${last_port}"
+    firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
     chkconfig openshift-sni-proxy off
@@ -2208,8 +2207,7 @@ PORTS_PER_USER=${ports_per_gear}
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    local port_list=$(seq -s, "$sni_first_port" "$last_port")
+    local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     sed -i -e "/PROXY_PORTS/ cPROXY_PORTS=${port_list}" /etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf
   fi
 
@@ -2667,6 +2665,8 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   local def_ports=5; is_xpaas && def_ports=15
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
+  let "district_uid_pool=30000/$ports_per_gear"
+  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -2674,6 +2674,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   sni_first_port="${CONF_SNI_FIRST_PORT:-2303}"
   def_ports=5; is_xpaas && def_ports=10
   sni_proxy_ports="${CONF_SNI_PROXY_PORTS:-$def_ports}"
+  let "sni_last_port=$sni_first_port+$sni_proxy_ports-1"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
   broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
@@ -2993,10 +2994,7 @@ configure_firewall_add_rules()
 
 configure_gear_isolation_firewall()
 {
-  if is_true "$isolate_gears"; then
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    oo-gear-firewall -i conf -b "$district_first_uid" -e "$last_port"
-  fi
+  is_true "$isolate_gears" && oo-gear-firewall -i conf -b "$district_first_uid" -e "$district_last_uid"
 }
 
 configure_openshift()
@@ -3016,7 +3014,6 @@ configure_openshift()
   node && configure_cgroups_on_node
   node && configure_quotas_on_node
   broker && configure_selinux_policy_on_broker
-  node && configure_selinux_policy_on_node
   node && configure_sysctl_on_node
   node && configure_sshd_on_node
   node && configure_idler_on_node
@@ -3032,6 +3029,7 @@ configure_openshift()
   node && configure_port_proxy
   node && configure_gears
   node && configure_node
+  node && configure_selinux_policy_on_node # must run after configure_node
   node && configure_wildcard_ssl_cert_on_node
   node && update_openshift_facts_on_node
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1706,8 +1706,8 @@ configure_selinux_policy_on_node()
     echo boolean -m --on allow_polyinstantiation
 
     # Enable rules to keep gears from binding where they should not
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$last_port"
+    # Note: relies on node code loading, must load after node.conf has correct frontend configured
+    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$district_last_uid"
   ) | time semanage -i -
 
 
@@ -2150,8 +2150,7 @@ enable_services_on_node()
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"; then
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    firewall_allow[sni]="tcp:${sni_first_port}:${last_port}"
+    firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
     chkconfig openshift-sni-proxy off
@@ -3116,8 +3115,7 @@ PORTS_PER_USER=${ports_per_gear}
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    local port_list=$(seq -s, "$sni_first_port" "$last_port")
+    local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     sed -i -e "/PROXY_PORTS/ cPROXY_PORTS=${port_list}" /etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf
   fi
 
@@ -3575,6 +3573,8 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   local def_ports=5; is_xpaas && def_ports=15
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
+  let "district_uid_pool=30000/$ports_per_gear"
+  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -3582,6 +3582,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   sni_first_port="${CONF_SNI_FIRST_PORT:-2303}"
   def_ports=5; is_xpaas && def_ports=10
   sni_proxy_ports="${CONF_SNI_PROXY_PORTS:-$def_ports}"
+  let "sni_last_port=$sni_first_port+$sni_proxy_ports-1"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
   broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
@@ -3901,10 +3902,7 @@ configure_firewall_add_rules()
 
 configure_gear_isolation_firewall()
 {
-  if is_true "$isolate_gears"; then
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    oo-gear-firewall -i conf -b "$district_first_uid" -e "$last_port"
-  fi
+  is_true "$isolate_gears" && oo-gear-firewall -i conf -b "$district_first_uid" -e "$district_last_uid"
 }
 
 configure_openshift()
@@ -3924,7 +3922,6 @@ configure_openshift()
   node && configure_cgroups_on_node
   node && configure_quotas_on_node
   broker && configure_selinux_policy_on_broker
-  node && configure_selinux_policy_on_node
   node && configure_sysctl_on_node
   node && configure_sshd_on_node
   node && configure_idler_on_node
@@ -3940,6 +3937,7 @@ configure_openshift()
   node && configure_port_proxy
   node && configure_gears
   node && configure_node
+  node && configure_selinux_policy_on_node # must run after configure_node
   node && configure_wildcard_ssl_cert_on_node
   node && update_openshift_facts_on_node
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1752,8 +1752,8 @@ configure_selinux_policy_on_node()
     echo boolean -m --on allow_polyinstantiation
 
     # Enable rules to keep gears from binding where they should not
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$last_port"
+    # Note: relies on node code loading, must load after node.conf has correct frontend configured
+    is_true "$isolate_gears" && oo-gear-firewall -s output -b "$district_first_uid" -e "$district_last_uid"
   ) | time semanage -i -
 
 
@@ -2196,8 +2196,7 @@ enable_services_on_node()
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"; then
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    firewall_allow[sni]="tcp:${sni_first_port}:${last_port}"
+    firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
     chkconfig openshift-sni-proxy off
@@ -3162,8 +3161,7 @@ PORTS_PER_USER=${ports_per_gear}
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
-    local last_port; let "last_port=$sni_first_port+$sni_proxy_ports-1"
-    local port_list=$(seq -s, "$sni_first_port" "$last_port")
+    local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     sed -i -e "/PROXY_PORTS/ cPROXY_PORTS=${port_list}" /etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf
   fi
 
@@ -3621,6 +3619,8 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   local def_ports=5; is_xpaas && def_ports=15
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
+  let "district_uid_pool=30000/$ports_per_gear"
+  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -3628,6 +3628,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   sni_first_port="${CONF_SNI_FIRST_PORT:-2303}"
   def_ports=5; is_xpaas && def_ports=10
   sni_proxy_ports="${CONF_SNI_PROXY_PORTS:-$def_ports}"
+  let "sni_last_port=$sni_first_port+$sni_proxy_ports-1"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
   broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
@@ -3947,10 +3948,7 @@ configure_firewall_add_rules()
 
 configure_gear_isolation_firewall()
 {
-  if is_true "$isolate_gears"; then
-    local last_port=6999; let "last_port=$district_first_uid+5999"
-    oo-gear-firewall -i conf -b "$district_first_uid" -e "$last_port"
-  fi
+  is_true "$isolate_gears" && oo-gear-firewall -i conf -b "$district_first_uid" -e "$district_last_uid"
 }
 
 configure_openshift()
@@ -3970,7 +3968,6 @@ configure_openshift()
   node && configure_cgroups_on_node
   node && configure_quotas_on_node
   broker && configure_selinux_policy_on_broker
-  node && configure_selinux_policy_on_node
   node && configure_sysctl_on_node
   node && configure_sshd_on_node
   node && configure_idler_on_node
@@ -3986,6 +3983,7 @@ configure_openshift()
   node && configure_port_proxy
   node && configure_gears
   node && configure_node
+  node && configure_selinux_policy_on_node # must run after configure_node
   node && configure_wildcard_ssl_cert_on_node
   node && update_openshift_facts_on_node
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1156291
Bug 1156291 - oo-gear-firewall fails during installation with mod_rewrite

oo-gear-firewall depends on node gem being loadable, which can depend on
correct configuration. In the case where mod_rewrite frontend is being
used, the node.conf needs to be updated from the default vhost before
the code will load properly. So oo-gear-firewall must be run only after
this has been done.

Additionally, the UID range used by oo-gear-firewall at install was
hardcoded in size; it now varies depending on PORTS_PER_USER as well as
the district first UID, if specified.
