### PR TITLE
Bug 1162422 - <oo-install> crash on move node

### DIFF
--- a/oo-install/lib/installer/assistant.rb
+++ b/oo-install/lib/installer/assistant.rb
@@ -1337,7 +1337,7 @@ module Installer
               end
             end
             choose do |menu|
-              menu.header = "\nChoose the district where Node host #{mode_to_move.host} should be assigned"
+              menu.header = "\nChoose the district where Node host #{node_to_move.host} should be assigned"
               menu.prompt = "#{translate(:menu_prompt)} "
               deployment.districts.sort_by{ |d| d.name }.select{ |d| d.name != district.name }.each do |district_choice|
                 menu.choice(district_choice.summarize) { target_district = district_choice }


### PR DESCRIPTION
- Fix oo-install crash when moving a node between districts

https://bugzilla.redhat.com/show_bug.cgi?id=1162422
