### PR TITLE
Bug 1146694 <oo-install> - use TMPDIR instead of hardcoded tmp

### DIFF
--- a/oo-install/site_assets/oo-install-bootstrap.sh
+++ b/oo-install/site_assets/oo-install-bootstrap.sh
@@ -28,8 +28,8 @@ then
   then
     echo "Using bundled assets."
   fi
-  cp INSTALLPKGNAME.tgz ${TMPDIR}/INSTALLPKGNAME.tgz
-elif [[ $OO_INSTALL_KEEP_ASSETS == 'true' && -e ${TMPDIR}/INSTALLPKGNAME.tgz ]]
+  cp INSTALLPKGNAME.tgz ${TMPDIR}INSTALLPKGNAME.tgz
+elif [[ $OO_INSTALL_KEEP_ASSETS == 'true' && -e ${TMPDIR}INSTALLPKGNAME.tgz ]]
 then
   if [ $OO_INSTALL_CONTEXT != 'origin_vm' ]
   then

--- a/oo-install/workflows/enterprise_deploy/launcher.rb
+++ b/oo-install/workflows/enterprise_deploy/launcher.rb
@@ -15,7 +15,7 @@ include Installer::Helpers
 # Stage 1: Handle ENV and ARGV input #
 ######################################
 @mongodb_port     = 27017
-@logfile          = '/tmp/openshift-deploy.log'
+@logfile          = File.join(Dir.tmpdir, 'openshift-deploy.log')
 
 # Check ENV for an alternate config file location.
 if ENV.has_key?('OO_INSTALL_CONFIG_FILE')
@@ -344,9 +344,9 @@ def execute_step_on_hosts(host_list, step)
 
       hostfile = @hostfiles[host_instance.host]
       hostfilename = File.basename(hostfile)
-      remotehostfile = "/tmp/#{hostfilename}"
-      openshiftsh = "#{File.dirname(__FILE__)}/openshift.sh"
-      remoteopenshiftsh = "/tmp/openshift.sh"
+      remotehostfile = File.join(Dir.tmpdir, hostfilename)
+      openshiftsh = File.join(File.dirname(__FILE__), 'openshift.sh')
+      remoteopenshiftsh = File.join(Dir.tmpdir, 'openshift.sh')
       if host_instance.localhost?
         copy_template    = `cp #{hostfile} #{remotehostfile}`
         # TODO: do not use predictable path for openshift.sh
@@ -368,7 +368,7 @@ def execute_step_on_hosts(host_list, step)
 
       puts "#{msg_prefix}Running the hostfile" if @debug
 
-      run_hostfile = host_instance.exec_on_host!("cd /tmp && ./#{hostfilename} |& tee -a #{@logfile} | stdbuf -oL -eL grep -i '^OpenShift:'\n")
+      run_hostfile = host_instance.exec_on_host!("cd #{Dir.tmpdir} && ./#{hostfilename} |& tee -a #{@logfile} | stdbuf -oL -eL grep -i '^OpenShift:'\n")
       if run_hostfile[:stdout].match(@abort_regex)
         display_error_info(host_instance, run_hostfile, 'Failed to run the hostfile.')
         exit 1

--- a/oo-install/workflows/enterprise_deploy/launcher.rb
+++ b/oo-install/workflows/enterprise_deploy/launcher.rb
@@ -371,7 +371,7 @@ def execute_step_on_hosts(host_list, step)
       puts "#{msg_prefix}Running the hostfile" if @debug
 
       stdout_filter = /^OpenShift:/
-      run_hostfile = host_instance.exec_on_host!("ERR_PIPE=$(mktemp -u --tempdir oo-install-stderr-pipe}; OUT_PIPE=$(mktemp -u --tempdir oo-install-stdout-pipe}; mkfifo $ERR_PIPE $OUT_PIPE; tee -a #{@logfile} < $ERR_PIPE >$2 & err_log_pid=$!; tee -a #{@logfile} < $OUT_PIPE & out_log_pid=$!; cd #{Dir.tmpdir} > $OUT_PIPE 2> $ERR_PIPE && stdbuf -oL -eL ./#{hostfilename} > $OUT_PIPE 2> $ERR_PIPE; wait $err_log_pid $out_log_pid")
+      run_hostfile = host_instance.exec_on_host!("ERR_PIPE=$(mktemp -u --tempdir oo-install-stderr-pipe); OUT_PIPE=$(mktemp -u --tempdir oo-install-stdout-pipe); mkfifo $ERR_PIPE $OUT_PIPE; tee -a #{@logfile} < $ERR_PIPE >$2 & err_log_pid=$!; tee -a #{@logfile} < $OUT_PIPE & out_log_pid=$!; cd #{Dir.tmpdir} > $OUT_PIPE 2> $ERR_PIPE && stdbuf -oL -eL ./#{hostfilename} > $OUT_PIPE 2> $ERR_PIPE; wait $err_log_pid $out_log_pid")
       if run_hostfile[:exit_code] != 0 or run_hostfile[:stdout].match(@abort_regex)
         display_error_info(host_instance, run_hostfile, 'Failed to run the hostfile.', stdout_filter, nil)
         exit 1


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1146694
- Change some temporary paths to honour $TMPDIR instead of hardcoded
  full path. This allows to invoke the installer with a custom tmpdir
  location. Note that $TMPDIR is used (same value) in all hosts though.
- set TMPDIR for remote commands if set
- Create TMPDIR on remote host if it doesn't exist
