### PR TITLE
Bug 1158821: 'time' command is not necessary in openshift.sh

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -503,13 +503,6 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
-  # We use the time command on the right-hand side of a pipeline in
-  # configure_selinux_policy_on_broker, which means that we need the
-  # external time command provided in the time package (Bash only allows
-  # builtins to be used on the left-hand side of a pipeline).  See
-  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
-  pkgs="$pkgs time"
-
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1421,13 +1421,6 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
-  # We use the time command on the right-hand side of a pipeline in
-  # configure_selinux_policy_on_broker, which means that we need the
-  # external time command provided in the time package (Bash only allows
-  # builtins to be used on the left-hand side of a pipeline).  See
-  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
-  pkgs="$pkgs time"
-
   yum_install_or_exit $pkgs
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1467,13 +1467,6 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
-  # We use the time command on the right-hand side of a pipeline in
-  # configure_selinux_policy_on_broker, which means that we need the
-  # external time command provided in the time package (Bash only allows
-  # builtins to be used on the left-hand side of a pipeline).  See
-  # <https://bugzilla.redhat.com/show_bug.cgi?id=1158019>.
-  pkgs="$pkgs time"
-
   yum_install_or_exit $pkgs
 }
 


### PR DESCRIPTION
## Don't install time package

Modify `install_broker_pkgs` not to install the time package.

With the previous commit, the time package is no longer needed.
## Put time command on LHS of pipeline

`configure_selinux_policy_on_broker`, `configure_selinux_policy_on_node`: When using the `time` command in a pipeline, use it on the left-hand side rather than on the right-hand side so that Bash's `time` builtin can be used rather than requiring the external time command provided by the time package.

This commit fixes bug 1158821.
