### PR TITLE
 Bug 1158688: oo-accept-broker reports SELinux errors after installation

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -437,6 +437,10 @@ install_broker_pkgs()
   pkgs="$pkgs openshift-origin-console"
 
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -448,8 +452,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   yum_install_or_exit -y $pkgs

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -428,7 +428,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs mcollective-client"

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -441,6 +441,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -960,6 +960,10 @@ install_broker_pkgs()
   pkgs="$pkgs openshift-origin-console"
 
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -971,8 +975,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   yum_install_or_exit -y $pkgs

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -964,6 +964,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -951,7 +951,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs mcollective-client"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1009,6 +1009,10 @@ install_broker_pkgs()
   pkgs="$pkgs openshift-origin-console"
 
 
+  # We use semanage in configure_selinux_policy_on_broker, so we need to
+  # install policycoreutils-python.
+  pkgs="$pkgs policycoreutils-python"
+
   yum_install_or_exit $pkgs
 }
 
@@ -1020,8 +1024,8 @@ install_node_pkgs()
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs mcollective openshift-origin-msg-node-mcollective"
 
-  # We use semanage in this script, so we need to install
-  # policycoreutils-python.
+  # We use semanage in configure_selinux_policy_on_node, so we need to
+  # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
   yum_install_or_exit -y $pkgs

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1013,6 +1013,13 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We use the time command on the right-hand side of a pipeline in
+  # configure_selinux_policy_on_broker, which means that we need the
+  # external time command provided in the time package (Bash only allows
+  # builtins to be used on the left-hand side of a pipeline).  See
+  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
+  pkgs="$pkgs time"
+
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1000,7 +1000,7 @@ configure_rhc()
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  pkgs="openshift-origin-broker"
+  local pkgs="openshift-origin-broker"
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs mcollective-client"


### PR DESCRIPTION
### `install_broker_pkgs`: Make `pkgs` local
    
Declare the `pkgs` variable in `install_broker_pkgs` as local.

### `install_broker_pkgs`: Install policycoreutils-python

Install policycoreutils-python so that the `semanage` command will be available for use in `configure_selinux_policy_on_broker`.

This commit fixes bug 1158688.

### `openshift.ks`: Install time package on broker

`install_broker_pkgs`: Install the time package so that the external `time` command will be available for use in `configure_selinux_policy_on_broker`.

Because we use the `time` command in the right-hand side of a pipeline, we must have the external command available rather than relying on Bash's builtin `time` command; Bash does not allow builtins to be used on the right-hand side of a pipeline.

This commit fixes bug 1158688.