### PR TITLE
Bug 1158019: oo-accept-broker reports SELinux errors after installation

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -503,6 +503,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1421,6 +1421,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1467,6 +1467,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 


### PR DESCRIPTION
### `install_broker_pkgs`: Make `pkgs` local

Declare the `pkgs` variable in `install_broker_pkgs` as local.
### `install_broker_pkgs`: Install policycoreutils-python

Install policycoreutils-python so that the `semanage` command will be available for use in `configure_selinux_policy_on_broker`.

This commit fixes bug 1158019.
### `openshift.ks`: Install time package on broker

`install_broker_pkgs`: Install the time package so that the external time command will be available for use in `configure_selinux_policy_on_broker`.

Because we use the `time` command in the right-hand side of a pipeline, we must have the external command available rather than relying on Bash's builtin `time` command; Bash does not allow builtins to be used on the right-hand side of a pipeline.

This commit fixes bug 1158019.
