### PR TITLE
Fixes for enterprise add node workflow

### DIFF
--- a/oo-install/lib/installer/question.rb
+++ b/oo-install/lib/installer/question.rb
@@ -30,7 +30,7 @@ module Installer
         role = type.split(':')[1].to_sym
         choose do |menu|
           menu.header = text
-          deployment.send(Installer::Deployment.list_map[role]).each do |host_instance|
+          deployment.send(Installer::Deployment.list_map[role]).select{|h| h.install_status != :validated}.each do |host_instance|
             menu.choice(host_instance.summarize) { workflow_cfg[id] = host_instance.host }
           end
         end


### PR DESCRIPTION
- Register dns for node being added
- Do not fail when adding a node using the add node workflow for missing
  passwords
- Automatically sync passwords if any hosts have entered or passed the
  configure step, do not allow for overriding
- Fix bug where add node workflow would complete with no action taken
- Reset broker state to the proper state prior to :post_deploy to ensure that
  the broker attempts to add the node to the configured district