### PR TITLE
yum-validator: Fixes for RHN and older RHSM

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -290,8 +290,9 @@ class OpenShiftYumValidator(object):
                               'these modifications to '
                               '/etc/yum/pluginconf.d/rhnplugin.conf:')
             for repoid in self.managed_changes[RHN].iterkeys():
-                self.logger.error('    Set "enabled=0" in the [%s] '
-                                  'section' % repoid)
+                self.logger.error('    Set "enabled=0" in the "[%s]" '
+                                  'section, creating the section if needed' %
+                                  repoid)
         if self.local_changes:
             if self.ycm_works():
                 self.logger.error('Disable Yum and/or RHSM-managed '
@@ -310,7 +311,8 @@ class OpenShiftYumValidator(object):
                                       'changes:' % repofile)
                     for repoid in changes.iterkeys():
                         self.logger.error('    Set "enabled=0" in the '
-                                          '[%s] section' % repoid)
+                                          '[%s] section, creating the '
+                                          'section if needed' % repoid)
 
     def check_version_conflict(self):
         """Determine if repositories for multiple versions of OpenShift have
@@ -432,7 +434,8 @@ class OpenShiftYumValidator(object):
                               '/etc/yum/pluginconf.d/rhnplugin.conf '
                               'with the following changes:')
             for repoid, priority in self.managed_changes[RHN].iteritems():
-                self.logger.error('    Set "priority=%d" in the [%s] section' %
+                self.logger.error('    Set "priority=%d" in the "[%s]" '
+                                  'section, creating the section if needed' %
                                   (priority, repoid))
         if self.local_changes:
             if self.ycm_works():
@@ -450,7 +453,8 @@ class OpenShiftYumValidator(object):
                                       'with the following changes:' % repofile)
                     for repoid, priority in changes.iteritems():
                         self.logger.error('    Set "priority=%d" in the '
-                                          '[%s] section' %
+                                          '[%s] section, creating the '
+                                          'section if needed' %
                                           (priority, repoid))
         self.committed_resolved_repos = self.resolved_repos.copy()
 
@@ -565,8 +569,9 @@ class OpenShiftYumValidator(object):
                               'modifications to '
                               '/etc/yum/pluginconf.d/rhnplugin.conf:')
             for repoid in self.managed_changes[RHN].iterkeys():
-                self.logger.error('    Set "enabled=1" in the [%s] '
-                                  'section' % repoid)
+                self.logger.error('    Set "enabled=1" in the "[%s]" '
+                                  'section, creating the section if '
+                                  'needed' % repoid)
         if self.local_changes:
             if self.ycm_works():
                 self.logger.error('Enable Yum and/or locally-managed RHSM '
@@ -583,8 +588,9 @@ class OpenShiftYumValidator(object):
                     self.logger.error('Update %s with the following '
                                       'changes:' % repofile)
                     for repoid in changes.iterkeys():
-                        self.logger.error('    Set "enabled=1" in the [%s] '
-                                          'section' % repoid)
+                        self.logger.error('    Set "enabled=1" in the "[%s]" '
+                                          'section, creating the section if '
+                                          'needed' % repoid)
 
     def check_disabled_repos(self):
         """Check if any required repositories are disabled, and fix or advise
@@ -724,15 +730,16 @@ class OpenShiftYumValidator(object):
             for repoid, exclusions in self.managed_changes[RHSM].iteritems():
                 self.logger.error('    # subscription-manager repo-override '
                                   '--repo=%s --add=exclude:"%s"' %
-                                  (repoid, exclusion))
+                                  (repoid, exclusions))
         if self.managed_changes[RHN]:
             self.logger.error('Set package exclusions for RHN-managed repos '
                               'by updating '
                               '/etc/yum/pluginconf.d/rhnplugin.conf '
                               'with the following changes:')
             for repoid, exclusions in self.managed_changes[RHN].iteritems():
-                self.logger.error('    Set "exclude=%s" in the [%s] section' %
-                                  (exclusion, repoid))
+                self.logger.error('    Set "exclude=%s" in the "[%s]" section, '
+                                  'creating the section if needed' %
+                                  (exclusions, repoid))
         if self.local_changes:
             if self.ycm_works():
                 self.logger.error('Set package exclusions for Yum '
@@ -752,8 +759,9 @@ class OpenShiftYumValidator(object):
                     self.logger.error('Update %s with the following '
                                       'changes:' % repofile)
                     for repoid, exclusions in changes.iteritems():
-                        self.logger.error('    Set "exclude=%s" in the [%s] '
-                                          'section' % (exclusions, repoid))
+                        self.logger.error('    Set "exclude=%s" in the "[%s]" '
+                                          'section, creating the section if '
+                                          'needed' % (exclusions, repoid))
 
 
     def set_excludes(self):

--- a/admin/yum-validator/yumvalidator/reconcile_rhsm_config.py
+++ b/admin/yum-validator/yumvalidator/reconcile_rhsm_config.py
@@ -69,8 +69,17 @@ class ReconciliationEngine(object):
         self.consumer_uuid = self.consumer_identity.getConsumerId()
         self.cp_provider = inj.require(inj.CP_PROVIDER)
         self.cp = self.cp_provider.get_consumer_auth_cp()
-        self.ATTR_DEFAULTS = dict([(attr, RepoConf.optionobj(attr).default) for attr in IMPORTANT_ATTRS])
+        # self.ATTR_DEFAULTS = dict([(attr, RepoConf.optionobj(attr).default) for attr in IMPORTANT_ATTRS])
+        self._set_attr_defaults()
         self.problem = False
+
+    def _set_attr_defaults(self):
+        self.ATTR_DEFAULTS = dict()
+        for attr in IMPORTANT_ATTRS:
+            try:
+                self.ATTR_DEFAULTS[attr] = RepoConf.optionobj(attr).default
+            except KeyError:
+                IMPORTANT_ATTRS.remove(attr)
 
     def get_overrides_and_repos(self):
         overrides = self.cp.getContentOverrides(self.consumer_uuid)


### PR DESCRIPTION
Re-implemented `repofile`-based RHSM repo check for systems with
`subscription-manager` versions which don't support content overrides,
added logic for systems without `yum-plugin-priorities` installed to
prevent useless exception throwing.

Added `CheckSources.override_supported` to indicate that a version of
`subscription-manager` which supports content overrides is installed,
`CheckSources.use_override` now means that `override_supported` is true
and that `subscription-manager` is managing the repository configuration
on this host (i.e. `manage_repos` is set to `1` in
`/etc/rhsm/rhsm.conf`)

Added some missing method documentation

Fixed typos in RHN exclusion advice output, added note for RHN advice to
create `INI` sections that don't already exist, added quotes around
`INI` section names.

Enterprise Bug: 1174193
https://bugzilla.redhat.com/show_bug.cgi?id=1174193
Enterprise Bug: 1175200
https://bugzilla.redhat.com/show_bug.cgi?id=1175200
Enterprise Bug: 1174194
https://bugzilla.redhat.com/show_bug.cgi?id=1174194
