### PR TITLE
yum-validator: Handle RHSM server request failures

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -836,10 +836,14 @@ class OpenShiftYumValidator(object):
         self.logger.info('Checking for discrepancies between local settings '
                          'and content overrides')
         from yumvalidator.reconcile_rhsm_config import ReconciliationEngine
-        r_eng = ReconciliationEngine(self.oscs, self.rdb, self.logger, self.opts)
-        if r_eng.reconcile_overrides():
-            self.problem = True
-            return False
+        try:
+            r_eng = ReconciliationEngine(self.oscs, self.rdb, self.logger, self.opts)
+            if r_eng.reconcile_overrides():
+                self.problem = True
+                return False
+        except Exception, rengex:
+            # We can't recover from any error here
+            raise SubscriptionManagerError(repr(rengex))
         return True
 
     def validate_version(self):
@@ -977,12 +981,11 @@ class OpenShiftYumValidator(object):
             self.logger.critical(uryum_err)
             return 128
         except SubscriptionManagerError, sm_err:
-            self.logger.critical('A problem occured while setting content '
-                                 'overrides using the subscription-manager '
-                                 'utility. This often indicates a problem '
-                                 'communicating with the subscription-manager '
-                                 'server component. Please resolve the issue '
-                                 'and try again.')
+            self.logger.critical('A problem occured while using '
+                                 'subscription-manager services. This often '
+                                 'indicates a problem communicating with the '
+                                 'subscription-manager server component. '
+                                 'Please resolve the issue and try again.')
             print ''
             self.logger.critical(sm_err)
             return 2

--- a/admin/yum-validator/yumvalidator/check_sources.py
+++ b/admin/yum-validator/yumvalidator/check_sources.py
@@ -25,7 +25,6 @@ import rpm
 
 from yumvalidator.reconcile_rhsm_config import SubscriptionManagerNotRegisteredError
 
-
 NAME = 'oo-admin-check-sources'
 VERSION = '0.1'
 USAGE = 'Apply a thin layer to scalp and sing'
@@ -130,10 +129,19 @@ class CheckSources(object):
                 except SubscriptionManagerNotRegisteredError:
                     self._use_override = False
                     raise
+                except Exception, rengex:
+                    # We can't recover from any error here
+                    raise SubscriptionManagerError(repr(rengex))
+
             return self._use_override
 
     def _update_overrides(self):
-        (self._repo_overrides, ovrd_repos) = self.r_eng.get_overrides_and_repos()
+        try:
+            (self._repo_overrides, ovrd_repos) = self.r_eng.get_overrides_and_repos()
+        except Exception, rengex:
+            # We can't recover from any error here
+            raise SubscriptionManagerError(repr(rengex))
+
         self._ovrd_age = time.time()
 
     def repo_overrides(self):
@@ -340,7 +348,11 @@ class CheckSources(object):
         """
         repo = self._resolve_repoid(repoid)
         if self.repo_act_invoker():
-            return self.repo_act_invoker().is_managed(repo.id)
+            try:
+                return self.repo_act_invoker().is_managed(repo.id)
+            except Exception, raiex:
+                # We can't recover from any error here
+                raise SubscriptionManagerError(repr(raiex))
         return False
 
     def repo_is_rhn(self, repoid):


### PR DESCRIPTION
Failed requests to the RHSM server generally can't be recovered from, so
now any request failure should make `oo-admin-yum-validator` exit with
rc=2
