### PR TITLE
install: fix all-in-one httpd conf

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2064,8 +2064,8 @@ fix_broker_routing()
 {
   case "$node_apache_frontend" in
     vhost)
-      # node vhost obscures the broker vhost with same ServerName; not really needed, so remove it.
-      sed -i -e '/<VirtualHost \*:443>/,/<\/VirtualHost/ s/^/#/' /etc/httpd/conf.d/000001_openshift_origin_frontend_vhost.conf
+      # node vhost obscures the broker vhost unless we bring the broker conf forward
+      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2982,8 +2982,8 @@ fix_broker_routing()
 {
   case "$node_apache_frontend" in
     vhost)
-      # node vhost obscures the broker vhost with same ServerName; not really needed, so remove it.
-      sed -i -e '/<VirtualHost \*:443>/,/<\/VirtualHost/ s/^/#/' /etc/httpd/conf.d/000001_openshift_origin_frontend_vhost.conf
+      # node vhost obscures the broker vhost unless we bring the broker conf forward
+      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3028,8 +3028,8 @@ fix_broker_routing()
 {
   case "$node_apache_frontend" in
     vhost)
-      # node vhost obscures the broker vhost with same ServerName; not really needed, so remove it.
-      sed -i -e '/<VirtualHost \*:443>/,/<\/VirtualHost/ s/^/#/' /etc/httpd/conf.d/000001_openshift_origin_frontend_vhost.conf
+      # node vhost obscures the broker vhost unless we bring the broker conf forward
+      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past


### PR DESCRIPTION
Change the workaround for node obscuring broker vhosts in allin1.

Bug 1116713 - node httpd conf intercepts requests for the broker in
all-in-one env
https://bugzilla.redhat.com/show_bug.cgi?id=1116713
