### PR TITLE
Bug 1158685: oo-accept-broker reports SELinux errors after installation

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -449,7 +449,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -459,6 +459,10 @@ install_broker_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -469,8 +473,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   pkgs="$pkgs rubygem-openshift-origin-container-selinux"

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -463,6 +463,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1058,6 +1058,10 @@ install_broker_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -1068,8 +1072,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   pkgs="$pkgs rubygem-openshift-origin-container-selinux"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1048,7 +1048,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1062,6 +1062,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1103,6 +1103,10 @@ install_broker_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
   is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -1113,8 +1117,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   pkgs="$pkgs rubygem-openshift-origin-container-selinux"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1093,7 +1093,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1107,6 +1107,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 


### PR DESCRIPTION
### `install_broker_pkgs`: Make `pkgs` local
    
Declare the `pkgs` variable in `install_broker_pkgs` as local.

### `install_broker_pkgs`: Install policycoreutils-python

Install policycoreutils-python so that the `semanage` command will be available for use in `configure_selinux_policy_on_broker`.

This commit fixes bug 1158685.

### `openshift.ks`: Install time package on broker

`install_broker_pkgs`: Install the time package so that the external `time` command will be available for use in `configure_selinux_policy_on_broker`.

Because we use the `time` command in the right-hand side of a pipeline, we must have the external command available rather than relying on Bash's builtin `time` command; Bash does not allow builtins to be used on the right-hand side of a pipeline.

This commit fixes bug 1158685.