### PR TITLE
Update repos.ini for node-eap-6.3

### DIFF
--- a/admin/yum-validator/etc/repos.ini
+++ b/admin/yum-validator/etc/repos.ini
@@ -66,7 +66,7 @@ key_pkg = rhc
 subscription = rhsm
 product = ose
 product_version = 1.2
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHSM 2.0 repos
@@ -96,7 +96,7 @@ key_pkg = rhc
 subscription = rhsm
 product = ose
 product_version = 2.0
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHSM 2.1 repos
@@ -126,7 +126,7 @@ key_pkg = rhc
 subscription = rhsm
 product = ose
 product_version = 2.1
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHSM 2.2 repos
@@ -157,7 +157,7 @@ key_pkg = rhc
 subscription = rhsm
 product = ose
 product_version = 2.2
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHN Common
@@ -228,7 +228,7 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 1.2
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHN 2.0 repos
@@ -258,7 +258,7 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 2.0
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHN 2.1 repos
@@ -288,7 +288,7 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 2.1
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 # RHN 2.2 repos
@@ -319,7 +319,7 @@ key_pkg = rhc
 subscription = rhn
 product = ose
 product_version = 2.2
-role = node-eap
+role = node-eap, node-eap-6.3
 key_pkg = openshift-origin-cartridge-jbosseap
 
 ### Premium cartridges ###


### PR DESCRIPTION
Had forgotten to add the `node-eap-6.3` role to the OpenShift jbosseap
cart channels.