### PR TITLE
Stop `YumUtilBase` from breaking o-a-y-v's logger

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -75,7 +75,7 @@ class OpenShiftYumValidator(object):
     def _setup_logger(self):
         self.opts.loglevel = logging.INFO
         # TODO: log to file if specified, with requested severity
-        self.logger = logging.getLogger()
+        self.logger = logging.getLogger(name='oo-admin-yum-validator')
         self.logger.setLevel(self.opts.loglevel)
         ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(self.opts.loglevel)


### PR DESCRIPTION
The `logger` object in `oo-admin-yum-validator` was initialized as the
`root` logger (with `logging.getLogger()`, but it should have been
initialized with a unique name. Some change in `YumUtilBase` in the RHEL
6.7 beta release modified the `root` logger, with the effect that
messages no longer appeared on `stdout`.

This change initializes the `logger` object with a
name ("`oo-admin-yum-validator`"), which prevents it from being
clobbered as before.

Enterprise bug 1221024
https://bugzilla.redhat.com/show_bug.cgi?id=1221024