### PR TITLE
installer: use $TMPDIR instead of hardcoded /tmp

### DIFF
--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2121,7 +2121,7 @@ configure_mmopenshift_selinux_policy()
   local req=selinux-policy-3.7.19-237.el6.noarch # no need if policy update released
   [[ $(rpm -q selinux-policy | sed "i$req" | sort -V | head -1 ) == $req ]] && return
   echo "Installing SELinux policy module for rsyslog7-mmopenshift per BZ 1096155"
-  local dir=$(mktemp -d /tmp/selinux.XXXXXXXX)
+  local dir=$(mktemp -d --tmpdir selinux.XXXXXXXX)
   pushd $dir
     cat <<POLICY > rsyslog7-mmopenshift.te
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2167,7 +2167,7 @@ configure_mmopenshift_selinux_policy()
   local req=selinux-policy-3.7.19-237.el6.noarch # no need if policy update released
   [[ $(rpm -q selinux-policy | sed "i$req" | sort -V | head -1 ) == $req ]] && return
   echo "Installing SELinux policy module for rsyslog7-mmopenshift per BZ 1096155"
-  local dir=$(mktemp -d /tmp/selinux.XXXXXXXX)
+  local dir=$(mktemp -d --tmpdir selinux.XXXXXXXX)
   pushd $dir
     cat <<POLICY > rsyslog7-mmopenshift.te
 

--- a/oo-install/workflows/enterprise_deploy/launcher.rb
+++ b/oo-install/workflows/enterprise_deploy/launcher.rb
@@ -15,7 +15,7 @@ include Installer::Helpers
 # Stage 1: Handle ENV and ARGV input #
 ######################################
 @mongodb_port     = 27017
-@logfile          = '/tmp/openshift-deploy.log'
+@logfile          = File.join(Dir.tmpdir, 'openshift-deploy.log')
 
 # Check ENV for an alternate config file location.
 if ENV.has_key?('OO_INSTALL_CONFIG_FILE')
@@ -344,9 +344,9 @@ def execute_step_on_hosts(host_list, step)
 
       hostfile = @hostfiles[host_instance.host]
       hostfilename = File.basename(hostfile)
-      remotehostfile = "/tmp/#{hostfilename}"
-      openshiftsh = "#{File.dirname(__FILE__)}/openshift.sh"
-      remoteopenshiftsh = "/tmp/openshift.sh"
+      remotehostfile = File.join(Dir.tmpdir, hostfilename)
+      openshiftsh = File.join(File.dirname(__FILE__), 'openshift.sh')
+      remoteopenshiftsh = File.join(Dir.tmpdir, 'openshift.sh')
       if host_instance.localhost?
         copy_template    = `cp #{hostfile} #{remotehostfile}`
         # TODO: do not use predictable path for openshift.sh
@@ -368,7 +368,7 @@ def execute_step_on_hosts(host_list, step)
 
       puts "#{msg_prefix}Running the hostfile" if @debug
 
-      run_hostfile = host_instance.exec_on_host!("cd /tmp && ./#{hostfilename} |& tee -a #{@logfile} | stdbuf -oL -eL grep -i '^OpenShift:'\n")
+      run_hostfile = host_instance.exec_on_host!("cd #{Dir.tmpdir} && ./#{hostfilename} |& tee -a #{@logfile} | stdbuf -oL -eL grep -i '^OpenShift:'\n")
       if run_hostfile[:stdout].match(@abort_regex)
         display_error_info(host_instance, run_hostfile, 'Failed to run the hostfile.')
         exit 1


### PR DESCRIPTION
Change some temporary paths to honour $TMPDIR instead of hardcoded
full path. This allows to invoke the installer with a custom tmpdir
location. Note that $TMPDIR is used (same value) in all hosts though.
Related to part 1 of:

Bug 1146694 - Minor updates to oo-install
