### PR TITLE
yum-validator: avoid content overrides if possible, bail on fail

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -8,11 +8,14 @@ repositories
 import sys
 from yumvalidator import repo_db
 from yumvalidator.check_sources import CheckSources
+from yumvalidator.check_sources import SubscriptionManagerError
 from yumvalidator.check_sources import SUBMAN_OVERRIDE_NVR
 # from yumvalidator.reconcile_rhsm_config import ReconciliationEngine
 from itertools import chain
 from yum import Errors
 import logging
+from os.path import normpath
+import rpm
 
 OSE_PRIORITY = 10
 RHEL_PRIORITY = 20
@@ -24,8 +27,8 @@ SUBS_NAME = {UNKNOWN: '', RHSM: 'Red Hat Subscription Manager',
              RHN: 'RHN Classic or RHN Satellite', YUM: 'Yum'}
 VALID_SUBS = SUBS_NAME.keys()[1:]
 ATTACH_ENTITLEMENTS_URL = 'https://access.redhat.com/site/articles/522923'
-# VALID_OO_VERSIONS = ['1.2', '2.0']
 VALID_ROLES = ['node', 'broker', 'client', 'node-eap', 'node-fuse', 'node-amq']
+WORKING_YCM_NVR = ('yum', '3.2.29', '47.el6')
 
 def flatten_uniq(llist):
     """Flatten nested iterables and filter result for uniqueness
@@ -114,7 +117,7 @@ class OpenShiftYumValidator(object):
         """
         return [repo.repoid for repo in self.blessed_repos(**kwargs)]
 
-    def blessed_repos(self, enabled = False, required = False, product = None):
+    def blessed_repos(self, enabled=False, required=False, product=None):
         """Return a list of RepoTuples from self.rdb that match the provided
         criteria
 
@@ -146,6 +149,32 @@ class OpenShiftYumValidator(object):
                     if not product or repo.product == product]
         return self.rdb.find_repos(**kwargs)
 
+    def ycm_works(self):
+        """Return True if the version of yum installed fixes known
+        yum-config-manager bugs"""
+        try:
+            return self._working_ycm
+        except AttributeError:
+            if not self.oscs.verify_package('yum-utils'):
+                self._working_ycm = False
+                return self._working_ycm
+            pkg_ycm = self.oscs.installed_package_matching(WORKING_YCM_NVR[0])
+            if pkg_ycm:
+                ycm_nvr = (pkg_ycm.name, pkg_ycm.ver, pkg_ycm.rel)
+                self._working_ycm = (
+                    rpm.labelCompare(ycm_nvr,
+                                     WORKING_YCM_NVR) >= 0)
+            else:
+                self._working_ycm = False
+            return self._working_ycm
+
+    def _set_local_change(self, repoid, value):
+        repo = self.oscs.repo_for_repoid(repoid)
+        repofile = normpath(repo.repofile)
+        if repofile not in self.local_changes:
+            self.local_changes[repofile] = {}
+        self.local_changes[repofile][repoid] = value
+
     def _available_subs(self):
         subs = {}
         for fxn_rcheck, sub in [(self.oscs.repo_is_rhsm, 'rhsm'),
@@ -167,7 +196,7 @@ class OpenShiftYumValidator(object):
         self.logger.info('Detected OpenShift version %s' %
                          self.opts.oo_version)
 
-    def _sub_ver(self, subscription, version = None):
+    def _sub_ver(self, subscription, version=None):
         if self.opts.subscription == UNKNOWN and not self.opts.oo_version:
             self._sub(subscription)
             if version:
@@ -242,6 +271,47 @@ class OpenShiftYumValidator(object):
             return self._sub_ver(avail_subs.keys()[0])
         return False
 
+
+    def _output_version_conflicts(self):
+        self.logger.error('Repositories have been found which conflict with '
+                          'the detected or specified product version.')
+        self.logger.error('To prevent problems due to package conflicts, '
+                          'disable these repositories according to the '
+                          'directions given below.')
+        if self.managed_changes[RHSM]:
+            for repoid in self.managed_changes[RHSM].iterkeys():
+                self.logger.error('Disable RHSM-managed repositories which '
+                                  'have existing content overrides by '
+                                  'running:')
+                self.logger.error('    # subscription-manager repos '
+                                  '--disable=%s' % repoid)
+        if self.managed_changes[RHN]:
+            self.logger.error('Disable RHN-managed repositories by making '
+                              'these modifications to '
+                              '/etc/yum/pluginconf.d/rhnplugin.conf:')
+            for repoid in self.managed_changes[RHN].iterkeys():
+                self.logger.error('    Set "enabled=0" in the [%s] '
+                                  'section' % repoid)
+        if self.local_changes:
+            if self.ycm_works():
+                self.logger.error('Disable Yum and/or RHSM-managed '
+                                  'repositories with local settings by '
+                                  'running these commands:')
+                for repofile, changes in self.local_changes.iteritems():
+                    for repoid in changes.iterkeys():
+                        self.logger.error('    # yum-config-manager '
+                                          '--disable %s' % repoid)
+            else:
+                self.logger.error('Disable Yum and/or locally-managed RHSM '
+                                  'repositories by modifying the following '
+                                  'file(s).')
+                for repofile, changes in self.local_changes.iteritems():
+                    self.logger.error('Update %s with the following '
+                                      'changes:' % repofile)
+                    for repoid in changes.iterkeys():
+                        self.logger.error('    Set "enabled=0" in the '
+                                          '[%s] section' % repoid)
+
     def check_version_conflict(self):
         """Determine if repositories for multiple versions of OpenShift have
         been wrongly enabled, and advise or fix accordingly.
@@ -259,6 +329,8 @@ class OpenShiftYumValidator(object):
                         self.logger.warning('Disabled repository %s' %
                                             repo.repoid)
             else:
+                self.managed_changes = {RHSM: {}, RHN: {}}
+                self.local_changes = {}
                 rhsm_conflicts = [repo.repoid for repo in conflicts if
                                   self.oscs.repo_is_rhsm(repo.repoid)]
                 rhn_conflicts = [repo.repoid for repo in conflicts if
@@ -267,36 +339,18 @@ class OpenShiftYumValidator(object):
                                    not (repo.repoid in rhsm_conflicts or
                                         repo.repoid in rhn_conflicts)]
                 if rhsm_conflicts:
-                    self.logger.error('The following OpenShift '
-                                      'repositories conflict with the '
-                                      'detected or specified product version.')
-                    self.logger.error('To prevent package conflicts, disable '
-                                      'these repositories by running these '
-                                      'commands:')
                     for repoid in rhsm_conflicts:
-                        self.logger.error('    # subscription-manager repos '
-                                          '--disable=%s' % repoid)
+                        if self.oscs.repo_attr_overridden(repoid, 'enabled'):
+                            self.managed_changes[RHSM][repoid] = 0
+                        else:
+                            self._set_local_change(repoid, 0)
                 if rhn_conflicts:
-                    self.logger.error('The following RHN Classic or RHN '
-                                      'Satellite-managed OpenShift '
-                                      'repositories conflict with the '
-                                      'detected or specified product version.')
-                    self.logger.error('To prevent package conflicts, disable '
-                                      'these repositories by making the '
-                                      'following modifications to '
-                                      '/etc/yum/pluginconf.d/rhnplugin.conf')
                     for repoid in rhn_conflicts:
-                        self.logger.error('    Set enabled=0 in the [%s] '
-                                          'section' % repoid)
+                        self.managed_changes[RHN][repoid] = 0
                 if other_conflicts:
-                    self.logger.error('The following Yum repositories conflict '
-                                      'with the detected or specified product '
-                                      'version.')
-                    self.logger.error('Disable these repositories by running '
-                                      'these commands:')
                     for repoid in other_conflicts:
-                        self.logger.error('    # yum-config-manager '
-                                          '--disable %s' % repoid)
+                        self._set_local_change(repoid, 0)
+                self._output_version_conflicts()
             return False
         return True
 
@@ -315,7 +369,8 @@ class OpenShiftYumValidator(object):
                     self.logger.error('Required package yum-plugin-priorities '
                                       'is not installed. Install the package '
                                       'with the following command:')
-                    self.logger.error('# yum install yum-plugin-priorities')
+                    self.logger.error('    # yum install '
+                                      'yum-plugin-priorities')
                 else:
                     self.logger.error('Required package yum-plugin-priorities '
                                       'is not available.')
@@ -350,43 +405,53 @@ class OpenShiftYumValidator(object):
                                 (repoid, priority))
             self.oscs.set_repo_priority(repoid, priority)
         else:
-            if not self.pri_resolve_header:
-                self.pri_resolve_header = True
-                if self.oscs.repo_is_rhn(repoid):
-                    self.logger.error('To resolve conflicting repositories, '
-                                      'update '
-                                      '/etc/yum/pluginconf.d/rhnplugin.conf '
-                                      'with the following changes:')
-                elif (self.oscs.repo_is_rhsm(repoid)
-                      and not self.oscs.use_override()):
-                    self.logger.error('To resolve conflicting repositories, '
-                                      'update /etc/yum.repos.d/redhat.repo '
-                                      'with the following changes:')
-                else:
-                    self.logger.error('To resolve conflicting repositories, '
-                                      'update repo priority by running:')
             if self.oscs.repo_is_rhn(repoid):
-                self.logger.error('    Set priority=%d in the [%s] section' %
-                                  (priority, repoid))
-            elif self.oscs.repo_is_rhsm(repoid):
-                if self.oscs.use_override():
-                    self.logger.error('# subscription-manager repo-override '
-                                      '--repo=%s --add=priority:%d' %
-                                      (repoid, priority))
-                else:
-                    self.logger.error('    Set priority=%d in the '
-                                      '[%s] section' %
-                                      (priority, repoid))
+                self.managed_changes[RHN][repoid] = priority
+            elif self.oscs.repo_is_rhsm(repoid) and self.oscs.repo_attr_overridden(repoid, 'priority'):
+                self.managed_changes[RHSM][repoid] = priority
             else:
-                self.logger.error('# yum-config-manager '
-                                  '--setopt=%s.priority=%d %s --save' %
-                                  (repoid, priority, repoid))
+                self._set_local_change(repoid, priority)
 
     def _commit_resolved_pris(self):
+        self.managed_changes = {RHSM: {}, RHN: {}}
+        self.local_changes = {}
         for repoid, pri in sorted(self.resolved_repos.items(),
-                                  key = lambda (kk, vv): vv):
+                                  key=lambda (kk, vv): vv):
             if not self.committed_resolved_repos.get(repoid, None) == pri:
                 self._set_pri(repoid, pri)
+        if self.managed_changes[RHSM]:
+            self.logger.error('To resolve conflicting repositories, '
+                              'update repo priority by running:')
+            for repoid, priority in self.managed_changes[RHSM].iteritems():
+                self.logger.error('    # subscription-manager repo-override '
+                                  '--repo=%s --add=priority:%d' %
+                                  (repoid, priority))
+        if self.managed_changes[RHN]:
+            self.logger.error('To resolve conflicting repositories, '
+                              'update '
+                              '/etc/yum/pluginconf.d/rhnplugin.conf '
+                              'with the following changes:')
+            for repoid, priority in self.managed_changes[RHN].iteritems():
+                self.logger.error('    Set "priority=%d" in the [%s] section' %
+                                  (priority, repoid))
+        if self.local_changes:
+            if self.ycm_works():
+                self.logger.error('To resolve conflicting repositories, '
+                                  'update repo priority by running:')
+                for repofile, changes in self.local_changes.iteritems():
+                    for repoid, priority in changes.iteritems():
+                        self.logger.error('    # yum-config-manager '
+                                          '--setopt=%s.priority=%d %s --save' %
+                                          (repoid, priority, repoid))
+            else:
+                for repofile, changes in self.local_changes.iteritems():
+                    self.logger.error('To resolve conflicting repositories, '
+                                      'update %s '
+                                      'with the following changes:' % repofile)
+                    for repoid, priority in changes.iteritems():
+                        self.logger.error('    Set "priority=%d" in the '
+                                          '[%s] section' %
+                                          (priority, repoid))
         self.committed_resolved_repos = self.resolved_repos.copy()
 
 
@@ -413,16 +478,17 @@ class OpenShiftYumValidator(object):
         """
         res = True
         ose_pri = self._limit_pri(ose_repos)
-        # rhel_pri = self._get_pri(rhel6_repo)
         rhel_pri = self._limit_pri(rhel6_repos, minpri=True)
         if rhel_pri <= ose_pri:
-            for repoid in ose_repos:
+            for repoid in (repoid for repoid in ose_repos if
+                           self._get_pri(repoid) != OSE_PRIORITY):
                 self.resolved_repos[repoid] = OSE_PRIORITY
                 res = False
             ose_pri = OSE_PRIORITY
         # Fix the rhel repos if any of them are at 99
         if rhel_pri <= ose_pri or self._limit_pri(rhel6_repos) >= 99:
-            for repoid in rhel6_repos:
+            for repoid in (repoid for repoid in rhel6_repos if
+                           self._get_pri(repoid) != RHEL_PRIORITY):
                 self.resolved_repos[repoid] = RHEL_PRIORITY
             res = False
         return res
@@ -441,10 +507,12 @@ class OpenShiftYumValidator(object):
             min_pri = self._limit_pri(rhel6_repos)
         if jboss_pri <= min_pri or jboss_max_pri >= 99:
             if rhel6_repos:
-                for repoid in rhel6_repos:
+                for repoid in (repoid for repoid in rhel6_repos if
+                               self._get_pri(repoid) != RHEL_PRIORITY):
                     self.resolved_repos[repoid] = RHEL_PRIORITY
             res = False
-            for repoid in jboss_repos:
+            for repoid in (repoid for repoid in jboss_repos if
+                           self._get_pri(repoid) != JBOSS_PRIORITY):
                 self.resolved_repos[repoid] = JBOSS_PRIORITY
                 res = False
         return res
@@ -470,14 +538,59 @@ class OpenShiftYumValidator(object):
                 res &= self.verify_jboss_priorities(ose_scl, jboss, rhel)
             else:
                 res &= self.verify_jboss_priorities(ose_scl, jboss)
-        self._commit_resolved_pris()
         return res
+
+    def _output_disabled_repos(self, disabled_repos):
+        self.managed_changes = {RHSM: {}, RHN: {}}
+        self.local_changes = {}
+        for repoid in disabled_repos:
+            if self.oscs.repo_is_rhn(repoid):
+                self.managed_changes[RHN][repoid] = 1
+            elif (self.oscs.repo_is_rhsm(repoid) and
+                  self.oscs.repo_attr_overridden(repoid, 'enabled')):
+                self.managed_changes[RHSM][repoid] = 1
+            else:
+                self._set_local_change(repoid, 1)
+        self.logger.error('Required OpenShift repositories have been found '
+                          'which are currently disabled. Enable them '
+                          'according to the following directions.')
+        if self.managed_changes[RHSM]:
+            self.logger.error('Enable RHSM-managed repos which have existing '
+                              'content overrides by running:')
+            for repoid in self.managed_changes[RHSM].iterkeys():
+                self.logger.error('    # subscription-manager repos '
+                                  '--enable=%s' % repoid)
+        if self.managed_changes[RHN]:
+            self.logger.error('Enable RHN-managed repos by making these '
+                              'modifications to '
+                              '/etc/yum/pluginconf.d/rhnplugin.conf:')
+            for repoid in self.managed_changes[RHN].iterkeys():
+                self.logger.error('    Set "enabled=1" in the [%s] '
+                                  'section' % repoid)
+        if self.local_changes:
+            if self.ycm_works():
+                self.logger.error('Enable Yum and/or locally-managed RHSM '
+                                  'repositories by running:')
+                for repofile, changes in self.local_changes.iteritems():
+                    for repoid in changes.iterkeys():
+                        self.logger.error('    # yum-config-manager --enable '
+                                          '%s' % repoid)
+            else:
+                self.logger.error('Enable Yum and/or locally-managed RHSM '
+                                  'repositories by modifying the following '
+                                  'file(s).')
+                for repofile, changes in self.local_changes.iteritems():
+                    self.logger.error('Update %s with the following '
+                                      'changes:' % repofile)
+                    for repoid in changes.iterkeys():
+                        self.logger.error('    Set "enabled=1" in the [%s] '
+                                          'section' % repoid)
 
     def check_disabled_repos(self):
         """Check if any required repositories are disabled, and fix or advise
         accordingly
         """
-        disabled_repos = list(set(self.blessed_repoids(required = True))
+        disabled_repos = list(set(self.blessed_repoids(required=True))
                               .intersection(self.oscs.disabled_repoids()))
         if disabled_repos:
             self.problem = True
@@ -486,26 +599,7 @@ class OpenShiftYumValidator(object):
                     if self.oscs.enable_repo(repo):
                         self.logger.warning('Enabled repository %s'%repo)
             else:
-                self.logger.error('The required OpenShift repositories '
-                                  'are disabled:')
-                for repo in disabled_repos:
-                    self.logger.error('    %s'%repo)
-                if self.opts.subscription == RHN:
-                    self.logger.error('Make the following modifications '
-                                      'to /etc/yum/pluginconf.d/rhnplugin.conf')
-                else:
-                    self.logger.error('Enable these repositories by running '
-                                      'these commands:')
-                for repoid in disabled_repos:
-                    if self.opts.subscription == RHN:
-                        self.logger.error('    Set enabled=1 in the [%s] '
-                                          'section' % repoid)
-                    elif self.opts.subscription == RHSM:
-                        self.logger.error('# subscription-manager repos '
-                                          '--enable=%s' % repoid)
-                    else:
-                        self.logger.error('# yum-config-manager --enable %s' %
-                                          repoid)
+                self._output_disabled_repos(disabled_repos)
             return False
         return True
 
@@ -515,7 +609,7 @@ class OpenShiftYumValidator(object):
 
         """
         missing_repos = [repo for repo in
-                         self.blessed_repoids(required = True)
+                         self.blessed_repoids(required=True)
                          if repo not in self.oscs.all_repoids()]
         if missing_repos:
             self.problem = True
@@ -594,10 +688,6 @@ class OpenShiftYumValidator(object):
                 res = False
             except Errors.RepoError as repo_err:
                 raise UnrecoverableYumError(repo_err)
-        # for repoid, pri in self.resolved_repos.iteritems():
-        #     if not old_resolved_repos.get(repoid, None) == pri:
-        #         self._set_pri(repoid, pri)
-        self._commit_resolved_pris()
         return res
 
     def _set_exclude(self, repo):
@@ -607,34 +697,64 @@ class OpenShiftYumValidator(object):
             self.oscs.merge_excludes(repo.repoid, list(repo.exclude))
         else:
             exc = ' '.join(repo.exclude)
-            if ' ' in exc:
-                exc = '"%s"' % exc
-            if self.opts.subscription == RHN or (
-                    self.opts.subscription == RHSM and
-                    not self.oscs.use_override()):
-                self.logger.error('Add the following to the [%s] section:' %
-                                  (repo.repoid))
-                self.logger.error('    exclude=%s'%exc)
-            elif self.opts.subscription == RHSM and self.oscs.use_override():
-                self.logger.error('# subscription-manager repo-override '
-                                  '--repo=%s --add=exclude:%s' %
-                                  (repo.repoid, exc))
+            repoid = repo.repoid
+            if self.oscs.repo_is_rhn(repoid):
+                self.managed_changes[RHN][repoid] = exc
+            elif self.oscs.repo_is_rhsm(repoid) and self.oscs.repo_attr_overridden(repoid, 'exclude'):
+                self.managed_changes[RHSM][repoid] = exc
             else:
-                repofile = self.oscs.yum_base.repos.repos[repo.repoid].repofile
-                if repofile:
-                    self.logger.error('In file %s, Add the following to the '
-                                      '[%s] section' % (repofile, repo.repoid))
-                    self.logger.error('    exclude=%s'%exc)
-                else: # Man, I don't know
-                    self.logger.error('# yum-config-manager '
-                                      '--setopt=%s.exclude=%d %s --save' %
-                                      (repo.repoid, exc, repo.repoid))
+                self._set_local_change(repoid, exc)
 
     def _excludes_needed(self, repo):
         if repo.exclude and repo.repoid in self.oscs.all_repoids():
             cur_excl = self.oscs.repo_for_repoid(repo.repoid).exclude
             # see if current set exclusions are (improper) superset of repo.exclude
             return not (set(cur_excl) >= set(repo.exclude))
+
+    def _output_excludes(self):
+        if self.opts.fix:
+            return
+        self.logger.error('To prevent problems due to package conflicts, '
+                          'modify these repositories according to the '
+                          'directions given below.')
+        if self.managed_changes[RHSM]:
+            self.logger.error('Set package exclusions for RHSM-managed '
+                              'repositories with existing content overrides '
+                              'by running:')
+            for repoid, exclusions in self.managed_changes[RHSM].iteritems():
+                self.logger.error('    # subscription-manager repo-override '
+                                  '--repo=%s --add=exclude:"%s"' %
+                                  (repoid, exclusion))
+        if self.managed_changes[RHN]:
+            self.logger.error('Set package exclusions for RHN-managed repos '
+                              'by updating '
+                              '/etc/yum/pluginconf.d/rhnplugin.conf '
+                              'with the following changes:')
+            for repoid, exclusions in self.managed_changes[RHN].iteritems():
+                self.logger.error('    Set "exclude=%s" in the [%s] section' %
+                                  (exclusion, repoid))
+        if self.local_changes:
+            if self.ycm_works():
+                self.logger.error('Set package exclusions for Yum '
+                                  'repositories and/or locally-managed RHSM '
+                                  'repositories by running:')
+                for repofile, changes in self.local_changes.iteritems():
+                    for repoid, exclusions in changes.iteritems():
+                        self.logger.error('    # yum-config-manager '
+                                          '--setopt=%s.exclude="%s" %s --save' %
+                                          (repoid, exclusions, repoid))
+            else:
+                self.logger.error('Set package exclusions for Yum '
+                                  'repositories and/or locally-managed RHSM '
+                                  'repositories by making these '
+                                  'modifications to the following file(s):')
+                for repofile, changes in self.local_changes.iteritems():
+                    self.logger.error('Update %s with the following '
+                                      'changes:' % repofile)
+                    for repoid, exclusions in changes.iteritems():
+                        self.logger.error('    Set "exclude=%s" in the [%s] '
+                                          'section' % (exclusions, repoid))
+
 
     def set_excludes(self):
         """Set any excludes configured for the required repositories
@@ -643,25 +763,19 @@ class OpenShiftYumValidator(object):
                         self._excludes_needed(repo)]
         if need_exclude:
             self.problem = True
+            self.logger.error('Repositories have been found which are '
+                              'missing one or more required package '
+                              'exclusions.')
             if self.opts.fix:
-                self.logger.error('Setting package exclusions for the '
-                                  'following repositories:')
+                self.logger.error('To prevent problems due to package '
+                                  'conflicts, package exclusions are being '
+                                  'set for the following repositories:')
             else:
-                self.logger.error('The following repositories need package '
-                                  'exclusions set:')
-                for repo in need_exclude:
-                    self.logger.error('    %s'%repo.repoid)
-                if self.opts.subscription == RHN:
-                    self.logger.error('Make the following modifications to '
-                                      '/etc/yum/pluginconf.d/rhnplugin.conf')
-                elif self.opts.subscription == RHSM and not self.oscs.use_override():
-                    self.logger.error('Make the following modifications to '
-                                      '/etc/yum.repos.d/redhat.repo')
-                else:
-                    self.logger.error('Modify the repositories by running '
-                                      'these commands:')
+                self.managed_changes = {RHSM: {}, RHN: {}}
+                self.local_changes = {}
             for repo in need_exclude:
                 self._set_exclude(repo)
+            self._output_excludes()
             return False
         return True
 
@@ -684,8 +798,8 @@ class OpenShiftYumValidator(object):
             if present_pkgs:
                 self.opts.role.append(role)
                 pkg_repos = flatten_uniq([self.rdb.find_repos(
-                    key_pkg = pkg.name,
-                    repoid = self.oscs.repo_for_package(pkg))
+                    key_pkg=pkg.name,
+                    repoid=self.oscs.repo_for_package(pkg))
                                           for pkg in present_pkgs])
                 # Peek ahead to see if we're possibly running an OSE install
                 for repo in pkg_repos:
@@ -764,6 +878,16 @@ class OpenShiftYumValidator(object):
                                  'is available for testing and '
                                  'troubleshooting.')
 
+    def run_priority_checks(self):
+        if not (self.verify_priorities() or self.opts.report_all):
+            self._commit_resolved_pris()
+            return False
+        if not (self.find_package_conflicts() or self.opts.report_all):
+            self._commit_resolved_pris()
+            return False
+        self._commit_resolved_pris()
+        return True
+
     def run_checks(self):
         if not self.validate_roles():
             return False
@@ -814,9 +938,7 @@ class OpenShiftYumValidator(object):
                                         'repository priorities may not be '
                                         'accurate.')
                     print ""
-            if not (self.verify_priorities() or self.opts.report_all):
-                return False
-            if not (self.find_package_conflicts() or self.opts.report_all):
+            if not (self.run_priority_checks() or self.opts.report_all):
                 return False
             if not (self.set_excludes() or self.opts.report_all):
                 return False
@@ -853,7 +975,17 @@ class OpenShiftYumValidator(object):
                                  'after the problem has been repaired:')
             print ''
             self.logger.critical(uryum_err)
-            return 255
+            return 128
+        except SubscriptionManagerError, sm_err:
+            self.logger.critical('A problem occured while setting content '
+                                 'overrides using the subscription-manager '
+                                 'utility. This often indicates a problem '
+                                 'communicating with the subscription-manager '
+                                 'server component. Please resolve the issue '
+                                 'and try again.')
+            print ''
+            self.logger.critical(sm_err)
+            return 2
         return 0
 
 
@@ -903,15 +1035,10 @@ def validate_yum():
                                 type=str, help=REPO_CONF_HELP)
         opt_parser.add_argument('-e', '--reconcile-overrides', action='store_true',
                                 default=False, help=RECONCILE_OVERRIDES_HELP)
-        # opt_parser.add_argument('-u', '--blend-user-repos',
-        #                         action='store_true', default=True,
-        #                         dest='user_repos_only',
-        #                         help=USER_REPOS_HELP)
         opts = opt_parser.parse_args()
     except ImportError:
         import optparse
         ROLE_HELP += ' One or more of: %s' % VALID_ROLES
-        # OO_VERSION_HELP += ' One of: %s' % VALID_OO_VERSIONS
         SUBSCRIPTION_HELP += ' One of: %s' % VALID_SUBS
         opt_parser = optparse.OptionParser()
         opt_parser.add_option('-r', '--role', default=None,
@@ -935,10 +1062,6 @@ def validate_yum():
                               type='string', help=REPO_CONF_HELP)
         opt_parser.add_option('-e', '--reconcile-overrides', action='store_true',
                               default=False, help=RECONCILE_OVERRIDES_HELP)
-        # opt_parser.add_option('-u', '--blend-user-repos',
-        #                       action='store_true', default=True,
-        #                       dest='user_repos_only',
-        #                       help=USER_REPOS_HELP)
         (opts, args) = opt_parser.parse_args()
     opts.user_repos_only = True
     try:


### PR DESCRIPTION
Adds logic to check if an override exists for a repo attribute and only
sets the new value via content override if an override already is in
place. Also added the `SubscriptionManagerError` exception so
`oo-admin-yum-validator` will bail with return code=2 if a call to
`subscription-manager` fails

Enterprise bug: 1166270
https://bugzilla.redhat.com/show_bug.cgi?id=1166270

yum-validator: rewrite priorities messaging

Since instructions to the user must now be grouped according to
overrides and non-overrides for RHSM repos, the `verify_priorities` and
`find_package_conflicts` methods have been more closely coupled in
method `run_priority_checks`. Repo priority changes are now deferred
until after both `verify_priorities` and `find_package_conflicts` have
been run, when appropriate (`_commit_resolved_pris`)

yum-validator: add check for yum-config-manager ver

To account for broken versions of `yum-config-manager`, added
`ycm_works` method, which checks for a minimum known-working
`yum-config-manager` version and caches the result

yum-validator: Update messaging to handle more cases

This change updates the output for each check to account for settings
which are stored as content overrides and to yield less error-prone
`yum-config-manager`-based instructions if a suitable version is
available.

Also:

```
* cleans up/unifies some of the output
* adds more intelligent quoting
* fixes the incorrect syntax identified in Bug 1167247
* eliminates redundant priority setting instructions
```

Enterprise bug: 1167247
https://bugzilla.redhat.com/show_bug.cgi?id=1167247
Enterprise bug: 1166270
https://bugzilla.redhat.com/show_bug.cgi?id=1166270
Enterprise bug: 1166276
https://bugzilla.redhat.com/show_bug.cgi?id=1166276
Enterprise bug: 1166277
https://bugzilla.redhat.com/show_bug.cgi?id=1166277

yum-validator: improve RHSM repo detection

This changes `repo_is_rhsm` so that the RHSM `RepoActionInvoker` method
`is_managed` is used instead of comparing the filename. This will work
even on systems where `manage_repos = 0` is set in `rhsm.conf` but a
valid subscription exists and repos from entitlements are provided from
a file other than `redhat.repo`

Also, `is_managed` is used to prevent repo overrides from being set on
systems that have that feature disabled.
