### PR TITLE
Add facter to the package exclusion list for 2.2 node repos

### DIFF
--- a/admin/yum-validator/etc/repos.ini
+++ b/admin/yum-validator/etc/repos.ini
@@ -129,6 +129,7 @@ product = ose
 product_version = 2.2
 role = node
 key_pkg = rubygem-openshift-origin-node
+exclude = facter
 
 [rhel-6-server-ose-2.2-infra-rpms]
 subscription = rhsm
@@ -282,6 +283,7 @@ product = ose
 product_version = 2.2
 role = node
 key_pkg = rubygem-openshift-origin-node
+exclude = facter
 
 [rhel-x86_64-server-6-ose-2.2-infrastructure]
 subscription = rhn


### PR DESCRIPTION
Puppet versions 3.x require newer versions of facter than those in the
node repos. With priorities in place this was preventing anyone from
upgrading or installing puppet 3.x. Recent versions of OpenShift
Enterprise only use the ruby193-facter package so excluding this
package from the repo is safe to do.
