### PR TITLE
Add `node-eap-6.3` role to support eap-6.3 channel

### DIFF
--- a/admin/yum-validator/etc/repos.ini
+++ b/admin/yum-validator/etc/repos.ini
@@ -24,6 +24,14 @@ role = node-eap
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
 
+[jb-eap-6.3-for-rhel-6-server-rpms]
+subscription = rhsm
+product = jboss
+product_version = 1.2, 2.0, 2.1, 2.2
+role = node-eap-6.3
+key_pkg = openshift-origin-cartridge-jbosseap
+exclude = httpd, httpd-tools, mod_ssl
+
 [rhel-server-rhscl-6-rpms]
 subscription = rhsm
 product = rhscl
@@ -175,6 +183,14 @@ subscription = rhn
 product = jboss
 product_version = 1.2, 2.0, 2.1, 2.2
 role = node-eap
+key_pkg = openshift-origin-cartridge-jbosseap
+exclude = httpd, httpd-tools, mod_ssl
+
+[jbappplatform-6.3-x86_64-server-6-rpm]
+subscription = rhn
+product = jboss
+product_version = 1.2, 2.0, 2.1, 2.2
+role = node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 exclude = httpd, httpd-tools, mod_ssl
 

--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -27,7 +27,7 @@ SUBS_NAME = {UNKNOWN: '', RHSM: 'Red Hat Subscription Manager',
              RHN: 'RHN Classic or RHN Satellite', YUM: 'Yum'}
 VALID_SUBS = SUBS_NAME.keys()[1:]
 ATTACH_ENTITLEMENTS_URL = 'https://access.redhat.com/site/articles/522923'
-VALID_ROLES = ['node', 'broker', 'client', 'node-eap', 'node-fuse', 'node-amq']
+VALID_ROLES = ['node', 'broker', 'client', 'node-eap', 'node-eap-6.3', 'node-fuse', 'node-amq']
 WORKING_YCM_NVR = ('yum', '3.2.29', '47.el6')
 
 def flatten_uniq(llist):
@@ -880,7 +880,7 @@ class OpenShiftYumValidator(object):
             self.guess_role()
         if self.opts.role:
             self.opts.role = [xx.lower() for xx in self.opts.role]
-            for role in ['node-eap', 'node-fuse', 'node-amq']:
+            for role in ['node-eap', 'node-eap-6.3', 'node-fuse', 'node-amq']:
                 if role in self.opts.role and not 'node' in self.opts.role:
                     self.opts.role.append('node')
             if 'broker' in self.opts.role and not 'client' in self.opts.role:
@@ -889,6 +889,8 @@ class OpenShiftYumValidator(object):
                                  'enables --role=client to ensure /usr/bin/rhc '
                                  'is available for testing and '
                                  'troubleshooting.')
+                if 'node-eap-6.3' in self.opts.role and 'node-eap' in self.opts.role:
+                    self.opts.role.remove('node-eap')
 
     def run_priority_checks(self):
         if not (self.verify_priorities() or self.opts.report_all):


### PR DESCRIPTION
In order to support the "6.3.3+ only" JBoss EAP channels in RHSM and
RHN, a new role - `node-eap-6.3` - is added. Specifying both the
`node-eap` and `node-eap-6.3` roles on the command line is equivalent to
specifying only `node-eap-6.3`.