### PR TITLE
openshift.ks clean-ups and features

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2307,11 +2307,11 @@ install_rsync_pub_key()
     if [[ $? -ne 0 ]]; then
       sleep 5
     else
-      ssh-keygen -lf /dev/stdin <<< $cert
+      ssh-keygen -lf /dev/stdin <<< "$cert"
       if [[ $? -ne 0 ]]; then
         break
       else
-        echo $cert >> /root/.ssh/authorized_keys
+        echo "$cert" >> /root/.ssh/authorized_keys
         echo "OpenShift node: SSH key downloaded from broker successfully."
         chmod 644 /root/.ssh/authorized_keys
         return

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1892,7 +1892,7 @@ $routingPolicy
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
-        If enabling the web console, you should make sure to require 
+        If enabling the web console, you should make sure to require
         authentication in jetty.xml and configure the admin/user
         passwords in jetty-realm.properties.
 
@@ -2321,7 +2321,7 @@ configure_httpd_auth()
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
           -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
           > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -15,6 +15,24 @@ CONF_NO_NTP=true
 # the log more useful.
 set -x
 
+set -euo pipefail
+
+annotate()
+{
+  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+}
+trap 'echo "Finished with exitcode $?" >&4' EXIT
+# <> redirection requires disabling posix.
+set +o posix
+exec 5>&1 \
+  1<> >(annotate O >&5) \
+  2<> >(annotate E >&5) \
+  3<> >(annotate D >&5) \
+  4<> >(annotate I >&5) \
+  5>&-
+BASH_XTRACEFD=3
+echo "Started $0 $*" >&4
+
 
 ########################################################################
 

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -741,30 +741,39 @@ install_cartridges()
 # given value to the setting.  If it does not, then comment out any
 # existing setting and add the given setting.
 #
-# The search pattern is /^\s*name\s*=\s*value\s*(|#.*)$/.  The
-# added line will be in the form 'name = value' or, if a short comment
-# is specified, 'name = value # short comment'.  If a long comment is
-# specified, a blank line followed by '# long comment' will be added
-# before the line for the setting itself.
+# The search pattern is /^\s*name\s*=\s*['"]?value\['"]?s*(|#.*)$/.  The added
+# line will be in the form 'name=value' or, if a non-empty short comment is
+# specified, 'name=value # short comment'.  Note that quotation marks are
+# tolerated when checking whether the setting is already present, but are not
+# added when adding the setting unless they are explicitly passed in with the
+# value.  If a long comment is specified using the fifth and possibly subsequent
+# arguments, a blank line followed by '# long comment' (one line per argument)
+# will be added before the line for the setting itself.
 #
 # $1 = configuration file's filename
 # $2 = setting name
 # $3 = value
 # $4 = short comment (optional)
-# $5 = long comment (optional)
+# $5- = long comment (optional)
 set_conf()
 {
-  if ! grep -q "^\\s*$2\\s*=\\s*$3\\s*\\(\\|#.*\\)$" "$1"
+  if ! grep -q "^\\s*$2\\s*=\\s*['\"]\\?$3['\"]\\?\\s*\\(\\|#.*\\)$" "$1"
   then
     sed -i -e "s/^\\s*$2\\s*=\\s*/#&/" "$1"
-    if [[ -n "$5" ]]
+    if [[ -n "${5-}" ]]
     then
       echo >> "$1"
-      echo "# $5" >> "$1"
+      args=( "$@" )
+      printf '# %s\n' "${args[@]:4}" >> "$1"
     fi
-    echo "$2 = $3${4:+ #$4}" >> "$1"
+    echo "$2=$3${4:+ #$4}" >> "$1"
   fi
 }
+
+set_mongodb() { set_conf /etc/mongodb.conf "$@"; }
+set_broker() { set_conf /etc/openshift/broker.conf "$@"; }
+set_console() { set_conf /etc/openshift/console.conf "$@"; }
+set_node() { set_conf /etc/openshift/node.conf "$@"; }
 
 # Fix up SELinux policy on the broker.
 configure_selinux_policy_on_broker()
@@ -1093,13 +1102,6 @@ configure_datastore_add_replicants()
   done
 
   set -x
-}
-
-# $1 = setting name
-# $2 = value
-set_mongodb()
-{
-  set_conf /etc/mongodb.conf "$1" "$2"
 }
 
 configure_datastore()
@@ -1887,12 +1889,12 @@ register_named_entries()
 configure_network()
 {
   # Ensure interface is configured to come up on boot
-  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+  set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
   if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
-    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$interface
-    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+    set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
+    set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
   fi
 }
 
@@ -1923,10 +1925,9 @@ update_controller_gear_size_configs()
 {
   # Configure the valid gear sizes, default gear capabilities and default gear
   # size for the broker
-  sed -i -e "s/^VALID_GEAR_SIZES=.*/VALID_GEAR_SIZES=\"${valid_gear_sizes}\"/" \
-      -e "s/^DEFAULT_GEAR_CAPABILITIES=.*/DEFAULT_GEAR_CAPABILITIES=\"${default_gear_capabilities}\"/" \
-      -e "s/^DEFAULT_GEAR_SIZE=.*/DEFAULT_GEAR_SIZE=\"${default_gear_size}\"/" \
-      /etc/openshift/broker.conf
+  set_broker VALID_GEAR_SIZES "$valid_gear_sizes"
+  set_broker DEFAULT_GEAR_CAPABILITIES "$default_gear_capabilities"
+  set_broker DEFAULT_GEAR_SIZE "$default_gear_size"
 
   RESTART_NEEDED=true
 }
@@ -1941,40 +1942,34 @@ configure_controller()
 
   # Configure the broker with the correct domain name, and use random salt
   # to the data store (the host running MongoDB).
-  sed -i -e "s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/" \
-      /etc/openshift/broker.conf
-  echo AUTH_SALT=${broker_auth_salt} >> /etc/openshift/broker.conf
+  set_broker CLOUD_DOMAIN "$domain"
+  set_broker AUTH_SALT "$broker_auth_salt"
 
   update_controller_gear_size_configs
 
   # Configure the session secret for the broker
-  sed -i -e "s/# SESSION_SECRET=.*$/SESSION_SECRET=${broker_session_secret}/" \
-      /etc/openshift/broker.conf
+  set_broker SESSION_SECRET "$broker_session_secret"
 
   # Configure the session secret for the console
-  if [[ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]]
-  then
-    echo "SESSION_SECRET=${console_session_secret}" >> /etc/openshift/console.conf
-  fi
+  set_console SESSION_SECRET "$console_session_secret"
 
   if [[ ${datastore_replicants} =~ , ]] || ! datastore
   then
     # MongoDB may be installed remotely or replicated, so configure it
     # with the given hostname(s).
-    sed -i -e "s/^MONGO_HOST_PORT=.*$/MONGO_HOST_PORT=\"${datastore_replicants}\"/" /etc/openshift/broker.conf
+    set_broker MONGO_HOST_PORT "$datastore_replicants"
   fi
 
   # configure MongoDB access
-  sed -i -e "s/MONGO_PASSWORD=.*$/MONGO_PASSWORD=\"${mongodb_broker_password}\"/
-            s/MONGO_USER=.*$/MONGO_USER=\"${mongodb_broker_user}\"/
-            s/MONGO_DB=.*$/MONGO_DB=\"${mongodb_name}\"/" \
-      /etc/openshift/broker.conf
+  set_broker MONGO_PASSWORD "$mongodb_broker_password"
+  set_broker MONGO_USER "$mongodb_broker_user"
+  set_broker MONGO_DB "$mongodb_name"
 
   # configure broker logs for syslog
   [[ "$log_to_syslog" = *broker* ]] && \
-    sed -i -e '/SYSLOG_ENABLED=/ cSYSLOG_ENABLED="true"' /etc/openshift/broker.conf
+    set_broker SYSLOG_ENABLED true
   [[ "$log_to_syslog" = *console* ]] && \
-    echo 'SYSLOG_ENABLED="true"' >> /etc/openshift/console.conf
+    set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
@@ -1996,9 +1991,8 @@ configure_messaging_plugin()
 
   local file=/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
   cp "$file"{.example,}
-  sed -i -e "s/DISTRICTS_FIRST_UID=.*/DISTRICTS_FIRST_UID=${district_first_uid}/
-             s/DISTRICTS_MAX_CAPACITY=.*/DISTRICTS_MAX_CAPACITY=${pool_size}/
-            " $file
+  set_conf "$file" DISTRICTS_FIRST_UID "$district_first_uid"
+  set_conf "$file" DISTRICTS_MAX_CAPACITY "$pool_size"
   RESTART_NEEDED=true
 }
 
@@ -2193,7 +2187,7 @@ configure_hostname()
 {
   if [[ ! "$hostname" =~ ^[0-9.]*$ ]]  # hostname is not just an IP
   then
-    sed -i -e "s/HOSTNAME=.*/HOSTNAME=${hostname}/" /etc/sysconfig/network
+    set_conf /etc/sysconfig/network HOSTNAME "$hostname"
     hostname "${hostname}"
   fi
 }
@@ -2207,27 +2201,22 @@ configure_node()
   elif [[ -f "$resrc.${node_profile}" ]]; then
     cp "$resrc.${node_profile}" $resrc
   fi
-  sed -i -e "s/^node_profile=.*$/node_profile=${node_profile_name}/" $resrc
+  set_conf "$resrc" node_profile "$node_profile_name"
 
-  local conf=/etc/openshift/node.conf
-  sed -i -e "s/^PUBLIC_IP=.*$/PUBLIC_IP=${node_ip_addr}/;
-             s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/;
-             s/^PUBLIC_HOSTNAME=.*$/PUBLIC_HOSTNAME=${hostname}/;
-             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/;
-             s/^[# ]*EXTERNAL_ETH_DEV=.*$/EXTERNAL_ETH_DEV='${interface}'/" \
-      $conf
+  set_node PUBLIC_IP "$node_ip_addr"
+  set_node CLOUD_DOMAIN "$domain"
+  set_node PUBLIC_HOSTNAME "$hostname"
+  set_node BROKER_HOST "$broker_hostname"
+  set_node EXTERNAL_ETH_DEV "$interface"
+
   if [[ "$ports_per_gear" != 5 ]]; then
-    sed -i -e "/PORTS_PER_USER=/ cPORTS_PER_USER=${ports_per_gear}" $conf
-    # If PORTS_PER_USER is not already there, we need to add it.
-    grep -q '^PORTS_PER_USER' $conf || sed -i -e "$ a\\
-\\
-# Number of proxy ports available per gear. Increasing the ports per gear requires reducing\\
-# the number of UIDs the district has so that the ports allocated to all UIDs fit in the\\
-# proxy port range.\\
-PORTS_PER_USER=${ports_per_gear}
-                                                 " $conf
+    set_node PORTS_PER_USER "$ports_per_gear" '' \
+     'Number of proxy ports available per gear. Increasing the ports per gear'\
+     'requires reducing the number of UIDs the district has so that the ports'\
+     'allocated to all UIDs fit in the proxy port range.'
   fi
 
+  local conf=/etc/openshift/node.conf
   case "$node_apache_frontend" in
     mod_rewrite)
       sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" $conf
@@ -2242,7 +2231,8 @@ PORTS_PER_USER=${ports_per_gear}
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
-    sed -i -e "/PROXY_PORTS/ cPROXY_PORTS=${port_list}" /etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf
+    local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'
+    set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
   echo $broker_hostname > /etc/openshift/env/OPENSHIFT_BROKER_HOST
@@ -2279,18 +2269,14 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
   fi
   if is_true "$node_log_context"; then
     # Annotate the frontend logs with UUIDs.
-    sed -i -e '
-      s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
-      s/^.*PLATFORM_LOG_CONTEXT_ATTRS=.*/PLATFORM_LOG_CONTEXT_ATTRS=request_id,app_uuid,container_uuid/
-    ' /etc/openshift/node.conf
+    set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
+    set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
   if [[ -n "$metrics_interval" ]]; then
     # Configure watchman with given the interval.
-    sed -i -e "
-      s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
-      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$metrics_interval/
-    " /etc/openshift/node.conf
+    set_node WATCHMAN_METRICS_ENABLED 'true'
+    set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
   fi
 }
 
@@ -3038,7 +3024,7 @@ configure_host()
   is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
-  sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;
+  set_conf /etc/grub.conf timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1599,11 +1599,6 @@ EOF
   chown 'apache:apache' "$mcollective_cfg"
   chmod 640 "$mcollective_cfg"
 
-  # Make sure the MCollective client log is created with proper ownership.
-  # If root owns it, the broker (apache user) can't log to it.
-  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
-  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
-
   RESTART_NEEDED=true
 }
 

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -403,7 +403,7 @@ gpgcheck=0
 sslverify=false
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} $yum_exclude_pkgs
+exclude=${exclude[$repo]-} $yum_exclude_pkgs
 
 YUM
     fi

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -3718,7 +3718,7 @@ do
   [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 
 # In the case of a kickstart, some services will not be able to start, and the
 # host will automatically reboot anyway after the kickstart script completes.

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -134,7 +134,7 @@ display_passwords()
 
 configure_repos()
 {
-  echo "OpenShift: Begin configuring repos."
+  echo 'OpenShift: Begin configuring repos.'
   # Determine which channels we need and define corresponding predicate
   # functions.
 
@@ -207,7 +207,7 @@ configure_repos()
       ;;
   esac
 
-  echo "OpenShift: Completed configuring repos."
+  echo 'OpenShift: Completed configuring repos.'
 }
 
 configure_yum_repos()
@@ -627,15 +627,15 @@ configure_outgoing_http_proxy()
     https_proxy_auth="${outgoing_https_proxy#*//}"
 
     # Split on '@' into (possibly) authentication credentials and the rest.
-    read http_proxy_auth http_proxy_host_port <<<"${http_proxy_auth//@/ }"
-    read https_proxy_auth https_proxy_host_port <<<"${https_proxy_auth//@/ }"
+    read http_proxy_auth http_proxy_host_port <<< "${http_proxy_auth//@/ }"
+    read https_proxy_auth https_proxy_host_port <<< "${https_proxy_auth//@/ }"
 
     if [[ -z "$http_proxy_host_port" ]]
     then # No credentials were specified.
       http_proxy_host_port="$http_proxy_auth"
       http_proxy_auth=
     else
-      read http_proxy_user http_proxy_pass <<<"${http_proxy_auth//:/ }"
+      read http_proxy_user http_proxy_pass <<< "${http_proxy_auth//:/ }"
     fi
 
     if [[ -z "$https_proxy_host_port" ]]
@@ -643,7 +643,7 @@ configure_outgoing_http_proxy()
       https_proxy_host_port="$https_proxy_auth"
       https_proxy_auth=
     else
-      read https_proxy_user https_proxy_pass <<<"${https_proxy_auth//:/ }"
+      read https_proxy_user https_proxy_pass <<< "${https_proxy_auth//:/ }"
     fi
 
     # Strip any trailing slashes (and possibly more, but there shouldn't be
@@ -652,8 +652,8 @@ configure_outgoing_http_proxy()
     https_proxy_host_port="${https_proxy_host_port%/*}"
 
     # Split on ':' into hostname and (possibly) port parts.
-    read http_proxy_hostname http_proxy_port <<<"${http_proxy_host_port//:/ }"
-    read https_proxy_hostname https_proxy_port <<<"${https_proxy_host_port//:/ }"
+    read http_proxy_hostname http_proxy_port <<< "${http_proxy_host_port//:/ }"
+    read https_proxy_hostname https_proxy_port <<< "${https_proxy_host_port//:/ }"
 
     local proxies_stanza="\
 <settings>
@@ -790,7 +790,7 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  if grep 'Enterprise Linux Server release 6.4' '/etc/redhat-release' && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
   then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
@@ -903,7 +903,7 @@ parse_cartridges()
     local metapkg
     for metapkg in "${meta[@]}"
     do
-      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      if [[ "${pkgs[@]}" =~ "-$metapkg" ]]
       then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
@@ -1116,8 +1116,8 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
-  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/tmp.conf'
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/shm.conf'
 }
 
 configure_cgroups_on_node()
@@ -1704,7 +1704,7 @@ configure_activemq()
 EOF
   fi
 
-  cat <<EOF > /etc/activemq/activemq.xml
+  cat <<EOF > '/etc/activemq/activemq.xml'
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
@@ -2127,7 +2127,7 @@ register_named_entries()
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<"${host_ip//:/ }"
+    read host ip <<< "${host_ip//:/ }"
     if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
@@ -2168,9 +2168,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
-  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-${interface}.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -2425,8 +2425,8 @@ configure_router()
       #
       # These files should be copies of /etc/pki/tls/certs/localhost.crt and
       # /etc/pki/tls/private/localhost.key, respectively, from a node host.
-      if [[ -e /etc/pki/tls/certs/node.example.com.crt &&
-            -e /etc/pki/tls/private/node.example.com.key ]]
+      if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
+            -e '/etc/pki/tls/private/node.example.com.key' ]]
       then
         service nginx16-nginx start
       fi
@@ -2449,7 +2449,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker.
   ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
-  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* '/etc/openshift/'
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
   cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
@@ -2529,7 +2529,7 @@ configure_node()
      'allocated to all UIDs fit in the proxy port range.'
   fi
 
-  local conf=/etc/openshift/node.conf
+  local conf='/etc/openshift/node.conf'
   case "$node_apache_frontend" in
     mod_rewrite)
       sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
@@ -2549,12 +2549,12 @@ configure_node()
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > '/etc/openshift/env/OPENSHIFT_BROKER_HOST'
+  echo "$domain" > '/etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN'
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf
+      '/etc/httpd/conf.d/000001_openshift_origin_node_servername.conf'
 
   configure_node_logs
   RESTART_NEEDED=true
@@ -2575,7 +2575,7 @@ configure_node_logs()
 PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
-    ' /etc/openshift/node.conf
+    ' '/etc/openshift/node.conf'
     echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
@@ -3019,10 +3019,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # ActiveMQ service are assumed to be the current host if we are
   # installing the component now or the broker host otherwise.
   if named
-  then
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
-  else
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
+  then named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
+  else named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
   fi
 
   # The nameservers to which named on the broker will forward requests.
@@ -3086,10 +3084,10 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   metrics_interval="${CONF_METRICS_INTERVAL-}"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
-  broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
+  broker && default_districts="${CONF_DEFAULT_DISTRICTS:-true}"
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
-  broker && district_mappings=${CONF_DISTRICT_MAPPINGS-}
+  broker && district_mappings="${CONF_DISTRICT_MAPPINGS-}"
 
   local randomized
 
@@ -3534,7 +3532,7 @@ restart_services()
 run_diagnostics()
 {
   echo 'OpenShift: Begin running oo-diagnostics.'
-  date +%Y-%m-%d-%H:%M:%S
+  date '+%Y-%m-%d-%H:%M:%S'
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2365,9 +2365,13 @@ configure_routing_daemon()
   set_routing_daemon ACTIVEMQ_PASSWORD "$routing_plugin_pass"
   set_routing_daemon CLOUD_DOMAIN "$domain"
 
-  [[ "$router" = nginx ]] && service openshift-routing-daemon start
+  # Comment out any settings that are not related to the configured
+  # load-balancer.
+  [[ "$router" != f5 ]] && sed -i -e 's/^\(UPDATE_INTERVAL\|MONITOR_\|VIRTUAL_\|BIGIP_\|LBAAS_\)/#&/' '/etc/openshift/routing-daemon.conf'
+  [[ "$router" != nginx ]] && sed -i -e 's/^NGINX_/#&/' '/etc/openshift/routing-daemon.conf'
 
-  return 0
+  chkconfig openshift-routing-daemon on
+  RESTART_NEEDED=true
 }
 
 configure_routing_plugin()
@@ -2428,17 +2432,8 @@ configure_router()
       firewall_allow[https]='tcp:443'
       firewall_allow[http]='tcp:80'
       setsebool -P httpd_can_network_connect=true
-      # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
-      # and /etc/pki/tls/private/node.example.com.key exist because nginx will
-      # fail to start without them.
-      #
-      # These files should be copies of /etc/pki/tls/certs/localhost.crt and
-      # /etc/pki/tls/private/localhost.key, respectively, from a node host.
-      if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
-            -e '/etc/pki/tls/private/node.example.com.key' ]]
-      then
-        service nginx16-nginx start
-      fi
+      chkconfig nginx16-nginx on
+      RESTART_NEEDED=true
       ;;
   esac
 }
@@ -3205,8 +3200,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker && openshift_user1="${CONF_OPENSHIFT_USER1:-demo}"
   broker && assign_pass openshift_password1 changeme CONF_OPENSHIFT_PASSWORD1
 
+  enable_ha="${CONF_ENABLE_HA-false}"
+  router="${CONF_ROUTER-}"
+
   # auth info for the topic from the sample routing SPI plugin
-  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
+  local default_enable_routing_plugin=false
+  broker && [[ -n "$router" ]] && default_enable_routing_plugin=true
+  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-$default_enable_routing_plugin}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
   assign_pass routing_plugin_pass routinginfopasswd CONF_ROUTING_PLUGIN_PASS
 
@@ -3215,9 +3215,6 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   outgoing_http_proxy="${CONF_HTTP_PROXY-}"
   outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
-
-  enable_ha="${CONF_ENABLE_HA-false}"
-  router="${CONF_ROUTER-}"
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
@@ -3542,6 +3539,23 @@ restart_services()
   node && service openshift-node-web-proxy restart
   node && is_true "$enable_sni_proxy" && service openshift-sni-proxy restart
   node && service openshift-watchman restart
+
+  if router && [[ "$router" = nginx ]]
+  then
+    service openshift-routing-daemon restart
+
+    # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
+    # and /etc/pki/tls/private/node.example.com.key exist because nginx will
+    # fail to start without them.
+    #
+    # These files should be copies of /etc/pki/tls/certs/localhost.crt and
+    # /etc/pki/tls/private/localhost.key, respectively, from a node host.
+    if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
+          -e '/etc/pki/tls/private/node.example.com.key' ]]
+    then
+      service nginx16-nginx restart
+    fi
+  fi
 
   # Ensure OpenShift facts are updated.
   node && '/etc/cron.minutely/openshift-facts'

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1225,7 +1225,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
+  printf '\nAcceptEnv GIT_SSH\n' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
   sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -22,9 +22,19 @@ set -x
 # hardware clock with that.
 synchronize_clock()
 {
+  local need_to_start_ntpd=
+
+  if service ntpd status | grep 'is running'
+  then
+    # Stop ntpd so that ntpdate succeeds.
+    service ntpd stop
+    need_to_start_ntpd=1
+  fi
 
   # Synchronize the system clock using NTP.
   ntpdate clock.redhat.com
+
+  [[ -n "$need_to_start_ntpd" ]] && service ntpd start
 
   # Synchronize the hardware clock to the system clock.
   hwclock --systohc

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -336,7 +336,7 @@ configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [[ -e "${extra_repo_file}" ]]; then
-      echo > "${extra_repo_file}"
+      > "${extra_repo_file}"
   fi
 
   local -A priority=(

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -151,7 +151,7 @@ configure_repos()
   then need_extra_repo() { :; }
   fi
 
-  if activemq || broker || datastore || named
+  if activemq || broker || datastore || named || router
   then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
     # packages.  The ose-infrastructure and ose-node channels also include
@@ -549,6 +549,20 @@ install_rhc_pkg()
   yum_install_or_exit rhc
 }
 
+# Install the router (nginx).
+install_router_pkgs()
+{
+  case "$router" in
+    (f5)
+      # Nothing to do; setting up an F5 instance is outside the scope of this
+      # script.
+      ;;
+    (nginx)
+      yum_install_or_exit nginx16-nginx rubygem-openshift-origin-routing-daemon
+      ;;
+  esac
+}
+
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
@@ -715,6 +729,7 @@ install_broker_pkgs()
   pkgs="$pkgs openshift-origin-console"
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
   is_true "$enable_routing_plugin" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
+  [[ "$router" = f5 ]] && pkgs="$pkgs rubygem-openshift-origin-routing-daemon"
 
   # We use semanage in configure_selinux_policy_on_broker, so we need to
   # install policycoreutils-python.
@@ -962,6 +977,7 @@ set_mongodb() { set_conf /etc/mongodb.conf "$@"; }
 set_broker() { set_conf /etc/openshift/broker.conf "$@"; }
 set_console() { set_conf /etc/openshift/console.conf "$@"; }
 set_node() { set_conf /etc/openshift/node.conf "$@"; }
+set_routing_daemon() { set_conf /etc/openshift/routing-daemon.conf "$@"; }
 
 # Fix up SELinux policy on the broker.
 configure_selinux_policy_on_broker()
@@ -2048,6 +2064,7 @@ configure_hosts_dns()
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
+    router && add_host_to_zone "$router_hostname" "$cur_ip_addr"
   elif [[ "$named_entries" =~ : ]]
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
@@ -2155,6 +2172,18 @@ configure_controller()
 
   # Configure the session secret for the console
   set_console SESSION_SECRET "$console_session_secret"
+
+  if is_true "$enable_ha"
+  then
+    # Enable highly available applications, manage DNS CNAME records for highly
+    # available access to applications where those records will point to the
+    # external router, and grant permission to create HA applications to new
+    # accounts by default.
+    set_broker ALLOW_HA_APPLICATIONS true
+    set_broker MANAGE_HA_DNS true
+    set_broker DEFAULT_ALLOW_HA true
+    set_broker ROUTER_HOSTNAME "$router_hostname"
+  fi
 
   if [[ "$datastore_replicants" =~ , ]] || ! datastore
   then
@@ -2279,6 +2308,23 @@ configure_httpd_auth()
   RESTART_NEEDED=true
 }
 
+configure_routing_daemon()
+{
+  # The routing daemon runs on the broker in the case that $router = f5
+  # or on the router in the case that $router = nginx.
+  [[ -z "$router" ]] && return 0
+  [[ "$router" = f5 ]] && ! broker && return 0
+  [[ "$router" = nginx ]] && ! router && return 0
+
+  set_routing_daemon LOAD_BALANCER "$router"
+  set_routing_daemon ACTIVEMQ_HOST "$activemq_replicants"
+  set_routing_daemon ACTIVEMQ_USER "$routing_plugin_user"
+  set_routing_daemon ACTIVEMQ_PASSWORD "$routing_plugin_pass"
+  set_routing_daemon CLOUD_DOMAIN "$domain"
+
+  [[ "$router" = nginx ]] && service openshift-routing-daemon start
+}
+
 configure_routing_plugin()
 {
   if is_true "$enable_routing_plugin"
@@ -2323,6 +2369,31 @@ EOF
     *)
       echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
+      ;;
+  esac
+}
+
+configure_router()
+{
+  case "$router" in
+    (f5)
+      # Nothing to do; configuration of F5 is outside the scope of this script.
+      ;;
+    (nginx)
+      firewall_allow[https]='tcp:443'
+      firewall_allow[http]='tcp:80'
+      setsebool -P httpd_can_network_connect=true
+      # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
+      # and /etc/pki/tls/private/node.example.com.key exist because nginx will
+      # fail to start without them.
+      #
+      # These files should be copies of /etc/pki/tls/certs/localhost.crt and
+      # /etc/pki/tls/private/localhost.key, respectively, from a node host.
+      if [[ -e /etc/pki/tls/certs/node.example.com.crt &&
+            -e /etc/pki/tls/private/node.example.com.key ]]
+      then
+        service nginx16-nginx start
+      fi
       ;;
   esac
 }
@@ -2547,6 +2618,7 @@ echo_installation_intentions()
   echo "Configuring with named with IP address ${named_ip_addr}."
   broker && echo "Configuring with datastore with hostname ${datastore_hostname}."
   echo "Configuring with activemq with hostname ${activemq_hostname}."
+  echo "Configuring with router with hostname ${router_hostname}."
 }
 
 # Modify console message to show install info
@@ -2686,7 +2758,7 @@ set_defaults()
   # The declare statement below is generated by the following command:
   #
   #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_HA]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTER]= [CONF_ROUTER_HOSTNAME]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
   local setting
@@ -2712,7 +2784,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   actions="${CONF_ACTIONS:-do_all_actions}"
 
   # Following are the different components that can be installed:
-  local components='broker node named activemq datastore'
+  local components='broker node named activemq datastore router'
 
   # By default, each component is _not_ installed.
   local component
@@ -2726,7 +2798,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   for component in ${CONF_INSTALL_COMPONENTS//,/ }
   do
     case "$component" in
-      (broker|node|named|activemq|datastore) ;;
+      (broker|node|named|activemq|datastore|router) ;;
       (*) abort_install "Unrecognized component: $component" ;;
     esac
     eval "$component() { :; }"
@@ -2744,7 +2816,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
   if [[ "$installing_something" = 0 ]]
   then
-    for component in $components
+    for component in ${components//router} # default: all but router
     do
       eval "$component() { :; }"
     done
@@ -2785,6 +2857,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   named_hostname=$(ensure_domain "${CONF_NAMED_HOSTNAME:-ns1}" "$hosts_domain")
   activemq_hostname=$(ensure_domain "${CONF_ACTIVEMQ_HOSTNAME:-activemq}" "$hosts_domain")
   datastore_hostname=$(ensure_domain "${CONF_DATASTORE_HOSTNAME:-datastore}" "$hosts_domain")
+  router_hostname=$(ensure_domain "${CONF_ROUTER_HOSTNAME:-www}" "$domain")
 
   # The hostname name for this host.
   # Note: If this host is, e.g., both a broker and a datastore, we want
@@ -2799,6 +2872,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   then hostname="$activemq_hostname"
   elif datastore
   then hostname="$datastore_hostname"
+  elif router
+  then hostname="$router_hostname"
   fi
 
   # Grab the IP address set during installation.
@@ -3087,6 +3162,9 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   outgoing_http_proxy="${CONF_HTTP_PROXY-}"
   outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
 
+  enable_ha="${CONF_ENABLE_HA-false}"
+  router="${CONF_ROUTER-}"
+
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
 
@@ -3239,6 +3317,7 @@ install_rpms()
   node && install_cartridges
   node && remove_abrt_addon_python
   broker && install_rhc_pkg
+  router && install_router_pkgs
   echo 'OpenShift: Completed installing RPMs.'
 }
 
@@ -3364,6 +3443,9 @@ configure_openshift()
   node && update_openshift_facts_on_node
 
   node && broker && fix_broker_routing
+
+  { broker || router; } && configure_routing_daemon
+  router && configure_router
 
   configure_firewall_add_rules
   node && configure_gear_isolation_firewall

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -209,6 +209,8 @@ configure_ose_yum_repos()
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
+
+  return 0
 }
 
 configure_rhel_repo()
@@ -385,7 +387,7 @@ configure_subscription()
    need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
-   oo-admin-yum-validator -o 2.2 --fix-all $roles # when fixing, rc is always false
+   oo-admin-yum-validator -o 2.2 --fix-all $roles || : # when fixing, rc is always false
    oo-admin-yum-validator -o 2.2 $roles || abort_install # so check when fixes are done
 
    # Normally we could just install o-e-release and it would pull in yum-validator;
@@ -394,6 +396,8 @@ configure_subscription()
    yum_install_or_exit openshift-enterprise-release
    configure_ose_yum_repos # refresh if overwritten by validator
    need_extra_repo && configure_extra_repos
+
+   return 0
 }
 
 configure_rhn_channels()
@@ -487,10 +491,8 @@ yum_install_or_exit()
   echo "OpenShift: yum install $*"
   local count=0
   time while true; do
-    yum install -y $* $disable_plugin
-    if [[ $? -eq 0 ]]; then
-      return
-    elif [[ $count -gt 3 ]]; then
+    yum install -y $* $disable_plugin && return
+    if [[ $count -gt 3 ]]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -919,7 +921,7 @@ configure_quotas_on_node()
 
 configure_idler_on_node()
 {
-  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return
+  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return 0
   cat <<CRON > /etc/cron.hourly/auto-idler
 (
   /usr/sbin/oo-last-access
@@ -1430,7 +1432,7 @@ configure_activemq()
   if is_true "${enable_routing_plugin}"
   then
     schedulerSupport='schedulerSupport="true"'
-    IFS= read -r -d '' routingPolicy <<'EOF'
+    IFS= read -r -d '' routingPolicy <<'EOF' || :
           <redeliveryPlugin fallbackToDeadLetter="true"
                             sendToDlqIfMaxRetriesExceeded="true">
             <redeliveryPolicyMap>
@@ -1850,6 +1852,8 @@ configure_hosts_dns()
   else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $named_entries"
   fi
+
+  return 0
 }
 
 # An alternate method for registering against a running named
@@ -1872,6 +1876,7 @@ register_named_entries()
     fi
   done
   is_false "$failed" && echo "OpenShift: Completed updating host DNS entries."
+  return 0
 }
 
 configure_network()
@@ -2303,12 +2308,11 @@ install_rsync_pub_key()
   local cert
   while [[ `date +%s` -lt $end ]]; do
     # Try to get the public key from the broker.
-    cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
-    if [[ $? -ne 0 ]]; then
+    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}"); then
       sleep 5
     else
-      ssh-keygen -lf /dev/stdin <<< "$cert"
-      if [[ $? -ne 0 ]]; then
+      if ! ssh-keygen -lf /dev/stdin <<< "$cert"
+      then
         break
       else
         echo "$cert" >> /root/.ssh/authorized_keys
@@ -2887,6 +2891,7 @@ init_message()
 {
   echo_installation_intentions
   [[ "$environment" = ks ]] && configure_console_msg
+  return 0
 }
 
 validate_preflight()
@@ -3137,7 +3142,7 @@ configure_openshift()
   configure_firewall_add_rules
   node && configure_gear_isolation_firewall
 
-  sysctl -p
+  sysctl -p || :
   restorecon -rv /etc/openshift
 
   PASSWORDS_TO_DISPLAY=true
@@ -3223,10 +3228,8 @@ configure_districts()
       # Query the node for the node profile via MCollective.
       profile=""
       for i in {1..10}; do
-        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
-        if [[ $? -eq 0 ]]; then
-          break;
-        fi
+        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
+         && break
         sleep 10
       done
       if [[ -n "$profile" ]]; then

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -909,8 +909,13 @@ configure_quotas_on_node()
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
     time restorecon "${geardata_mnt}"
+
+    # quotacheck fails if quotas are enabled.
+    quotaoff "${geardata_mnt}"
+
     # Generate user quota info for the mount point.
     time quotacheck -cmug "${geardata_mnt}"
+
     # Fix the SELinux label of the created quota file.
     restorecon "${geardata_mnt}"/aquota.user
 

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2102,7 +2102,9 @@ fix_broker_routing()
   case "$node_apache_frontend" in
     vhost)
       # node vhost obscures the broker vhost unless we bring the broker conf forward
-      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      if [[ ! -e '/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf' ]]
+      then ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      fi
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2007,9 +2007,9 @@ configure_controller()
   set_broker MONGO_DB "$mongodb_name"
 
   # configure broker logs for syslog
-  [[ "$log_to_syslog" = *broker* ]] && \
+  [[ "$log_to_syslog" = *broker* ]] &&
     set_broker SYSLOG_ENABLED true
-  [[ "$log_to_syslog" = *console* ]] && \
+  [[ "$log_to_syslog" = *console* ]] &&
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
@@ -2272,7 +2272,7 @@ configure_node()
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -1109,6 +1109,10 @@ configure_datastore()
   # Require authentication.
   set_mongodb auth true
 
+  # Workaround for oo-accept-broker, which performs a strict pattern match for
+  # 'auth = true' (with spaces).
+  sed -i -e 's/auth=true/auth = true/' '/etc/mongodb.conf'
+
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -571,7 +571,7 @@ install_router_pkgs()
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
-  # set_conf expects there to be a new line.
+  # set_conf expects there to be a newline character on the last line.
   echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
@@ -615,9 +615,9 @@ configure_outgoing_http_proxy()
       > '/etc/openshift/skel/.npmrc'
 
     # Configure Maven for JBoss.
-    # So far all this fancy^H^H^H^H^Had hoc, good-enough parsing is needed only
-    # for Maven, but it could be moved earlier in the function if its results
-    # could be used elsewhere.
+    # So far we only need to parse the URL for Maven, but it could be moved
+    # earlier in this function if future additions to this function have some
+    # use for the URL components.
     local http_proxy_auth https_proxy_auth \
           http_proxy_user http_proxy_pass https_proxy_user https_proxy_pass \
           http_proxy_host_port https_proxy_host_port \

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -17,21 +17,21 @@ set -x
 
 set -euo pipefail
 
-annotate()
-{
-  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
-}
-trap 'echo "Finished with exitcode $?" >&4' EXIT
-# <> redirection requires disabling posix.
-set +o posix
-exec 5>&1 \
-  1<> >(annotate O >&5) \
-  2<> >(annotate E >&5) \
-  3<> >(annotate D >&5) \
-  4<> >(annotate I >&5) \
-  5>&-
-BASH_XTRACEFD=3
-echo "Started $0 $*" >&4
+#annotate()
+#{
+#  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+#}
+#trap 'echo "Finished with exitcode $?" >&4' EXIT
+## <> redirection requires disabling posix.
+#set +o posix
+#exec 5>&1 \
+#  1<> >(annotate O >&5) \
+#  2<> >(annotate E >&5) \
+#  3<> >(annotate D >&5) \
+#  4<> >(annotate I >&5) \
+#  5>&-
+#BASH_XTRACEFD=3
+#echo "Started $0 $*" >&4
 
 
 ########################################################################

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -685,6 +685,7 @@ configure_outgoing_http_proxy()
     # an external tool instead?).
     shopt -s extglob # for *()
     proxies_stanza="${proxies_stanza//$'\n'*([[:space:]])$'\n'/$'\n'}"
+    shopt -u extglob
     mkdir -p '/etc/openshift/skel/.m2'
     local settings_xml='/etc/openshift/skel/.m2/settings.xml'
     if ! [[ -e "$settings_xml" ]] || ! grep -q '<proxies>' "$settings_xml"

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -3092,7 +3092,9 @@ configure_host()
   set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  if broker || node
+  then sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  fi
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -82,11 +82,11 @@ display_passwords()
 
   for k in "${!passwords[@]}"
   do
-    out_string=""
-    matchingvar=""
+    out_string=
+    matchingvar=
     for postfix in password password1 pass
     do
-      vprefix=${k%${postfix}}
+      vprefix="${k%$postfix}"
       [[ "$vprefix" != "$k" ]] && break
     done
 
@@ -94,22 +94,22 @@ display_passwords()
     do
       if [[ -n "${!v+x}" ]]
       then
-        matchingvar=$v
+        matchingvar="$v"
         break
       fi
     done
 
-    formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}
+    formattedprefix="${vprefix//_/ }"
+    for s in "${!subs[@]}"
     do
-      formattedprefix=${formattedprefix//${s}/${subs[$s]}}
+      formattedprefix="${formattedprefix//${s}/${subs[$s]}}"
     done
 
     out_string+="$formattedprefix"
     [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
     [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
-    echo $out_string
+    echo "$out_string"
   done
   set -x
 }
@@ -159,16 +159,16 @@ configure_repos()
 
     # The jbosseap and jbossas cartridges require the jbossas packages
     # in the jbappplatform channel.
-    is_true "${need_jbosseap}" \
+    is_true "$need_jbosseap" \
              && need_jbosseap_cartridge_repo() { :; } \
              && need_jbosseap_repo() { :; }
 
     # The jbossews cartridge requires the tomcat packages in the jb-ews channel.
-    is_true "${need_jbossews}" && need_jbossews_repo() { :; }
+    is_true "$need_jbossews" && need_jbossews_repo() { :; }
 
     # The fuse/amq cartridges require their own channels.
-    is_true "${need_fuse}" && need_fuse_cartridge_repo() { :; }
-    is_true "${need_amq}" && need_amq_cartridge_repo() { :; }
+    is_true "$need_fuse" && need_fuse_cartridge_repo() { :; }
+    is_true "$need_amq" && need_amq_cartridge_repo() { :; }
 
     # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
@@ -231,18 +231,18 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]
+if [[ -n "$rhel_repo" ]]
 then
-  cat > /etc/yum.repos.d/rhel.repo <<YUM
+  cat > '/etc/yum.repos.d/rhel.repo' <<YUM
 [rhel6]
 name=RHEL 6 base OS
-baseurl=${rhel_repo}
+baseurl=$rhel_repo
 enabled=1
 gpgcheck=0
 sslverify=false
 priority=20
 sslverify=false
-exclude=tomcat6* ${yum_exclude_pkgs}
+exclude=tomcat6* $yum_exclude_pkgs
 
 YUM
 fi
@@ -250,18 +250,18 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]
+if [[ -n "$rhel_optional_repo" ]]
 then
-  cat > /etc/yum.repos.d/rheloptional.repo <<YUM
+  cat > '/etc/yum.repos.d/rheloptional.repo' <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
-baseurl=${rhel_optional_repo}
+baseurl=$rhel_optional_repo
 enabled=1
 gpgcheck=0
 sslverify=false
 priority=20
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 fi
@@ -269,20 +269,20 @@ fi
 
 def_ose_yum_repo()
 {
-  local repo_base=$1
-  local layout=$2  # one of: puddle, extra, cdn
-  local channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
+  local repo_base="$1"
+  local layout="$2"  # one of: puddle, extra, cdn
+  local channel="$3" # one of: client_tools, infra, node, jbosseap_cartridge
 
   local -A map
   local url
-  case $layout in
+  case "$layout" in
   puddle | extra)
     map=([client_tools]=RHOSE-CLIENT-2.2 [infra]=RHOSE-INFRA-2.2 [node]=RHOSE-NODE-2.2 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.2)
-    url="$repo_base/${map[$channel]}/x86_64/os/"
+    url="${repo_base}/${map[$channel]}/x86_64/os/"
     ;;
   cdn | * )
     map=([client_tools]=ose-rhc [infra]=ose-infra [node]=ose-node [jbosseap_cartridge]=ose-jbosseap)
-    url="$repo_base/${map[$channel]}/2.2/os"
+    url="${repo_base}/${map[$channel]}/2.2/os"
     ;;
   esac
   cat > "/etc/yum.repos.d/openshift-${channel}-${layout}.repo" <<YUM
@@ -294,16 +294,16 @@ gpgcheck=0
 sslverify=false
 priority=10
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 }
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]
+  if [[ -n "$rhscl_repo_base" ]]
   then
-    cat <<YUM > /etc/yum.repos.d/rhscl.repo
+    cat <<YUM > '/etc/yum.repos.d/rhscl.repo'
 [rhscl]
 name=rhscl
 baseurl=${rhscl_repo_base}/rhscl/1/os/
@@ -311,7 +311,7 @@ enabled=1
 priority=10
 gpgcheck=0
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 
@@ -336,14 +336,14 @@ configure_cart_repos()
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
-name=${repo}
+name=$repo
 baseurl=${url[$repo]}
 enabled=1
 gpgcheck=0
 sslverify=false
 priority=30
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
   done
@@ -352,10 +352,10 @@ YUM
 # Add all defined extra repos in one file.
 configure_extra_repos()
 {
-  local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]
+  local extra_repo_file='/etc/yum.repos.d/ose_extra.repo'
+  if [[ -e "$extra_repo_file" ]]
   then
-      > "${extra_repo_file}"
+      > "$extra_repo_file"
   fi
 
   local -A priority=(
@@ -374,18 +374,18 @@ configure_extra_repos()
   for repo in "${!priority[@]}"
   do
     local url="${!repo}"
-    if [[ -n "${url}" ]]
+    if [[ -n "$url" ]]
     then
-      cat <<YUM >> "${extra_repo_file}"
+      cat <<YUM >> "$extra_repo_file"
 [${repo}]
-name=${repo}
-baseurl=${url}
+name=$repo
+baseurl=$url
 enabled=1
 gpgcheck=0
 sslverify=false
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} ${yum_exclude_pkgs}
+exclude=${exclude[$repo]} $yum_exclude_pkgs
 
 YUM
     fi
@@ -399,7 +399,7 @@ configure_subscription()
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
-   local roles=""  # we will build the list of roles we need, then enable them.
+   local roles=  # we will build the list of roles we need, then enable them.
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
@@ -423,18 +423,18 @@ configure_rhn_channels()
 {
   if [[ -n "$rhn_reg_actkey" ]]
   then
-    echo "OpenShift: Register to RHN Classic using an activation key"
-    rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register to RHN Classic using an activation key'
+    rhnreg_ks --force "--activationkey=$rhn_reg_actkey" "--profilename=$rhn_profile_name" $rhn_reg_opts || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # Don't log password.
-      echo "OpenShift: Register to RHN Classic with username and password"
-      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" ${rhn_reg_opts}"
-      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "${rhn_user}" --password "${rhn_pass}" ${rhn_reg_opts} || abort_install
+      echo 'OpenShift: Register to RHN Classic with username and password'
+      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
+      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
       set -x
     else
-      echo "OpenShift: No credentials given for RHN Classic; assuming already configured"
+      echo 'OpenShift: No credentials given for RHN Classic; assuming already configured'
     fi
   fi
 
@@ -455,7 +455,7 @@ configure_rhn_channels()
     set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"
-    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
     done
     set -x
   fi
@@ -468,20 +468,20 @@ configure_rhsm_channels()
   if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # Don't log password.
-    echo "OpenShift: Register with RHSM"
-    echo "subscription-manager register --force \"--username=$rhn_user\" --name \"$rhn_profile_name\" ${rhn_reg_opts}"
-    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register with RHSM'
+    echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
+    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
     set -x
   else
-    echo "OpenShift: No credentials given for RHSM; assuming already configured"
+    echo 'OpenShift: No credentials given for RHSM; assuming already configured'
   fi
 
-  if [[ -n "${sm_reg_pool}" ]]
+  if [[ -n "$sm_reg_pool" ]]
   then
-    echo "OpenShift: Removing all current subscriptions"
+    echo 'OpenShift: Removing all current subscriptions'
     subscription-manager remove --all
   else
-    echo "OpenShift: No pool ids were given, so none are being registered"
+    echo 'OpenShift: No pool ids were given, so none are being registered'
   fi
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
@@ -494,17 +494,17 @@ configure_rhsm_channels()
 
   # Enable the node or infrastructure repo to enable installing the release RPM
   if need_node_repo
-  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
-  else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
+  then subscription-manager repos '--enable=rhel-6-server-ose-2.2-node-rpms' || abort_install
+  else subscription-manager repos '--enable=rhel-6-server-ose-2.2-infra-rpms' || abort_install
   fi
   configure_subscription
 }
 
 abort_install()
 {
-  [[ "$#" -ge 1 ]] && echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$*"
   # Don't change this; it is used as an automation cue.
-  echo "OpenShift: Aborting Installation."
+  echo 'OpenShift: Aborting Installation.'
   exit 1
 }
 
@@ -514,11 +514,11 @@ yum_install_or_exit()
   local count=0
   time while true
   do
-    yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]
+    yum install -y "$@" $disable_plugin && return
+    if [[ "$count" -gt 3 ]]
     then
       echo "OpenShift: Command failed: yum install $*"
-      echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
+      echo 'OpenShift: Please ensure relevant repos/subscriptions are configured.'
       abort_install
     fi
     let count+=1
@@ -535,16 +535,16 @@ install_rhc_pkg()
 configure_rhc()
 {
   # set_conf expects there to be a new line.
-  echo "" >> /etc/openshift/express.conf
+  echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
-  set_conf /etc/openshift/express.conf libra_server "'${broker_hostname}'"
+  set_conf '/etc/openshift/express.conf' libra_server "'${broker_hostname}'"
 }
 
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  local pkgs="openshift-origin-broker"
+  local pkgs='openshift-origin-broker'
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"
@@ -564,7 +564,7 @@ install_broker_pkgs()
 # Install node-specific packages.
 install_node_pkgs()
 {
-  local pkgs="rubygem-openshift-origin-node ruby193-rubygem-passenger-native"
+  local pkgs='rubygem-openshift-origin-node ruby193-rubygem-passenger-native'
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
@@ -597,7 +597,7 @@ YUM
       pkgs="$pkgs rubygem-openshift-origin-frontend-apache-vhost"
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -683,11 +683,11 @@ parse_cartridges()
   local -a all=( ${p[@]} )
 
   # Set some package groups and aliases to provide shortcuts to the user.
-  p[all]="${all[@]}"
-  p[premium]="${premium[@]}"
-  p[stdframework]="${stdframework[@]}"
-  p[stdaddon]="${stdaddon[@]}"
-  p[standard]="${stdframework[@]} ${stdaddon[@]}"
+  p[all]="${all[*]}"
+  p[premium]="${premium[*]}"
+  p[stdframework]="${stdframework[*]}"
+  p[stdaddon]="${stdaddon[*]}"
+  p[standard]="${stdframework[*]} ${stdaddon[*]}"
   p[jboss]="${p[jbossews]} ${p[jbosseap]}"
   p[postgres]="${p[postgresql]}"
 
@@ -707,8 +707,8 @@ parse_cartridges()
       # anything in $p.
       for pkg in ${p[${cart_spec:1}]:-${cart_spec:1}}
       do
-        for k in ${!pkgs[@]}
-        do [[ ${pkgs[$k]} = $pkg ]] && unset "pkgs[$k]"
+        for k in "${!pkgs[@]}"
+        do [[ "${pkgs[$k]}" = "$pkg" ]] && unset "pkgs[$k]"
         done
       done
     else
@@ -721,12 +721,12 @@ parse_cartridges()
   if metapkgs_optional || metapkgs_recommended
   then
     local metapkg
-    for metapkg in ${meta[@]}
+    for metapkg in "${meta[@]}"
     do
       if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
       then
-        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
-        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
+        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
+        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
       fi
     done
   fi
@@ -734,13 +734,13 @@ parse_cartridges()
   # Set need_<cart>=1 if $pkgs includes the relevant cartridge,
   # need_<cart>=0 otherwise, so that configure_repos will enable
   # only the appropriate channels.
-  need_jbosseap=0; [[ "${pkgs[@]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
-  need_jbossews=0; [[ "${pkgs[@]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
+  need_jbosseap=0; [[ "${pkgs[*]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
+  need_jbossews=0; [[ "${pkgs[*]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
     # fuse is "special" because there's also a fuse-builder cart that can be used with
     # either fuse or amq and doesn't necessarily imply either. It comes from either of
     # those two channels; assume if desired they will have one of those channels already.
-  need_fuse=0;     [[ "${pkgs[@]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
-  need_amq=0;      [[ "${pkgs[@]}" = *"${p[amq]}"* ]] && need_amq=1
+  need_fuse=0;     [[ "${pkgs[*]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
+  need_amq=0;      [[ "${pkgs[*]}" = *"${p[amq]}"* ]] && need_amq=1
 
   # Uniquify (and, as a side effect, sort) pkgs and assign the result to
   # install_cart_pkgs for install_cartridges to use.
@@ -759,7 +759,7 @@ install_cartridges()
   # still install as much as possible.
   #install_cart_pkgs="${install_cart_pkgs} --skip-broken"
 
-  yum_install_or_exit "${install_cart_pkgs}"
+  yum_install_or_exit $install_cart_pkgs
 }
 
 # Given the filename of a configuration file, the name of a setting,
@@ -832,9 +832,9 @@ configure_selinux_policy_on_broker()
   fixfiles -R ruby193-rubygem-passenger restore
   fixfiles -R ruby193-mod_passenger restore
 
-  restorecon -rv /var/run
+  restorecon -rv '/var/run'
   # This should cover everything in the SCL, including passenger
-  time restorecon -rv /opt
+  time restorecon -rv '/opt'
 }
 
 # Fix up SELinux policy on the node.
@@ -870,31 +870,31 @@ configure_selinux_policy_on_node()
   ) | semanage -i -
 
 
-  restorecon -rv /var/run
-  time restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
+  restorecon -rv '/var/run'
+  time restorecon -rv '/var/lib/openshift' '/etc/httpd/conf.d/openshift'
   # disallow gear users from seeing what other gears exist
-  chmod 0751 /var/lib/openshift
+  chmod 0751 '/var/lib/openshift'
 }
 
 configure_pam_on_node()
 {
-  sed -i -e 's|pam_selinux|pam_openshift|g' /etc/pam.d/sshd
+  sed -i -e 's|pam_selinux|pam_openshift|g' '/etc/pam.d/sshd'
 
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "su" "system-auth-ac"
+  for f in runuser runuser-l sshd su system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_namespace.so" "$t"
+    if ! grep -q 'pam_namespace.so' "$t"
     then
       # We add two rules.  The first checks whether the user's shell is
       # /usr/bin/oo-trap-user, which indicates that this is a gear user,
       # and skips the second rule if it is not.
-      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
+      echo -e 'session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user' >> "$t"
 
       # The second rule enables polyinstantiation so that the user gets
       # private /tmp and /dev/shm directories.
-      echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
+      echo -e 'session\t\trequired\tpam_namespace.so no_unmount_on_close' >> "$t"
     fi
   done
 
@@ -902,27 +902,27 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo "/tmp        \$HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/tmp.conf
-  echo "/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
 }
 
 configure_cgroups_on_node()
 {
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "system-auth-ac"
+  for f in runuser runuser-l sshd system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_cgroup" "$t"
+    if ! grep -q 'pam_cgroup' "$t"
     then
-      echo -e "session\t\toptional\tpam_cgroup.so" >> "$t"
+      echo -e 'session\t\toptional\tpam_cgroup.so' >> "$t"
     fi
   done
 
-  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf /etc/cgconfig.conf
-  restorecon -rv /etc/cgconfig.conf
-  mkdir -p /cgroup
-  restorecon -rv /cgroup
+  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf '/etc/cgconfig.conf'
+  restorecon -rv '/etc/cgconfig.conf'
+  mkdir -p '/cgroup'
+  restorecon -rv '/cgroup'
   chkconfig cgconfig on
   chkconfig cgred on
 }
@@ -930,45 +930,45 @@ configure_cgroups_on_node()
 configure_quotas_on_node()
 {
   # Get the mountpoint for /var/lib/openshift (should be /).
-  local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
+  local geardata_mnt=$(df -P '/var/lib/openshift' 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
   if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
     # Enable user quotas for the filesystem housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" '/etc/fstab'
     # Remount to enable quotas immediately.
-    mount -o remount "${geardata_mnt}"
+    mount -o remount "$geardata_mnt"
 
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
-    time restorecon "${geardata_mnt}"
+    time restorecon "$geardata_mnt"
 
     # quotacheck fails if quotas are enabled.
-    quotaoff "${geardata_mnt}"
+    quotaoff "$geardata_mnt"
 
     # Generate user quota info for the mount point.
-    time quotacheck -cmug "${geardata_mnt}"
+    time quotacheck -cmug "$geardata_mnt"
 
     # Fix the SELinux label of the created quota file.
-    restorecon "${geardata_mnt}"/aquota.user
+    restorecon "${geardata_mnt}/aquota.user"
 
     # (Re)enable quotas.
-    time quotaon "${geardata_mnt}"
+    time quotaon "$geardata_mnt"
   fi
 }
 
 configure_idler_on_node()
 {
   [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return 0
-  cat <<CRON > /etc/cron.hourly/auto-idler
+  cat <<CRON > '/etc/cron.hourly/auto-idler'
 (
   /usr/sbin/oo-last-access
-  /usr/sbin/oo-auto-idler idle --interval $idle_interval
-) >> /var/log/openshift/node/auto-idler.log 2>&1
+  /usr/sbin/oo-auto-idler idle --interval "$idle_interval"
+) >> '/var/log/openshift/node/auto-idler.log' 2>&1
 CRON
-  chmod +x /etc/cron.hourly/auto-idler
+  chmod +x '/etc/cron.hourly/auto-idler'
 }
 
 # $1 = setting name
@@ -976,25 +976,25 @@ CRON
 # $3 = long comment
 set_sysctl()
 {
-  set_conf /etc/sysctl.conf "$1" "$2" '' "$3"
+  set_conf '/etc/sysctl.conf' "$1" "$2" '' "$3"
 }
 
 # Turn some sysctl knobs.
 configure_sysctl_on_node()
 {
-  set_sysctl kernel.sem '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
+  set_sysctl 'kernel.sem' '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
 
-  set_sysctl net.ipv4.ip_local_port_range '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_local_port_range' '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
 
-  set_sysctl net.netfilter.nf_conntrack_max 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
+  set_sysctl 'net.netfilter.nf_conntrack_max' 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_forward' 1 'Enable forwarding for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
+  set_sysctl 'net.ipv4.conf.all.route_localnet' 1 'Allow the OpenShift port proxy to route using loopback addresses.'
 
   # As recommended elsewhere and investigated at length in https://bugzilla.redhat.com/show_bug.cgi?id=1085115
   # this is a safe, effective way to keep lots of short requests from exhausting the connection table.
-  set_sysctl net.ipv4.tcp_tw_reuse 1 'Reuse closed connections quickly.' 
+  set_sysctl 'net.ipv4.tcp_tw_reuse' 1 'Reuse closed connections quickly.'
 }
 
 
@@ -1003,11 +1003,11 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
-  sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config
-  sed -i -e "s/^#MaxStartups .*$/MaxStartups 40/" /etc/ssh/sshd_config
+  sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'
+  sed -i -e 's/^#MaxStartups .*$/MaxStartups 40/' '/etc/ssh/sshd_config'
 
   RESTART_NEEDED=true
 }
@@ -1038,14 +1038,14 @@ wait_for_mongod()
 # $4 = password (optional)
 execute_mongodb()
 {
-  echo "Running commands on MongoDB:"
-  echo "---"
+  echo 'Running commands on MongoDB:'
+  echo '---'
   echo "$1"
-  echo "---"
+  echo '---'
 
   local userpass=
   if [[ -n "${3+x}" && -n "${4+x}" ]]
-  then userpass="-u ${3} -p ${4} admin"
+  then userpass="-u $3 -p $4 admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
@@ -1065,7 +1065,7 @@ configure_datastore_add_users()
   wait_for_mongod
 
   time execute_mongodb "$(
-    if [[ ${datastore_replicants} =~ , ]]
+    if [[ "$datastore_replicants" =~ , ]]
     then
       echo 'while (rs.isMaster().primary == null) { sleep(5); }'
     fi
@@ -1078,7 +1078,7 @@ configure_datastore_add_users()
     fi
 
     # Add the user that the broker will use.
-    echo "use ${mongodb_name}"
+    echo "use $mongodb_name"
     echo "db.addUser('${mongodb_broker_user}', '${mongodb_broker_password}')"
   )"
   set -x
@@ -1095,10 +1095,10 @@ configure_datastore_add_replicants()
 
   # initiate the replica set with just this host
   time execute_mongodb 'rs.initiate()' '"ok" : 1' ||
-    abort_install "OpenShift: Failed to form MongoDB replica set; please do this manually."
+    abort_install 'OpenShift: Failed to form MongoDB replica set; please do this manually.'
 
   local master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
-    abort_install "OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually."
+    abort_install 'OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually.'
 
   configure_datastore_add_users
 
@@ -1116,15 +1116,15 @@ configure_datastore_add_replicants()
       for i in {1..10}
       do
         echo "Attempting to connect to ${replicant}..."
-        if echo "" | mongo $replicant
+        if echo | mongo "$replicant"
         then
           break
         fi
         sleep 60
       done
 
-      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' ${mongodb_admin_user} ${mongodb_admin_password} ||
-        abort_install "OpenShift: Failed to add ${replicant} to replica set; please verify the replica set manually"
+      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' "$mongodb_admin_user" "$mongodb_admin_password" ||
+        abort_install "OpenShift: Failed to add $replicant to replica set; please verify the replica set manually"
     fi
   done
 
@@ -1143,7 +1143,7 @@ configure_datastore()
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 
-  if [[ ${datastore_replicants} =~ , ]]
+  if [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will be part of a replicated setup.
 
@@ -1154,21 +1154,21 @@ configure_datastore()
     set_mongodb journal true
 
     # Enable replication.
-    set_mongodb replSet "${mongodb_replset}"
+    set_mongodb replSet "$mongodb_replset"
 
     # Configure a key for the replica set.
-    set_mongodb keyFile /etc/mongodb.keyfile
+    set_mongodb keyFile '/etc/mongodb.keyfile'
 
-    rm -f /etc/mongodb.keyfile
-    echo "${mongodb_key}" > /etc/mongodb.keyfile
-    chown -v mongodb.mongodb /etc/mongodb.keyfile
-    chmod -v 400 /etc/mongodb.keyfile
+    rm -f '/etc/mongodb.keyfile'
+    echo "$mongodb_key" > '/etc/mongodb.keyfile'
+    chown -v 'mongodb.mongodb' '/etc/mongodb.keyfile'
+    chmod -v 400 '/etc/mongodb.keyfile'
   fi
 
   # If mongod is running on a separate host from the broker OR
   # we are configuring a replica set, open up the firewall to allow
   # other broker or datastore hosts to connect.
-  if broker && ! [[ ${datastore_replicants} =~ , ]]
+  if broker && ! [[ "$datastore_replicants" =~ , ]]
   then
     echo 'The broker and data store are on the same host.'
     echo 'Skipping firewall and mongod configuration;'
@@ -1177,10 +1177,10 @@ configure_datastore()
     echo 'The data store needs to be accessible externally.'
 
     echo 'Configuring the firewall to allow connections to mongod...'
-    firewall_allow[mongodb]=tcp:27017
+    firewall_allow[mongodb]='tcp:27017'
 
     echo 'Configuring mongod to listen on all interfaces...'
-    set_mongodb bind_ip 0.0.0.0
+    set_mongodb bind_ip '0.0.0.0'
   fi
 
   # Configure mongod to start on boot.
@@ -1189,7 +1189,7 @@ configure_datastore()
   # Start mongod so we can perform some administration now.
   service mongod start
 
-  if ! [[ ${datastore_replicants} =~ , ]]
+  if ! [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will _not_ be part of a replicated setup.
     configure_datastore_add_users
@@ -1206,9 +1206,9 @@ configure_port_proxy()
 {
   chkconfig openshift-iptables-port-proxy on
   sed -i '/:OUTPUT ACCEPT \[.*\]/a \
-:rhc-app-comm - [0:0]' /etc/sysconfig/iptables
+:rhc-app-comm - [0:0]' '/etc/sysconfig/iptables'
   sed -i '/-A INPUT -i lo -j ACCEPT/a \
--A INPUT -j rhc-app-comm' /etc/sysconfig/iptables
+-A INPUT -j rhc-app-comm' '/etc/sysconfig/iptables'
 }
 
 configure_gears()
@@ -1223,7 +1223,7 @@ configure_gears()
     sed -i -e '
       /outputtype\b/I coutputType = syslog
       /outputtypefromenviron/I coutputTypeFromEnviron = true
-    ' /etc/openshift/logshifter.conf
+    ' '/etc/openshift/logshifter.conf'
     # use rsyslog7 so we can annotate
     # disable some of the stock options shipped
     sed -i -e '
@@ -1232,9 +1232,9 @@ configure_gears()
       /ModLoad imjournal/ s/^/#/    # imjournal module is not even available...
       /IMJournalStateFile/ s/^/#/
       /OmitLocalLogging/ s/^/#/
-    ' /etc/rsyslog.conf
+    ' '/etc/rsyslog.conf'
     # enable custom log format via imuxsock
-    cat <<'LOGCONF' >> /etc/rsyslog.d/imuxsock-and-openshift-gears.conf
+    cat <<'LOGCONF' >> '/etc/rsyslog.d/imuxsock-and-openshift-gears.conf'
 # load the modules as necessary for gear logs to be annotated
 module(load="imuxsock" SysSock.Annotate="on" SysSock.ParseTrusted="on" SysSock.UsePIDFromSystem="on")
 module(load="mmopenshift")
@@ -1277,12 +1277,12 @@ LOGCONF
 # Enable services to start on boot for the node.
 enable_services_on_node()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   # Allow connections to openshift-node-web-proxy
-  firewall_allow[ws]=tcp:8000
-  firewall_allow[wss]=tcp:8443
+  firewall_allow[ws]='tcp:8000'
+  firewall_allow[wss]='tcp:8443'
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"
@@ -1306,8 +1306,8 @@ enable_services_on_node()
 # Enable services to start on boot for the broker and fix up some issues.
 enable_services_on_broker()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   chkconfig httpd on
   chkconfig network on
@@ -1325,10 +1325,10 @@ generate_mcollective_pools_configuration()
   for replicant in ${activemq_replicants//,/ }
   do
     let num_replicants=num_replicants+1
-    new_member="plugin.activemq.pool.${num_replicants}.host = ${replicant}
+    new_member="plugin.activemq.pool.${num_replicants}.host = $replicant
 plugin.activemq.pool.${num_replicants}.port = 61613
-plugin.activemq.pool.${num_replicants}.user = ${mcollective_user}
-plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
+plugin.activemq.pool.${num_replicants}.user = $mcollective_user
+plugin.activemq.pool.${num_replicants}.password = $mcollective_password
 "
     members="${members}${new_member}"
   done
@@ -1343,8 +1343,8 @@ plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
 # https://bugzilla.redhat.com/show_bug.cgi?id=963332
 configure_mcollective_for_activemq_on_broker()
 {
-  local mcollective_cfg="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
-  cat <<EOF > $mcollective_cfg
+  local mcollective_cfg='/opt/rh/ruby193/root/etc/mcollective/client.cfg'
+  cat <<EOF > "$mcollective_cfg"
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -1373,13 +1373,13 @@ plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 
 EOF
 
-  chown apache:apache $mcollective_cfg
-  chmod 640 $mcollective_cfg
+  chown 'apache:apache' "$mcollective_cfg"
+  chmod 640 "$mcollective_cfg"
 
   # Make sure the MCollective client log is created with proper ownership.
   # If root owns it, the broker (apache user) can't log to it.
-  touch /var/log/openshift/broker/ruby193-mcollective-client.log
-  chown apache:root /var/log/openshift/broker/ruby193-mcollective-client.log
+  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
+  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
 
   RESTART_NEEDED=true
 }
@@ -1388,7 +1388,7 @@ EOF
 # Configure mcollective on the node to use ActiveMQ.
 configure_mcollective_for_activemq_on_node()
 {
-  cat <<EOF > /opt/rh/ruby193/root/etc/mcollective/server.cfg
+  cat <<EOF > '/opt/rh/ruby193/root/etc/mcollective/server.cfg'
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -1469,7 +1469,7 @@ configure_activemq()
   networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
 
   local schedulerSupport= routingPolicy=
-  if is_true "${enable_routing_plugin}"
+  if is_true "$enable_routing_plugin"
   then
     schedulerSupport='schedulerSupport="true"'
     IFS= read -r -d '' routingPolicy <<'EOF' || :
@@ -1589,10 +1589,10 @@ $networkConnectors
           <simpleAuthenticationPlugin>
              <users>
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
-               ${authenticationUser_amq}
+               $authenticationUser_amq
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
                $( if is_true "$enable_routing_plugin"
-                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+                  then echo "<authenticationUser username=\"${routing_plugin_user}\" password=\"${routing_plugin_pass}\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -1616,7 +1616,7 @@ $networkConnectors
               </authorizationMap>
             </map>
           </authorizationPlugin>
-${routingPolicy}
+$routingPolicy
         </plugins>
 
           <!--
@@ -1684,8 +1684,8 @@ ${routingPolicy}
 EOF
 
   # Allow connections to ActiveMQ.
-  firewall_allow[stomp]=tcp:61613
-  allow_openwire && firewall_allow[openwire]=tcp:61616
+  firewall_allow[stomp]='tcp:61613'
+  allow_openwire && firewall_allow[openwire]='tcp:61616'
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -1701,18 +1701,18 @@ install_named_pkgs()
 configure_named()
 {
   # Ensure we have a key for service named status to communicate with BIND.
-  rndc-confgen -a -r /dev/urandom
+  rndc-confgen -a -r '/dev/urandom'
   restorecon /etc/rndc.* /etc/named.*
-  chown root:named /etc/rndc.key
-  chmod 640 /etc/rndc.key
+  chown 'root:named' '/etc/rndc.key'
+  chmod 640 '/etc/rndc.key'
 
   # Set up DNS forwarding if so directed.
-  local forwarders="recursion no;"
+  local forwarders='recursion no;'
   if is_true "$enable_dns_forwarding"
   then
-    echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
-    restorecon /var/named/forwarders.conf
-    chmod 644 /var/named/forwarders.conf
+    echo "forwarders { ${nameservers} } ;" > '/var/named/forwarders.conf'
+    restorecon '/var/named/forwarders.conf'
+    chmod 644 '/var/named/forwarders.conf'
     forwarders='// set forwarding to the next nearest server (from DHCP response)
 	forward only;
         include "forwarders.conf";
@@ -1722,15 +1722,15 @@ configure_named()
 
   # Install the configuration file for the OpenShift Enterprise domain
   # name.
-  rm -rf /var/named/dynamic
-  mkdir -p /var/named/dynamic
+  rm -rf '/var/named/dynamic'
+  mkdir -p '/var/named/dynamic'
 
-  chgrp named -R /var/named
-  chown named -R /var/named/dynamic
-  restorecon -rv /var/named
+  chgrp named -R '/var/named'
+  chown named -R '/var/named/dynamic'
+  restorecon -rv '/var/named'
 
   # Replace named.conf.
-  cat <<EOF > /etc/named.conf
+  cat <<EOF > '/etc/named.conf'
 // named.conf
 //
 // Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
@@ -1771,8 +1771,8 @@ controls {
 
 include "/etc/named.rfc1912.zones";
 EOF
-  chown root:named /etc/named.conf
-  chcon system_u:object_r:named_conf_t:s0 -v /etc/named.conf
+  chown 'root:named' '/etc/named.conf'
+  chcon 'system_u:object_r:named_conf_t:s0' -v '/etc/named.conf'
 
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
@@ -1783,7 +1783,7 @@ EOF
   configure_hosts_dns
 
   # Configure named to start on boot.
-  firewall_allow[dns]=tcp:53,udp:53
+  firewall_allow[dns]='tcp:53,udp:53'
   chkconfig named on
 
   # Start named so we can perform some updates immediately.
@@ -1798,46 +1798,46 @@ configure_named_zone()
   then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
-    rm -f /var/named/K${zone_tolower}*
-    dnssec-keygen -a ${bind_keyalgorithm} -b ${bind_keysize} -n USER -r /dev/urandom -K /var/named ${zone}
+    rm -f "/var/named/K${zone_tolower}"*
+    dnssec-keygen -a "$bind_keyalgorithm" -b "$bind_keysize" -n USER -r '/dev/urandom' -K '/var/named' "$zone"
     # $zone may have uppercase letters in it.  However the file that
     # dnssec-keygen creates will have the zone in lowercase.
-    bind_key="$(grep Key: /var/named/K${zone_tolower}*.private | cut -d ' ' -f 2)"
-    rm -f /var/named/K${zone_tolower}*
+    bind_key="$(grep 'Key:' "/var/named/K${zone_tolower}"*.private | cut -d ' ' -f 2)"
+    rm -f "/var/named/K${zone_tolower}"*
   fi
 
   # Install the key where BIND and oo-register-dns expect it.
-  cat <<EOF > /var/named/${zone}.key
-key ${zone} {
+  cat <<EOF > "/var/named/${zone}.key"
+key $zone {
   algorithm "${bind_keyalgorithm}";
   secret "${bind_key}";
 };
 EOF
 
   # Create the initial BIND database.
-  cat <<EOF > /var/named/dynamic/${zone}.db
+  cat <<EOF > "/var/named/dynamic/${zone}.db"
 \$ORIGIN .
 \$TTL 1	; 1 seconds (for testing only)
-${zone}		IN SOA	$named_hostname. hostmaster.$zone. (
+${zone}		IN SOA	${named_hostname}. hostmaster.${zone}. (
 				2011112904 ; serial
 				60         ; refresh (1 minute)
 				15         ; retry (15 seconds)
 				1800       ; expire (30 minutes)
 				10         ; minimum (10 seconds)
 				)
-				IN NS	$named_hostname.
-				IN MX	10 mail.$zone.
+				IN NS	${named_hostname}.
+				IN MX	10 mail.${zone}.
 \$ORIGIN ${zone}.
 EOF
 
   # Add a record for the zone to named conf
-  cat <<EOF >> /etc/named.conf
+  cat <<EOF >> '/etc/named.conf'
 include "${zone}.key";
 
 zone "${zone}" IN {
 	type master;
 	file "dynamic/${zone}.db";
-	allow-update { key ${zone} ; } ;
+	allow-update { key $zone ; } ;
 };
 EOF
 }
@@ -1847,7 +1847,7 @@ EOF
 # $2 = domain
 ensure_domain()
 {
-  if [[ $1 = *.* ]]
+  if [[ "$1" = *.* ]]
   then # $1 is already a FQDN or IP address.
     echo "$1"
   else # $1 needs a domain appended.
@@ -1865,9 +1865,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  if [[ "$1" =~ $ip_regex || ! "$2" =~ $ip_regex ]]
   then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  else echo "${1%.${zone}}			IN A	$2" >> "$nsdb"
   fi
 }
 
@@ -1906,23 +1906,23 @@ register_named_entries()
 {
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  local failed="false"
+  local failed=false
   local host_ip
   local host
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    read host ip <<<"${host_ip//:/ }"
+    if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "$hosts_domain_keyfile" -n "$ip"
     then
       echo "WARNING: Failed to register host $host with IP $ip"
-      failed="true"
+      failed=true
     fi
   done
-  is_false "$failed" && echo "OpenShift: Completed updating host DNS entries."
+  "$failed" && echo 'OpenShift: Completed updating host DNS entries.'
   return 0
 }
 
@@ -1932,7 +1932,7 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  if grep -q IPADDR "/etc/sysconfig/network-scripts/ifcfg-$interface"
   then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
@@ -1950,12 +1950,12 @@ configure_dns_resolution()
   # will resolve public addresses even when our private named is
   # nonfunctional.  However, our private named must appear first in
   # order for hostnames private to our OpenShift PaaS to resolve.
-  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
+  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -1978,7 +1978,7 @@ configure_controller()
 {
   if [[ -z "$broker_auth_salt" ]]
   then
-    echo "Warning: broker authentication salt is empty!"
+    echo 'Warning: broker authentication salt is empty!'
   fi
 
   # Configure the broker with the correct domain name, and use random salt
@@ -1994,7 +1994,7 @@ configure_controller()
   # Configure the session secret for the console
   set_console SESSION_SECRET "$console_session_secret"
 
-  if [[ ${datastore_replicants} =~ , ]] || ! datastore
+  if [[ "$datastore_replicants" =~ , ]] || ! datastore
   then
     # MongoDB may be installed remotely or replicated, so configure it
     # with the given hostname(s).
@@ -2013,8 +2013,8 @@ configure_controller()
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
-  sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf
+  sed -i -e "s/ServerName .*\$/ServerName ${hostname}/" \
+      '/etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf'
 
   # Configure the broker service to start on boot.
   chkconfig openshift-broker on
@@ -2030,7 +2030,7 @@ configure_messaging_plugin()
   local pool_size=6000
   let "pool_size=30000/$ports"
 
-  local file=/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
+  local file='/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf'
   cp "$file"{.example,}
   set_conf "$file" DISTRICTS_FIRST_UID "$district_first_uid"
   set_conf "$file" DISTRICTS_MAX_CAPACITY "$pool_size"
@@ -2048,21 +2048,21 @@ configure_dns_plugin()
     echo 'after installation.'
   fi
 
-  mkdir -p /etc/openshift/plugins.d
-  cat <<EOF > /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+  mkdir -p '/etc/openshift/plugins.d'
+  cat <<EOF > '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
   if [[ -z "$bind_krb_keytab" ]]
   then
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KEYNAME="${domain}"
 BIND_KEYVALUE="${bind_key}"
 BIND_KEYALGORITHM="${bind_keyalgorithm}"
 EOF
   else
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KRB_PRINCIPAL="${bind_krb_principal}"
 BIND_KRB_KEYTAB="${bind_krb_keytab}"
 EOF
@@ -2075,7 +2075,7 @@ EOF
 configure_httpd_auth()
 {
   # Configure the broker to use the remote-user authentication plugin.
-  cp -p /etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf{.example,}
+  cp -p '/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf'{.example,}
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
@@ -2083,27 +2083,28 @@ configure_httpd_auth()
   then
     yum_install_or_exit mod_auth_kerb
     local d
-    for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
+    for d in '/var/www/openshift/broker/httpd/conf.d' '/var/www/openshift/console/httpd/conf.d'
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
-        -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
+          -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
+	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return
   fi
 
   # Install the Apache Basic Authentication configuration file.
-  cp -p /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
-  cp -p /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
   # The above configuration file configures Apache to use
   # /etc/openshift/htpasswd for its password file.
   #
   # Here we create a test user:
-  htpasswd -bc /etc/openshift/htpasswd "$openshift_user1" "$openshift_password1"
+  htpasswd -bc '/etc/openshift/htpasswd' "$openshift_user1" "$openshift_password1"
   #
   # Use the following command to add more users:
   #
@@ -2120,12 +2121,12 @@ configure_routing_plugin()
 {
   if is_true "$enable_routing_plugin"
   then
-    local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
-    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
+    local conffile='/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf'
+    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' "${conffile}.example" > "$conffile"
     cat <<EOF >> "$conffile"
-ACTIVEMQ_HOST='$activemq_replicants'
-ACTIVEMQ_USERNAME='$routing_plugin_user'
-ACTIVEMQ_PASSWORD='$routing_plugin_pass'
+ACTIVEMQ_HOST='${activemq_replicants}'
+ACTIVEMQ_USERNAME='${routing_plugin_user}'
+ACTIVEMQ_PASSWORD='${routing_plugin_pass}'
 EOF
     RESTART_NEEDED=true
   fi
@@ -2144,7 +2145,7 @@ fix_broker_routing()
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past
-      cat <<EOF >> /var/lib/openshift/.httpd.d/nodes.txt
+      cat <<EOF >> '/var/lib/openshift/.httpd.d/nodes.txt'
 __default__ REDIRECT:/console
 __default__/rsync_id_rsa.pub NOPROXY
 __default__/console TOHTTPS:127.0.0.1:8118/console
@@ -2153,12 +2154,12 @@ __default__/admin-console TOHTTPS:127.0.0.1:8080/admin-console
 __default__/assets TOHTTPS:127.0.0.1:8080/assets
 EOF
 
-      httxt2dbm -f DB -i /etc/httpd/conf.d/openshift/nodes.txt -o /etc/httpd/conf.d/openshift/nodes.db
-      chown root:apache /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
-      chmod 750 /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
+      httxt2dbm -f DB -i '/etc/httpd/conf.d/openshift/nodes.txt' -o '/etc/httpd/conf.d/openshift/nodes.db'
+      chown 'root:apache' '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
+      chmod 750 '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -2168,21 +2169,21 @@ configure_access_keys_on_broker()
 {
   # Generate a broker access key for remote apps (Jenkins) to access
   # the broker.
-  echo "${broker_auth_priv_key}" > /etc/openshift/server_priv.pem
-  openssl rsa -in /etc/openshift/server_priv.pem -pubout > /etc/openshift/server_pub.pem
-  chown apache:apache /etc/openshift/server_pub.pem
-  chmod 640 /etc/openshift/server_pub.pem
+  echo "$broker_auth_priv_key" > '/etc/openshift/server_priv.pem'
+  openssl rsa -in '/etc/openshift/server_priv.pem' -pubout > '/etc/openshift/server_pub.pem'
+  chown 'apache:apache' '/etc/openshift/server_pub.pem'
+  chmod 640 '/etc/openshift/server_pub.pem'
 
   # If a key pair already exists, delete it so that the ssh-keygen
   # command will not have to ask the user what to do.
-  rm -f /root/.ssh/rsync_id_rsa /root/.ssh/rsync_id_rsa.pub
+  rm -f '/root/.ssh/rsync_id_rsa' '/root/.ssh/rsync_id_rsa.pub'
 
   # Generate a key pair for moving gears between nodes from the broker.
-  ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
+  ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
   cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
-  cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
+  cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
   # The node install script can retrieve this or it can be performed manually:
   #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
@@ -2193,16 +2194,16 @@ configure_wildcard_ssl_cert_on_node()
 {
   # Generate a 2048 bit key and self-signed cert.
   cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-*.${domain}
-root@${domain}
+*.$domain
+root@$domain
 EOF
 
 }
@@ -2210,17 +2211,17 @@ EOF
 configure_broker_ssl_cert()
 {
   # Generate a 2048 bit key and self-signed cert
-  cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+  cat << EOF | openssl req -new -rand '/dev/urandom' \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-${broker_hostname}
-root@${domain}
+$broker_hostname
+root@$domain
 EOF
 }
 
@@ -2229,19 +2230,19 @@ configure_hostname()
 {
   if [[ ! "$hostname" =~ ^[0-9.]*$ ]]  # hostname is not just an IP
   then
-    set_conf /etc/sysconfig/network HOSTNAME "$hostname"
-    hostname "${hostname}"
+    set_conf '/etc/sysconfig/network' HOSTNAME "$hostname"
+    hostname "$hostname"
   fi
 }
 
 # Set some parameters in the OpenShift node configuration files.
 configure_node()
 {
-  local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
-  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]
-  then cp "$resrc.${node_profile}" $resrc
+  local resrc='/etc/openshift/resource_limits.conf'
+  if [[ -f "${resrc}.${node_profile}.${node_host_type}" ]]
+  then cp "${resrc}.${node_profile}.${node_host_type}" "$resrc"
+  elif [[ -f "${resrc}.${node_profile}" ]]
+  then cp "${resrc}.${node_profile}" "$resrc"
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -2262,25 +2263,25 @@ configure_node()
   local conf=/etc/openshift/node.conf
   case "$node_apache_frontend" in
     mod_rewrite)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
       ;;
     vhost)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" "$conf"
       ;;
   esac
 
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
-      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' "$conf" ||
+      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' "$conf"
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo $broker_hostname > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo $domain > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
+  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
@@ -2306,24 +2307,24 @@ PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
-    echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
+    echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
   then
     # Send the frontend logs to syslog (in addition to file).
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' '/etc/sysconfig/httpd'
   fi
   if is_true "$node_log_context"
   then
     # Annotate the frontend logs with UUIDs.
-    set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
+    set_node PLATFORM_LOG_CONTEXT_ENABLED 1
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' '/etc/sysconfig/httpd'
   fi
   if [[ -n "$metrics_interval" ]]
   then
     # Configure watchman with given the interval.
-    set_node WATCHMAN_METRICS_ENABLED 'true'
+    set_node WATCHMAN_METRICS_ENABLED true
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
   fi
 }
@@ -2339,40 +2340,40 @@ update_openshift_facts_on_node()
 # public key (if available) and add it to node's authorized keys.
 install_rsync_pub_key()
 {
-  mkdir -p /root/.ssh
-  chmod 700 /root/.ssh
+  mkdir -p '/root/.ssh'
+  chmod 700 '/root/.ssh'
 
   local wait=600
   local end=`date -d "$wait seconds" +%s`
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]
+  while [[ `date +%s` -lt "$end" ]]
   do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    if ! cert="$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=$node_hostname")"
     then
       sleep 5
     else
-      if ! ssh-keygen -lf /dev/stdin <<< "$cert"
+      if ! ssh-keygen -lf '/dev/stdin' <<< "$cert"
       then
         break
       else
-        echo "$cert" >> /root/.ssh/authorized_keys
-        echo "OpenShift node: SSH key downloaded from broker successfully."
-        chmod 644 /root/.ssh/authorized_keys
+        echo "$cert" >> '/root/.ssh/authorized_keys'
+        echo 'OpenShift node: SSH key downloaded from broker successfully.'
+        chmod 644 '/root/.ssh/authorized_keys'
         return
       fi
     fi
   done
 
-  echo "OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually."
+  echo 'OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually.'
 
 }
 
 echo_installation_intentions()
 {
-  echo "The following components should be installed:"
+  echo 'The following components should be installed:'
   local components='broker node named activemq datastore'
   local component
   for component in $components
@@ -2390,10 +2391,10 @@ echo_installation_intentions()
 configure_console_msg()
 {
   # add the IP to /etc/issue for convenience
-  echo "Install-time IP address: ${cur_ip_addr}" >> /etc/issue
-  echo_installation_intentions >> /etc/issue
-  echo "Check /root/anaconda-post.log to see the %post output." >> /etc/issue
-  echo >> /etc/issue
+  echo "Install-time IP address: $cur_ip_addr" >> '/etc/issue'
+  echo_installation_intentions >> '/etc/issue'
+  echo 'Check /root/anaconda-post.log to see the %post output.' >> '/etc/issue'
+  echo >> '/etc/issue'
 }
 
 
@@ -2433,12 +2434,12 @@ parse_cmdline()
 
 metapkgs_optional()
 {
-  [[ ${metapkgs,,} =~ 'optional' ]]
+  [[ "${metapkgs,,}" =~ 'optional' ]]
 }
 
 metapkgs_recommended()
 {
-  metapkgs_optional || [[ ${metapkgs,,} =~ 'recommended' ]]
+  metapkgs_optional || [[ "${metapkgs,,}" =~ 'recommended' ]]
 }
 
 is_true()
@@ -2465,7 +2466,7 @@ is_false()
 is_xpaas()
 {
   local profile="${1:-$node_profile}"
-  [[ "${profile}" = *xpaas* ]]
+  [[ "$profile" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -2579,7 +2580,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [[ $installing_something = 0 ]]
+  if [[ "$installing_something" = 0 ]]
   then
     for component in $components
     do
@@ -2677,13 +2678,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
-    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
+    rhel_optional_repo="${rhel_optional_repo:-${cdn_repo_base}/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    if [[ "$cdn_repo_base" = "$ose_repo_base" ]]
     then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  elif [[ "$rhel_repo" = "${ose_repo_base}/os" ]]
   then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
@@ -2782,7 +2783,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
   [[ -n "${CONF_DEFAULT_GEAR_CAPABILITIES:+x}" ]] && isset_default_gear_capabilities() { :; }
-  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
+  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-$valid_gear_sizes}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
   [[ -n "${CONF_DEFAULT_GEAR_SIZE:+x}" ]] && isset_default_gear_size() { :; }
@@ -2796,7 +2797,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
   let "district_uid_pool=30000/$ports_per_gear"
-  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
+  let "district_last_uid=${district_first_uid}+${district_uid_pool}-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -2820,28 +2821,28 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Generate a random salt for the broker authentication.
   randomized=$(openssl rand -base64 20)
-  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-${randomized}}"
+  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-$randomized}"
 
   # Generate a random session secret for broker sessions.
   randomized=$(openssl rand -hex 64)
-  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-${randomized}}"
+  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-$randomized}"
 
   # Generate a random session secret for console sessions.
   randomized=$(openssl rand -hex 64)
-  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-${randomized}}"
+  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-$randomized}"
 
   # Generate a new 2048 bit RSA keypair for broker authentication if
   # CONF_BROKER_AUTH_PRIV_KEY not set
   broker && broker_auth_priv_key="${CONF_BROKER_AUTH_PRIV_KEY:-$(openssl genrsa 2048)}"
 
   # If no list of replicants is provided, assume there is only one datastore host.
-  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
+  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-${datastore_hostname}:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
   datastore_replicants="$( for repl in ${datastore_replicants//,/ }
                            do
-                             [[ "$repl" =~ : ]] || repl=$repl:27017
-                             printf ",%s" "${repl}"
+                             [[ "$repl" =~ : ]] || repl="${repl}:27017"
+                             printf ',%s' "$repl"
                            done)"
   datastore_replicants="${datastore_replicants:1}"
 
@@ -2865,18 +2866,18 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   ActiveMQ broker replicants to communicate with one another.  The
   #   amq user is enabled only if replicants are specified using the
   #   activemq_replicants.setting
-  activemq && assign_pass activemq_amq_user_password "password" CONF_ACTIVEMQ_AMQ_USER_PASSWORD
+  activemq && assign_pass activemq_amq_user_password password CONF_ACTIVEMQ_AMQ_USER_PASSWORD
 
   #   This is the user and password shared between broker and node for
   #   communicating over the mcollective topic channels in ActiveMQ.
   #   Must be the same on all broker and node hosts.
   (broker || node || activemq) && mcollective_user="${CONF_MCOLLECTIVE_USER:-mcollective}"
-  (broker || node || activemq) && assign_pass mcollective_password "marionette" CONF_MCOLLECTIVE_PASSWORD
+  (broker || node || activemq) && assign_pass mcollective_password marionette CONF_MCOLLECTIVE_PASSWORD
 
   # Enable authentication for MongoDB.
   if is_true "${CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST:-false}"
-  then enable_datastore_auth='false'
-  else enable_datastore_auth='true'
+  then enable_datastore_auth=false
+  else enable_datastore_auth=true
   fi
 
   #   These are the username and password of the administrative user
@@ -2886,19 +2887,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   enforce authentication.
   datastore && mongodb_admin_user="${CONF_MONGODB_ADMIN_USER:-admin}"
   datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  datastore &&  assign_pass mongodb_admin_password "mongopass" tmpvar
+  datastore &&  assign_pass mongodb_admin_password mongopass tmpvar
 
   #   These are the username and password of the normal user that will
   #   be created for the broker to connect to the MongoDB datastore. The
   #   broker application's MongoDB plugin is also configured with these
   #   values.
   (datastore || broker) && mongodb_broker_user="${CONF_MONGODB_BROKER_USER:-openshift}"
-  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  (datastore || broker) && assign_pass mongodb_broker_password "mongopass" tmpvar
+  (datastore || broker) && tmpvar="${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}"
+  (datastore || broker) && assign_pass mongodb_broker_password mongopass tmpvar
 
   #   In replicated setup, this is the key that slaves will use to
   #   authenticate with the master.
-  datastore && assign_pass mongodb_key "OSEnterprise" CONF_MONGODB_KEY
+  datastore && assign_pass mongodb_key OSEnterprise CONF_MONGODB_KEY
 
   #   In replicated setup, this is the name of the replica set.
   mongodb_replset="${CONF_MONGODB_REPLSET:-ose}"
@@ -2911,12 +2912,12 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   file as a demo/test user. You will likely want to remove it after
   #   installation (or just use a different auth method).
   broker && openshift_user1="${CONF_OPENSHIFT_USER1:-demo}"
-  broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
+  broker && assign_pass openshift_password1 changeme CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
   enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  assign_pass routing_plugin_pass "routinginfopasswd" CONF_ROUTING_PLUGIN_PASS
+  assign_pass routing_plugin_pass routinginfopasswd CONF_ROUTING_PLUGIN_PASS
 
   broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
   broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
@@ -2943,32 +2944,32 @@ init_message()
 
 validate_preflight()
 {
-  echo "OpenShift: Begin preflight validation."
+  echo 'OpenShift: Begin preflight validation.'
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  if ! grep -q 'Enterprise.* 6' /etc/redhat-release
   then
-    echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
+    echo 'OpenShift: This process needs to begin with Enterprise Linux 6 installed.'
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  if ! command -v getenforce || ! [[ "$(getenforce)" =~ Enforcing|Permissive ]]
   then
-    echo "OpenShift: SELinux needs to be installed and enabled."
+    echo 'OpenShift: SELinux needs to be installed and enabled.'
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
   if ! command -v rpm || ! command -v yum
   then
-    echo "OpenShift: rpm and yum must be installed."
+    echo 'OpenShift: rpm and yum must be installed.'
     preflight_failure=1
   fi
   if ! rpm -q rpm yum
   then
-    echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
+    echo 'OpenShift: rpm command failed; there may be a problem with the RPM DB.'
     preflight_failure=1
   fi
 
@@ -2981,12 +2982,12 @@ validate_preflight()
     #
     # Note: With RHN, we need credentials both for registration and
     # adding channels.
-    if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
+    if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhn requires an RHN user and password."
+        echo 'OpenShift: Install method rhn requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3005,7 +3006,7 @@ validate_preflight()
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhsm requires an RHN user and password."
+        echo 'OpenShift: Install method rhsm requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3025,14 +3026,14 @@ validate_preflight()
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
     then
-      echo "OpenShift: Install method rhsm requires a poolid."
+      echo 'OpenShift: Install method rhsm requires a poolid.'
       preflight_failure=1
     fi
   fi
 
   if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
   then
-    echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
+    echo 'OpenShift: Install method yum requires providing URLs for at least OpenShift repos.'
     preflight_failure=1
   fi
 
@@ -3040,21 +3041,21 @@ validate_preflight()
   # ... ?
 
   [[ -n "$preflight_failure" ]] && abort_install
-  echo "OpenShift: Completed preflight validation."
+  echo 'OpenShift: Completed preflight validation.'
 }
 
 install_rpms()
 {
-  echo "OpenShift: Begin installing RPMs."
+  echo 'OpenShift: Begin installing RPMs.'
   # We often rely on the latest SELinux policy and other updates.
-  echo "OpenShift: yum update"
+  echo 'OpenShift: yum update'
   yum $disable_plugin clean all
 
   local count=0
   while true
   do
     yum $disable_plugin update -y && break
-    if [[ $count -gt 3 ]]
+    if [[ "$count" -gt 3 ]]
     then abort_install
     fi
     let count+=1
@@ -3073,12 +3074,12 @@ install_rpms()
   node && install_cartridges
   node && remove_abrt_addon_python
   broker && install_rhc_pkg
-  echo "OpenShift: Completed installing RPMs."
+  echo 'OpenShift: Completed installing RPMs.'
 }
 
 configure_host()
 {
-  echo "OpenShift: Begin configuring host."
+  echo 'OpenShift: Begin configuring host.'
   is_true "$enable_ntp" && synchronize_clock
   # Note: configure_named must run before configure_controller if we are
   # installing both named and broker on the same host.
@@ -3088,18 +3089,18 @@ configure_host()
   is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
-  set_conf /etc/grub.conf timeout 1
+  set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
+  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall
 
   # All hosts should enable SSH access.
-  firewall_allow[ssh]=tcp:22
+  firewall_allow[ssh]='tcp:22'
   configure_firewall_add_rules
-  echo "OpenShift: Completed configuring host."
+  echo 'OpenShift: Completed configuring host.'
 }
 
 configure_firewall()
@@ -3110,7 +3111,7 @@ configure_firewall()
   echo '--disabled' > "$conf"
 
   # Configure iptables.
-cat > /etc/sysconfig/iptables <<'EOF'
+cat > '/etc/sysconfig/iptables' <<'EOF'
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
@@ -3130,12 +3131,12 @@ EOF
 # Note: This function must be run after configure_firewall.
 configure_firewall_add_rules()
 {
-  local rules=""
+  local rules=
   local port
   local prot
   local rule
   local svc
-  for svc in ${!firewall_allow[@]}
+  for svc in "${!firewall_allow[@]}"
   do
     rules+="$(
       for rule in ${firewall_allow[$svc]//,/ }
@@ -3150,7 +3151,7 @@ configure_firewall_add_rules()
 
   # Insert the rules specified by ${firewall_allow[@]} before the first
   # REJECT rule in the INPUT chain.
-  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" /etc/sysconfig/iptables
+  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" '/etc/sysconfig/iptables'
 }
 
 configure_gear_isolation_firewall()
@@ -3160,7 +3161,7 @@ configure_gear_isolation_firewall()
 
 configure_openshift()
 {
-  echo "OpenShift: Begin configuring OpenShift."
+  echo 'OpenShift: Begin configuring OpenShift.'
 
   # Prepare services that the broker and node depend on.
   datastore && configure_datastore
@@ -3200,16 +3201,16 @@ configure_openshift()
   node && configure_gear_isolation_firewall
 
   sysctl -p || :
-  restorecon -rv /etc/openshift
+  restorecon -rv '/etc/openshift'
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true
-  echo "OpenShift: Completed configuring OpenShift."
+  echo 'OpenShift: Completed configuring OpenShift.'
 }
 
 restart_services()
 {
-  echo "OpenShift: Begin restarting services."
+  echo 'OpenShift: Begin restarting services.'
 
   service iptables restart
 
@@ -3236,41 +3237,41 @@ restart_services()
   node && service openshift-watchman restart
 
   # Ensure OpenShift facts are updated.
-  node && /etc/cron.minutely/openshift-facts
+  node && '/etc/cron.minutely/openshift-facts'
 
-  echo "OpenShift: Completed restarting services."
+  echo 'OpenShift: Completed restarting services.'
 }
 
 run_diagnostics()
 {
-  echo "OpenShift: Begin running oo-diagnostics."
+  echo 'OpenShift: Begin running oo-diagnostics.'
   date +%Y-%m-%d-%H:%M:%S
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed running oo-diagnostics."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed running oo-diagnostics.'
 }
 
 reboot_after()
 {
-  echo "OpenShift: Rebooting after install."
+  echo 'OpenShift: Rebooting after install.'
   reboot
 }
 
 configure_districts()
 {
-  echo "OpenShift: Configuring districts."
-  date +%Y-%m-%d-%H:%M:%S
+  echo 'OpenShift: Configuring districts.'
+  date '+%Y-%m-%d-%H:%M:%S'
 
-  local restart=$RESTART_NEEDED
+  local restart="$RESTART_NEEDED"
   if is_true "$default_districts"
   then
     local p
     for p in ${valid_gear_sizes//,/ }
     do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
-      oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+      oo-admin-ctl-district -p "$p" -n "default-$p" -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
     done
   else
@@ -3284,12 +3285,12 @@ configure_districts()
     do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
-      firstnode=${nodes//,*/}
+      firstnode="${nodes//,*/}"
       # Query the node for the node profile via MCollective.
-      profile=""
+      profile=
       for i in {1..10}
       do
-        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
+        profile="$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)" \
          && break
         sleep 10
       done
@@ -3297,7 +3298,7 @@ configure_districts()
       then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
-        oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+        oo-admin-ctl-district -p "$profile" -n "$district" -c add-node -i "$nodes" |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
         is_xpaas "$profile" && configure_messaging_plugin  # back to default
       else
         echo "OpenShift: Could not determine gear profile for nodes: ${nodes}, cannot add to district $district"
@@ -3305,15 +3306,15 @@ configure_districts()
     done
   fi
   # Configuring districts should not normally require a service restart.
-  RESTART_NEEDED=$restart
+  RESTART_NEEDED="$restart"
 
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed configuring districts."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed configuring districts.'
 }
 
 post_deploy()
 {
-  echo "OpenShift: Begin post deployment steps."
+  echo 'OpenShift: Begin post deployment steps.'
 
   if broker
   then
@@ -3323,7 +3324,7 @@ post_deploy()
       RESTART_NEEDED=true
     fi
 
-    $RESTART_NEEDED && restart_services && RESTART_COMPLETED=true
+    "$RESTART_NEEDED" && restart_services && RESTART_COMPLETED=true
 
     # Import cartridges.
     oo-admin-ctl-cartridge -c import-node --activate --obsolete
@@ -3333,7 +3334,7 @@ post_deploy()
 
   node && install_rsync_pub_key
 
-  echo "OpenShift: Completed post deployment steps."
+  echo 'OpenShift: Completed post deployment steps.'
 }
 
 do_all_actions()
@@ -3379,8 +3380,8 @@ RESTART_COMPLETED=false
 # Make sure /sbin and /usr/sbin are in PATH
 for admin_path in /sbin /usr/sbin
 do
-  if [[ :$PATH: != *:"${admin_path}":* ]]
-  then PATH=${PATH}:${admin_path}
+  if [[ ":$PATH:" != *:"$admin_path":* ]]
+  then PATH="${PATH}:${admin_path}"
   fi
 done
 
@@ -3390,10 +3391,10 @@ declare -A firewall_allow
 
 set_defaults
 
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 for action in ${actions//,/ }
 do
-  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S
@@ -3402,9 +3403,9 @@ date +%Y-%m-%d-%H:%M:%S
 # host will automatically reboot anyway after the kickstart script completes.
 [[ "$environment" = ks ]] && RESTART_NEEDED=false
 
-$RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
+"$RESTART_NEEDED" && ! "$RESTART_COMPLETED" && restart_services
 
-$PASSWORDS_TO_DISPLAY && display_passwords
+"$PASSWORDS_TO_DISPLAY" && display_passwords
 
 
 chmod 600 /root/.ssh/named_rsa

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -50,7 +50,7 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [ -n "${!3}" ]; then
+  if [[ -n "${!3}" ]]; then
     printf -v "$1" '%s' "${!3}"
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
@@ -83,11 +83,11 @@ display_passwords()
     matchingvar=""
     for postfix in password password1 pass; do
       vprefix=${k%${postfix}}
-      [ "$vprefix" != "$k" ] && break
+      [[ "$vprefix" != "$k" ]] && break
     done
 
     for v in "${vprefix}user" "${vprefix}user1"; do
-      if [ "x${!v}" != "x" ]; then
+      if [[ -n "${!v}" ]]; then
         matchingvar=$v
         break
       fi
@@ -99,8 +99,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [ "x$matchingvar" != "x" ] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [ "$vprefix" != "$k" ] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
+    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
     echo $out_string
   done
@@ -122,7 +122,7 @@ configure_repos()
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
 
-  if [ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]; then
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
     need_extra_repo() { :; }
   fi
 
@@ -200,11 +200,11 @@ configure_ose_yum_repos()
   # this can be useful even if the main subscription is via RHN
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
-    if [ "$ose_repo_base" != "" ]; then
-      local layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+    if [[ -n "$ose_repo_base" ]]; then
+      local layout=puddle; [[ -n "$CONF_CDN_LAYOUT" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [ "$ose_extra_repo_base" != "" ]; then
+    if [[ -n "$ose_extra_repo_base" ]]; then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -216,7 +216,7 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [ "${rhel_repo}x" != "x" ]; then
+if [[ -n "${rhel_repo}" ]]; then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -234,7 +234,7 @@ fi
 
 configure_optional_repo()
 {
-if [ "${rhel_optional_repo}x" != "x" ]; then
+if [[ -n "${rhel_optional_repo}" ]]; then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -284,7 +284,7 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [ "x${rhscl_repo_base}" != "x" ]; then
+  if [[ -n "${rhscl_repo_base}" ]]; then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -332,7 +332,7 @@ YUM
 configure_extra_repos()
 { # add all defined extra repos in one file
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [ -e "${extra_repo_file}" ]; then
+  if [[ -e "${extra_repo_file}" ]]; then
       echo > "${extra_repo_file}"
   fi
 
@@ -351,7 +351,7 @@ configure_extra_repos()
   local repo
   for repo in "${!priority[@]}"; do
     local url="${!repo}"
-    if [ "${url}x" != "x" ]; then
+    if [[ -n "${url}" ]]; then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -395,11 +395,11 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [ "x$CONF_RHN_REG_ACTKEY" != x ]; then
+  if [[ -n "$CONF_RHN_REG_ACTKEY" ]]; then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${CONF_RHN_REG_ACTKEY}" "--profilename=$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
-  else 
-    if [ $rhn_creds_provided ]
+  else
+    if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # don't log password
       echo "OpenShift: Register to RHN Classic with username and password"
@@ -411,7 +411,7 @@ configure_rhn_channels()
     fi
   fi
 
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     # Enable the node or infrastructure channel to enable installing the release RPM
     local repos=('rhel-x86_64-server-6-rhscl-1')
@@ -427,7 +427,7 @@ configure_rhn_channels()
     set +x # don't log password
     local repo
     for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" == *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
+      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
     done
     set -x
   fi
@@ -437,7 +437,7 @@ configure_rhn_channels()
 
 configure_rhsm_channels()
 {
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # don't log password
     echo "OpenShift: Register with RHSM"
@@ -448,7 +448,7 @@ configure_rhsm_channels()
     echo "OpenShift: No credentials given for RHSM; assuming already configured"
   fi
 
-  if [[ "${CONF_SM_REG_POOL}" ]]
+  if [[ -n "${CONF_SM_REG_POOL}" ]]
   then
     echo "OpenShift: Removing all current subscriptions"
     subscription-manager remove --all
@@ -472,7 +472,7 @@ configure_rhsm_channels()
 
 abort_install()
 {
-  [[ "$@"x == x ]] || echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$@"
   # don't change this; could be used as an automation cue.
   echo "OpenShift: Aborting Installation."
   exit 1
@@ -484,9 +484,9 @@ yum_install_or_exit()
   local count=0
   time while true; do
     yum install -y $* $disable_plugin
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       return
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -892,7 +892,7 @@ configure_quotas_on_node()
   # Get the mountpoint for /var/lib/openshift (should be /).
   local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
-  if ! [ x"$geardata_mnt" != x ]
+  if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
@@ -999,13 +999,13 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [ -n "$3" -a -n "$4" ]; then
+  if [[ -n "$3" && -n "$4" ]]; then
     userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [ "$2" ]; then # test output against regex
+  if [[ -n "$2" ]]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -1393,7 +1393,7 @@ configure_activemq()
   local replicant
   for replicant in ${activemq_replicants//,/ }
   do
-    if ! [ "$replicant" = "$activemq_hostname" ]
+    if [[ "$replicant" != "$activemq_hostname" ]]
     then
       : ${networkConnectors:='        <networkConnectors>'$'\n'}
       : ${authenticationUser_amq:="<authenticationUser username=\"amq\" password=\"${activemq_amq_user_password}\" groups=\"admins,everyone\" />"}
@@ -1730,7 +1730,7 @@ EOF
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
   configure_named_zone "$hosts_domain"
-  [ "$domain" != "$hosts_domain" ] && configure_named_zone "$domain"
+  [[ "$domain" != "$hosts_domain" ]] && configure_named_zone "$domain"
 
   # configure in any hosts as needed
   configure_hosts_dns
@@ -1747,7 +1747,7 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [ "x$bind_key" = x ]; then
+  if [[ -z "$bind_key" ]]; then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -1797,7 +1797,7 @@ EOF
 ensure_domain()
 { # adds a domain to hostname if it does not have one
   # $1 = host; $2 = domain
-  if [[ $1 == *.* ]]; then # already FQDN or IP
+  if [[ $1 = *.* ]]; then # already FQDN or IP
     echo "$1"
   else # needs a domain
     echo "$1.$2"
@@ -1822,8 +1822,8 @@ configure_hosts_dns()
 {
   add_host_to_zone "$named_hostname" "$named_ip_addr" # always define self
   # glue record for NS host in subdomain:
-  [[ "$hosts_domain" == *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
-  if [ -z "$CONF_NAMED_ENTRIES" ]; then
+  [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
+  if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
@@ -1911,7 +1911,7 @@ update_controller_gear_size_configs()
 # Update the controller configuration.
 configure_controller()
 {
-  if [ "x$broker_auth_salt" = "x" ]
+  if [[ -z "$broker_auth_salt" ]]
   then
     echo "Warning: broker authentication salt is empty!"
   fi
@@ -1929,7 +1929,7 @@ configure_controller()
       /etc/openshift/broker.conf
 
   # Configure the session secret for the console
-  if [ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]
+  if [[ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]]
   then
     echo "SESSION_SECRET=${console_session_secret}" >> /etc/openshift/console.conf
   fi
@@ -1980,7 +1980,7 @@ configure_messaging_plugin()
 # Configure the broker to use the BIND DNS plug-in.
 configure_dns_plugin()
 {
-  if [ "x$bind_key" = x ] && [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_key" && -z "$bind_krb_keytab" ]]
   then
     echo 'WARNING: Neither key nor keytab has been set for communication'
     echo 'with BIND. You will need to modify the value of BIND_KEYVALUE'
@@ -1994,7 +1994,7 @@ BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
-  if [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_krb_keytab" ]]
   then
     cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
 BIND_KEYNAME="${domain}"
@@ -2019,7 +2019,7 @@ configure_httpd_auth()
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
-  if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
+  if [[ -n "$CONF_BROKER_KRB_SERVICE_NAME" && -n "$CONF_BROKER_KRB_AUTH_REALMS" ]]
   then
     yum_install_or_exit mod_auth_kerb
     local d
@@ -2258,7 +2258,7 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ "$CONF_METRICS_INTERVAL" != "" ]]; then
+  if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
     # configure watchman with given interval
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
@@ -2289,11 +2289,11 @@ install_rsync_pub_key()
   while [[ `date +%s` -lt $end ]]; do
     # try to get key hosted on broker machine
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
       sleep 5
     else
       ssh-keygen -lf /dev/stdin <<< $cert
-      if [ $? -ne 0 ]; then
+      if [[ $? -ne 0 ]]; then
         break
       else
         echo $cert >> /root/.ssh/authorized_keys
@@ -2383,7 +2383,7 @@ is_true()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 1
+    [[ "$arg" =~ (1|true) ]] || return 1
   done
 
   return 0
@@ -2393,7 +2393,7 @@ is_false()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 0
+    [[ "$arg" =~ (1|true) ]] || return 0
   done
 
   return 1
@@ -2402,7 +2402,7 @@ is_false()
 is_xpaas()
 { # checks first arg or $node_profile, true if contains "xpaas"
   local profile="${1:-$node_profile}"
-  [[ "${profile}" == *xpaas* ]]
+  [[ "${profile}" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -2466,7 +2466,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   local setting
   for setting in "${!CONF_@}"
   do
-    if ! [[ ${valid_settings[$setting]+1} ]]
+    if [[ -z "${valid_settings[$setting]+x}" ]]
     then
       if is_true "$abort_on_unrecognized_settings"
       then
@@ -2476,7 +2476,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       fi
     else
       # The setting is recognized, so check whether a non-empty value is given.
-      [[ ${!setting} ]] || abort_install "Setting is assigned an empty value: $setting"
+      [[ -n "${!setting}" ]] || abort_install "Setting is assigned an empty value: $setting"
     fi
   done
   set -x
@@ -2516,7 +2516,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [ $installing_something = 0 ]
+  if [[ $installing_something = 0 ]]
   then
     for component in $components
     do
@@ -2562,26 +2562,26 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Use CDN layout as the default for all yum repos if this is set.
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [ "x$cdn_repo_base" != "x" ]; then
+  if [[ -n "$cdn_repo_base" ]]; then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [ "${cdn_repo_base}" == "${ose_repo_base}" ]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
       CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [ "${rhel_repo}" == "${ose_repo_base}/os" ]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
     CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
   # no need to waste time checking both subscription plugins if using one
   disable_plugin=""
-  [[ "$CONF_INSTALL_METHOD" == "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
-  [[ "$CONF_INSTALL_METHOD" == "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
+  [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
+  [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
   # could do the same for "yum" method but it's more likely to surprise someone
-  #[[ "$CONF_INSTALL_METHOD" == "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
+  #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
 
   # remap subscription parameters used previously
   CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
@@ -2658,7 +2658,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values
   # are both non-empty, or set $bind_key to the value of $CONF_BIND_KEY
   # if the latter is non-empty.
-  if [ "x$CONF_BIND_KRB_KEYTAB" != x ] && [ "x$CONF_BIND_KRB_PRINCIPAL" != x ] ; then
+  if [[ -n "$CONF_BIND_KRB_KEYTAB" && -n "$CONF_BIND_KRB_PRINCIPAL" ]]; then
   bind_krb_keytab="$CONF_BIND_KRB_KEYTAB"
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
@@ -2673,15 +2673,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
-  [ -n "$CONF_VALID_GEAR_SIZES" ] && isset_valid_gear_sizes() { :; }
+  [[ -n "$CONF_VALID_GEAR_SIZES" ]] && isset_valid_gear_sizes() { :; }
   broker && valid_gear_sizes="${CONF_VALID_GEAR_SIZES:-small}"
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
-  [ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ] && isset_default_gear_capabilities() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ]] && isset_default_gear_capabilities() { :; }
   broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
-  [ -n "$CONF_DEFAULT_GEAR_SIZE" ] && isset_default_gear_size() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
   # Set $node_profile to $CONF_NODE_PROFILE
@@ -2819,7 +2819,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 init_message()
 {
   echo_installation_intentions
-  [ "$environment" = ks ] && configure_console_msg
+  [[ "$environment" = ks ]] && configure_console_msg
 }
 
 validate_preflight()
@@ -2860,7 +2860,7 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2876,7 +2876,7 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2893,15 +2893,15 @@ validate_preflight()
     # subscription-manager gets to write all of its plentiful output
     # before grep closes the pipeline.  Without it, we will get
     # a harmless but possibly alarming "Broken pipe" error message.
-    if [[ ! "$CONF_SM_REG_POOL" ]] &&
-        ( [[ "$CONF_RHN_USER" && "$CONF_RHN_PASS" ]] ||
+    if [[ -z "$CONF_SM_REG_POOL" ]] &&
+        ( [[ -n "$CONF_RHN_USER" && -n "$CONF_RHN_PASS" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [ "$CONF_INSTALL_METHOD" = yum -a ! "$ose_repo_base" ]; then
+  if [[ "$CONF_INSTALL_METHOD" = yum && -z "$ose_repo_base" ]]; then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -2909,7 +2909,7 @@ validate_preflight()
   # Test that known problematic RPMs aren't present
   # ... ?
 
-  [ "$preflight_failure" ] && abort_install
+  [[ -n "$preflight_failure" ]] && abort_install
   echo "OpenShift: Completed preflight validation."
 }
 
@@ -2923,9 +2923,9 @@ install_rpms()
   local count=0
   while true; do
     yum $disable_plugin update -y
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       break
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       abort_install
     fi
     let count+=1
@@ -3157,12 +3157,12 @@ configure_districts()
       profile=""
       for i in {1..10}; do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
-        if [ $? -eq 0 ]; then
+        if [[ $? -eq 0 ]]; then
           break;
         fi
         sleep 10
       done
-      if [ "x$profile" != "x" ]; then
+      if [[ -n "$profile" ]]; then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -3258,7 +3258,7 @@ set_defaults
 date +%Y-%m-%d-%H:%M:%S
 for action in ${actions//,/ }
 do
-  [ "$(type -t "$action")" = function ] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -446,7 +446,8 @@ configure_rhn_channels()
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       echo 'OpenShift: Register to RHN Classic with username and password'
       echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
       rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
@@ -470,7 +471,8 @@ configure_rhn_channels()
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     local repo
     for repo in "${repos[@]}"
     do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
@@ -485,7 +487,8 @@ configure_rhsm_channels()
 {
   if [[ -n "$rhn_creds_provided" ]]
   then
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     echo 'OpenShift: Register with RHSM'
     echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
     subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
@@ -2990,7 +2993,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     # Check for subscription parameters under all previously used setting
     # names.
     rhn_user="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-${CONF_RHN_REG_NAME-}}}"
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     rhn_pass="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-${CONF_RHN_REG_PASS-}}}"
     if [[ -n "$rhn_user" && -n "$rhn_pass" ]]
     then rhn_creds_provided='true'
@@ -3260,7 +3264,8 @@ validate_preflight()
     # adding channels.
     if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhn requires an RHN user and password.'
@@ -3279,7 +3284,8 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhsm requires an RHN user and password.'

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2703,8 +2703,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
-  # Set $node_profile to $CONF_NODE_PROFILE
-  node && node_profile="${CONF_NODE_PROFILE:-small}"
+  node_profile="${CONF_NODE_PROFILE:-small}"
   node && node_profile_name="${CONF_NODE_PROFILE_NAME:-$node_profile}"
   node && node_host_type="${CONF_NODE_HOST_TYPE:-m3.xlarge}"
   # determine node port and UID settings

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -463,7 +463,7 @@ configure_rhn_channels()
   then
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
-    local repos=('rhel-x86_64-server-6-rhscl-1')
+    local -a repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo
     then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
@@ -879,7 +879,7 @@ parse_cartridges()
   # cartridges that the user instructs us to install ($cartridges).  See
   # the documentation on the CONF_CARTRIDGES / cartridges options for
   # the rules governing how $cartridges will be passed.
-  local pkgs=( )
+  local -a pkgs=( )
   local pkg
   local cart_spec
   for cart_spec in ${cartridges//,/ }

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -424,6 +424,7 @@ configure_subscription()
    need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
+   # We want word-splitting on $roles.
    oo-admin-yum-validator -o 2.2 --fix-all $roles || : # when fixing, rc is always false
    oo-admin-yum-validator -o 2.2 $roles || abort_install # so check when fixes are done
 
@@ -442,6 +443,7 @@ configure_rhn_channels()
   if [[ -n "$rhn_reg_actkey" ]]
   then
     echo 'OpenShift: Register to RHN Classic using an activation key'
+    # We want word-splitting on $rhn_reg_opts.
     rhnreg_ks --force "--activationkey=$rhn_reg_actkey" "--profilename=$rhn_profile_name" $rhn_reg_opts || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
@@ -738,6 +740,7 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We want word-splitting on $pkgs.
   yum_install_or_exit $pkgs
 }
 
@@ -782,6 +785,7 @@ YUM
       ;;
   esac
 
+  # We want word-splitting on $pkgs.
   yum_install_or_exit $pkgs
 }
 
@@ -884,7 +888,7 @@ parse_cartridges()
     then
       # Remove every package indicated by the cart_spec, or remove the package
       # with name equal to $cart_spec itself if the cart_spec does not map to
-      # anything in $p.
+      # anything in $p.  This means we want word-splitting, so don't quote it.
       for pkg in ${p[${cart_spec:1}]:-${cart_spec:1}}
       do
         for k in "${!pkgs[@]}"
@@ -892,8 +896,10 @@ parse_cartridges()
         done
       done
     else
-      # Append all packages indicated by the cart_spec, or append
-      # $cart_spec itself if it does not map to anything in $p.
+      # Append all packages indicated by the cart_spec, or append $cart_spec
+      # itself if it does not map to anything in $p.  We want word-splitting
+      # in case $cart_spec or ${p[$cart_spec]} maps to multiple cartridges, so
+      # don't quote it.
       pkgs+=( ${p[$cart_spec]:-$cart_spec} )
     fi
   done
@@ -939,6 +945,7 @@ install_cartridges()
   # still install as much as possible.
   #install_cart_pkgs="${install_cart_pkgs} --skip-broken"
 
+  # We want word-splitting on $install_cart_pkgs.
   yum_install_or_exit $install_cart_pkgs
 }
 
@@ -1262,7 +1269,8 @@ execute_mongodb()
   then userpass="-u $3 -p $4 admin"
   fi
 
-  local output="$( echo "$1" | mongo ${userpass} )"
+  # We want word-splitting on $userpass.
+  local output="$( echo "$1" | mongo $userpass )"
   echo "$output"
   if [[ -n "${2+x}" ]]
   then # test output against regex
@@ -2105,6 +2113,7 @@ configure_hosts_dns()
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
+    # We want word-splitting on $named_entries and $host_ip.
     for host_ip in ${named_entries//,/ }
     do add_host_to_zone ${host_ip//:/ }
     done
@@ -2645,6 +2654,7 @@ echo_installation_intentions()
   echo 'The following components should be installed:'
   local components='broker node named activemq datastore'
   local component
+  # We want word-splitting on $components.
   for component in $components
   do "$component" && printf '\t%s.\n' "$component"
   done
@@ -2692,6 +2702,7 @@ parse_args()
 # Parse the kernel command-line using parse_args.
 parse_kernel_cmdline()
 {
+  # We want word-splitting on the command substitution, so don't quote it.
   parse_args $(cat /proc/cmdline)
   : "${CONF_ABORT_ON_UNRECOGNIZED_SETTINGS:=false}"
 }
@@ -2842,6 +2853,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # If nothing is explicitly enabled, enable everything.
   local installing_something=0
+  # We want word-splitting on $components.
   for component in $components
   do
     if "$component"
@@ -3329,6 +3341,7 @@ install_rpms()
   echo 'OpenShift: Begin installing RPMs.'
   # We often rely on the latest SELinux policy and other updates.
   echo 'OpenShift: yum update'
+  # We want word-splitting (including null-argument removal) on $disable_plugin.
   yum $disable_plugin clean all
 
   local count=0

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -50,7 +50,7 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [[ -n "${!3}" ]]; then
+  if [[ -n "${!3-}" ]]; then
     printf -v "$1" '%s' "${!3}"
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
@@ -87,7 +87,7 @@ display_passwords()
     done
 
     for v in "${vprefix}user" "${vprefix}user1"; do
-      if [[ -n "${!v}" ]]; then
+      if [[ -n "${!v+x}" ]]; then
         matchingvar=$v
         break
       fi
@@ -120,7 +120,7 @@ configure_repos()
       eval "need_${repo}_repo() { false; }"
   done
 
-  is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
+  is_true "$enable_optional_repo" && need_optional_repo() { :; }
 
   if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
     need_extra_repo() { :; }
@@ -168,7 +168,7 @@ configure_repos()
   # The configure_yum_repos, configure_rhn_channels, and
   # configure_rhsm_channels functions will use the need_${repo}_repo
   # predicate functions define above.
-  case "$CONF_INSTALL_METHOD" in
+  case "$install_method" in
     (yum)
       configure_yum_repos
       ;;
@@ -202,7 +202,7 @@ configure_ose_yum_repos()
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [[ -n "$ose_repo_base" ]]; then
-      local layout=puddle; [[ -n "$CONF_CDN_LAYOUT" ]] && layout=cdn
+      local layout=puddle; [[ -n "$cdn_layout" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
     if [[ -n "$ose_extra_repo_base" ]]; then
@@ -227,7 +227,7 @@ gpgcheck=0
 sslverify=false
 priority=20
 sslverify=false
-exclude=tomcat6* ${CONF_YUM_EXCLUDE_PKGS}
+exclude=tomcat6* ${yum_exclude_pkgs}
 
 YUM
 fi
@@ -245,7 +245,7 @@ gpgcheck=0
 sslverify=false
 priority=20
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 fi
@@ -278,7 +278,7 @@ gpgcheck=0
 sslverify=false
 priority=10
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 }
@@ -294,7 +294,7 @@ enabled=1
 priority=10
 gpgcheck=0
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 
@@ -325,7 +325,7 @@ gpgcheck=0
 sslverify=false
 priority=30
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
   done
@@ -364,7 +364,7 @@ gpgcheck=0
 sslverify=false
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} ${CONF_YUM_EXCLUDE_PKGS}
+exclude=${exclude[$repo]} ${yum_exclude_pkgs}
 
 YUM
     fi
@@ -382,7 +382,7 @@ configure_subscription()
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
-   need_jbosseap_cartridge_repo && roles="$roles --role ${jbosseap_yumvalidator_role}"
+   need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
    oo-admin-yum-validator -o 2.2 --fix-all $roles # when fixing, rc is always false
@@ -398,16 +398,16 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [[ -n "$CONF_RHN_REG_ACTKEY" ]]; then
+  if [[ -n "$rhn_reg_actkey" ]]; then
     echo "OpenShift: Register to RHN Classic using an activation key"
-    rhnreg_ks --force "--activationkey=${CONF_RHN_REG_ACTKEY}" "--profilename=$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
+    rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # Don't log password.
       echo "OpenShift: Register to RHN Classic with username and password"
-      echo "rhnreg_ks --force \"--profilename=$profile_name\" --username \"${CONF_RHN_USER}\" ${CONF_RHN_REG_OPTS}"
-      rhnreg_ks --force "--profilename=$profile_name" --username "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" ${CONF_RHN_REG_OPTS} || abort_install
+      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" ${rhn_reg_opts}"
+      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "${rhn_user}" --password "${rhn_pass}" ${rhn_reg_opts} || abort_install
       set -x
     else
       echo "OpenShift: No credentials given for RHN Classic; assuming already configured"
@@ -424,14 +424,14 @@ configure_rhn_channels()
     fi
     need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.2-node' 'jb-ews-2-x86_64-server-6-rpm')
     need_client_tools_repo && repos+=('rhel-x86_64-server-6-ose-2.2-rhc')
-    need_jbosseap_cartridge_repo && repos+=("rhel-x86_64-server-6-ose-2.2-jbosseap" "jbappplatform-${jbosseap_version}-x86_64-server-6-rpm")
+    need_jbosseap_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbosseap' "jbappplatform-${jbosseap_version}-x86_64-server-6-rpm")
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
     set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
+      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
     done
     set -x
   fi
@@ -445,14 +445,14 @@ configure_rhsm_channels()
   then
     set +x # Don't log password.
     echo "OpenShift: Register with RHSM"
-    echo "subscription-manager register --force \"--username=$CONF_RHN_USER\" --name \"$profile_name\" ${CONF_RHN_REG_OPTS}"
-    subscription-manager register --force "--username=$CONF_RHN_USER" "--password=$CONF_RHN_PASS" --name "$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
+    echo "subscription-manager register --force \"--username=$rhn_user\" --name \"$rhn_profile_name\" ${rhn_reg_opts}"
+    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" ${rhn_reg_opts} || abort_install
     set -x
   else
     echo "OpenShift: No credentials given for RHSM; assuming already configured"
   fi
 
-  if [[ -n "${CONF_SM_REG_POOL}" ]]
+  if [[ -n "${sm_reg_pool}" ]]
   then
     echo "OpenShift: Removing all current subscriptions"
     subscription-manager remove --all
@@ -462,7 +462,7 @@ configure_rhsm_channels()
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
   local poolid
-  for poolid in ${CONF_SM_REG_POOL//[, :+\/-]/ }; do
+  for poolid in ${sm_reg_pool//[, :+\/-]/ }; do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
   done
@@ -526,7 +526,7 @@ install_broker_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-dns-nsupdate"
   pkgs="$pkgs openshift-origin-console"
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
-  is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
+  is_true "$enable_routing_plugin" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
   # We use semanage in configure_selinux_policy_on_broker, so we need to
   # install policycoreutils-python.
@@ -550,7 +550,7 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
 
-  if [[ "$CONF_SYSLOG" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]; then
     if rpm -q rsyslog ; then
       # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
@@ -919,11 +919,11 @@ configure_quotas_on_node()
 
 configure_idler_on_node()
 {
-  [[ "$CONF_IDLE_INTERVAL" =~ ^[[:digit:]]+$ ]] || return
+  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return
   cat <<CRON > /etc/cron.hourly/auto-idler
 (
   /usr/sbin/oo-last-access
-  /usr/sbin/oo-auto-idler idle --interval $CONF_IDLE_INTERVAL
+  /usr/sbin/oo-auto-idler idle --interval $idle_interval
 ) >> /var/log/openshift/node/auto-idler.log 2>&1
 CRON
   chmod +x /etc/cron.hourly/auto-idler
@@ -1002,13 +1002,13 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [[ -n "$3" && -n "$4" ]]; then
+  if [[ -n "${3+x}" && -n "${4+x}" ]]; then
     userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [[ -n "$2" ]]; then # test output against regex
+  if [[ -n "${2+x}" ]]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -1026,7 +1026,7 @@ configure_datastore_add_users()
     then
       echo 'while (rs.isMaster().primary == null) { sleep(5); }'
     fi
-    if is_false "$CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST"
+    if is_true "$enable_datastore_auth"
     then
       # Add an administrative user.
       echo 'use admin'
@@ -1177,7 +1177,7 @@ configure_gears()
   chkconfig openshift-gears on
 
   # configure gear logging
-  if [[ "$CONF_SYSLOG" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]; then
     # make the gear app servers log to syslog by default (overrideable)
     sed -i -e '
       /outputtype\b/I coutputType = syslog
@@ -1253,7 +1253,7 @@ enable_services_on_node()
 
   chkconfig httpd on
   chkconfig network on
-  is_false "$CONF_NO_NTP" && chkconfig ntpd on
+  is_true "$enable_ntp" && chkconfig ntpd on
   chkconfig sshd on
   chkconfig oddjobd on
   chkconfig openshift-node-web-proxy on
@@ -1269,7 +1269,7 @@ enable_services_on_broker()
 
   chkconfig httpd on
   chkconfig network on
-  is_false "$CONF_NO_NTP" && chkconfig ntpd on
+  is_true "$enable_ntp" && chkconfig ntpd on
   chkconfig sshd on
 }
 
@@ -1427,7 +1427,7 @@ configure_activemq()
   networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
 
   local schedulerSupport= routingPolicy=
-  if is_true "${CONF_ROUTING_PLUGIN}"
+  if is_true "${enable_routing_plugin}"
   then
     schedulerSupport='schedulerSupport="true"'
     IFS= read -r -d '' routingPolicy <<'EOF'
@@ -1549,7 +1549,7 @@ $networkConnectors
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
                ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
-               $( if is_true "$CONF_ROUTING_PLUGIN"; then
+               $( if is_true "$enable_routing_plugin"; then
                     echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
@@ -1564,7 +1564,7 @@ $networkConnectors
                   <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
-                  $( if is_true "$CONF_ROUTING_PLUGIN"; then
+                  $( if is_true "$enable_routing_plugin"; then
                        echo '<authorizationEntry topic="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                        echo '<authorizationEntry queue="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                      fi
@@ -1665,7 +1665,7 @@ configure_named()
 
   # Set up DNS forwarding if so directed.
   local forwarders="recursion no;"
-  if is_true "$CONF_FORWARD_DNS"; then
+  if is_true "$enable_dns_forwarding"; then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
     chmod 644 /var/named/forwarders.conf
@@ -1835,20 +1835,20 @@ configure_hosts_dns()
   # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
 
-  if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
+  if [[ -z "$named_entries" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-  elif [[ "$CONF_NAMED_ENTRIES" =~ : ]]; then
+  elif [[ "$named_entries" =~ : ]]; then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
-    for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
+    for host_ip in ${named_entries//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
   else # If "none" is specified, then just don't add anything.
-    echo "Not adding named entries; named_entries = $CONF_NAMED_ENTRIES"
+    echo "Not adding named entries; named_entries = $named_entries"
   fi
 }
 
@@ -1862,7 +1862,7 @@ register_named_entries()
   local host_ip
   local host
   local ip
-  for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
+  for host_ip in ${named_entries//,/ }; do
     read host ip <<<$(echo ${host_ip//:/ })
     if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
@@ -1961,9 +1961,9 @@ configure_controller()
       /etc/openshift/broker.conf
 
   # configure broker logs for syslog
-  [[ "$CONF_SYSLOG" = *broker* ]] && \
+  [[ "$log_to_syslog" = *broker* ]] && \
     sed -i -e '/SYSLOG_ENABLED=/ cSYSLOG_ENABLED="true"' /etc/openshift/broker.conf
-  [[ "$CONF_SYSLOG" = *console* ]] && \
+  [[ "$log_to_syslog" = *console* ]] && \
     echo 'SYSLOG_ENABLED="true"' >> /etc/openshift/console.conf
 
   # Set the ServerName for httpd
@@ -2034,14 +2034,14 @@ configure_httpd_auth()
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
-  if [[ -n "$CONF_BROKER_KRB_SERVICE_NAME" && -n "$CONF_BROKER_KRB_AUTH_REALMS" ]]
+  if [[ -n "$broker_krb_service_name" && -n "$broker_krb_auth_realms" ]]
   then
     yum_install_or_exit mod_auth_kerb
     local d
     for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
     do
-      sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
-        -e "s#KrbAuthRealms.*#KrbAuthRealms ${CONF_BROKER_KRB_AUTH_REALMS}#" \
+      sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
+        -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
 	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
     done
     return
@@ -2073,7 +2073,7 @@ configure_httpd_auth()
 
 configure_routing_plugin()
 {
-  if is_true "$CONF_ROUTING_PLUGIN"; then
+  if is_true "$enable_routing_plugin"; then
     local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
@@ -2246,7 +2246,7 @@ PORTS_PER_USER=${ports_per_gear}
 
 configure_node_logs()
 {
-  if [[ "$CONF_SYSLOG" = *node* ]]; then
+  if [[ "$log_to_syslog" = *node* ]]; then
     # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
@@ -2261,11 +2261,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
-  if [[ "$CONF_SYSLOG" = *frontend* ]]; then
+  if [[ "$log_to_syslog" = *frontend* ]]; then
     # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
-  if is_true "$CONF_NODE_LOG_CONTEXT"; then
+  if is_true "$node_log_context"; then
     # Annotate the frontend logs with UUIDs.
     sed -i -e '
       s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
@@ -2273,11 +2273,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
+  if [[ -n "$metrics_interval" ]]; then
     # Configure watchman with given the interval.
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
-      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$CONF_METRICS_INTERVAL/
+      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$metrics_interval/
     " /etc/openshift/node.conf
   fi
 }
@@ -2547,76 +2547,27 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   jbosseap_version="${CONF_JBOSSEAP_VERSION:-6.3}"
   # Check jbosseap_version for validity
-  case "${jbosseap_version}" in
+  case "$jbosseap_version" in
       (6.3|6.4)
-          jbosseap_version="${jbosseap_version}"
-          jbosseap_yumvalidator_role="node-eap-${jbosseap_version}"
+          jbosseap_version="$jbosseap_version"
+          jbosseap_yumvalidator_role="node-eap-$jbosseap_version"
           ;;
       (current|6)
           jbosseap_version="6"
-          jbosseap_yumvalidator_role="node-eap"
+          jbosseap_yumvalidator_role='node-eap'
           ;;
-    (*) abort_install "Unrecognized JBoss EAP channel version: ${CONF_JBOSSEAP_VERSION}" ;;
+    (*) abort_install "Unrecognized JBoss EAP channel version: $CONF_JBOSSEAP_VERSION" ;;
   esac
 
-  # There are no defaults for these.  Customers should be using
-  # subscriptions via RHN.  Internally, we use private systems.
-  rhel_repo="${CONF_RHEL_REPO%/}"
-  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
-  jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
-  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
-  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
-  fuse_extra_repo="${CONF_FUSE_EXTRA_REPO%/}"
-  amq_extra_repo="${CONF_AMQ_EXTRA_REPO%/}"
-  rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
-  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
-  rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
-  # Where to find the OpenShift repositories; just the base part before
-  # splitting out into Infrastructure/Node/etc.
-  ose_repo_base="${CONF_OSE_REPO_BASE:-$CONF_REPOS_BASE}"
-  ose_repo_base="${ose_repo_base%/}"
-
-  # Use CDN layout as the default for all yum repos if this is set.
-  cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [[ -n "$cdn_repo_base" ]]; then
-    rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
-    jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
-    rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
-    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
-    ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
-      CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
-    fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
-    CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
-  fi
-  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
-  rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
-  # There is no need to waste time checking both subscription plugins
-  # if using one is explicitly enabled.
-  disable_plugin=""
-  [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
-  [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
-  # We could do the same for "yum" method, but that would be more likely
-  # to surprise someone.
-  #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
-
-  # Check for subscription parameters under all previously used setting
-  # names.
-  CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
-  set +x # Don't log password.
-  CONF_RHN_PASS="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-$CONF_RHN_REG_PASS}}"
-  if [[ "${CONF_RHN_USER}" && "${CONF_RHN_PASS}" ]]; then
-    rhn_creds_provided=true
-  else
-    rhn_creds_provided=false
-  fi
-  set -x
+  named_entries="${CONF_NAMED_ENTRIES-}"
 
   # The domain name for the OpenShift Enterprise installation.
   domain="${CONF_DOMAIN:-example.com}"
   hosts_domain="${CONF_HOSTS_DOMAIN:-$domain}"
   hosts_domain_keyfile="${CONF_HOSTS_DOMAIN_KEYFILE:-/var/named/${hosts_domain}.key}"
+
+  keep_nameservers="${CONF_KEEP_NAMESERVERS:-false}"
+  keep_hostname="${CONF_KEEP_HOSTNAME:-false}"
 
   # Hostnames to use for the components (could all resolve to same host).
   broker_hostname=$(ensure_domain "${CONF_BROKER_HOSTNAME:-broker}" "$hosts_domain")
@@ -2651,8 +2602,91 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # host.
   node_ip_addr="${CONF_NODE_IP_ADDR:-$cur_ip_addr}"
 
-  # How to label the system when subscribing.
-  profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
+  # There are no defaults for these.  Customers should be using
+  # subscriptions via RHN.  Internally, we use private systems.
+  rhel_repo="${CONF_RHEL_REPO%/}"
+  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
+  jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
+  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
+  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
+  fuse_extra_repo="${CONF_FUSE_EXTRA_REPO%/}"
+  amq_extra_repo="${CONF_AMQ_EXTRA_REPO%/}"
+  rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
+  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
+  enable_optional_repo="${CONF_OPTIONAL_REPO:-false}"
+  rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
+  yum_exclude_pkgs="${CONF_YUM_EXCLUDE_PKGS-}"
+  # Where to find the OpenShift repositories; just the base part before
+  # splitting out into Infrastructure/Node/etc.
+  ose_repo_base="${CONF_OSE_REPO_BASE:-${CONF_REPOS_BASE-}}"
+  ose_repo_base="${ose_repo_base%/}"
+
+  # By default, do not use CDN layout for Yum repositories, unless
+  # CONF_CDN_REPO_BASE is set.
+  cdn_layout="${CONF_CDN_REPO_BASE-}"
+  cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
+  if [[ -n "$cdn_repo_base" ]]; then
+    rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
+    jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
+    rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
+    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
+    ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
+      cdn_layout=1  # use the CDN layout for OpenShift yum repos
+    fi
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
+    cdn_layout=1  # use the CDN layout for OpenShift yum repos
+  fi
+  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
+  rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
+
+  install_method="${CONF_INSTALL_METHOD:-none}"
+  # There is no need to waste time checking both subscription plugins
+  # if using one is explicitly enabled.
+  disable_plugin=
+  case "$install_method" in
+    (rhsm)
+      disable_plugin='--disableplugin=rhnplugin'
+      sm_reg_pool="${CONF_SM_REG_POOL-}"
+    ;;
+    (rhn)
+      disable_plugin='--disableplugin=subscription-manager'
+      rhn_reg_actkey="${CONF_RHN_REG_ACTKEY-}"
+    ;;
+    (yum)
+      # We could do the same for "yum" method, but that would be more likely
+      # to surprise someone.
+      #disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
+    ;;
+  esac
+
+  # Note: we use the rhn_user, rhn_pass, rhn_reg_opts, and rhn_profile_name
+  # variables for both RHN and RHSM.
+  if [[ "$install_method" =~ rhn|rhsm ]]
+  then
+    rhn_reg_opts="${CONF_RHN_REG_OPTS-}"
+
+    # Check for subscription parameters under all previously used setting
+    # names.
+    rhn_user="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-${CONF_RHN_REG_NAME-}}}"
+    set +x # Don't log password.
+    rhn_pass="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-${CONF_RHN_REG_PASS-}}}"
+    if [[ -n "$rhn_user" && -n "$rhn_pass" ]]
+    then rhn_creds_provided='true'
+    else rhn_creds_provided='false'
+    fi
+    set -x
+
+    # How to label the system when subscribing.
+    rhn_profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
+  fi
+
+  # Install and enable the ntpd daemon.
+  if is_true "${CONF_NO_NTP:-false}"
+  then enable_ntp='false'
+  else enable_ntp='true'
+  fi
+
 
   node_apache_frontend="${CONF_NODE_APACHE_FRONTEND:-vhost}"
 
@@ -2670,21 +2704,22 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # This should be a list of IP addresses with a semicolon after each.
   nameservers="$(awk '/nameserver/ { printf "%s; ", $2 }' /etc/resolv.conf)"
 
+  # Configure BIND to enable DNS forwarding.
+  enable_dns_forwarding="${CONF_FORWARD_DNS:-false}"
+
+  # Log the specified components to syslog.
+  log_to_syslog="${CONF_SYSLOG-}"
+
   # Main interface to configure
   interface="${CONF_INTERFACE:-eth0}"
 
-  # Set $bind_krb_keytab and $bind_krb_principal to the values of
-  # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values
-  # are both non-empty, or set $bind_key to the value of $CONF_BIND_KEY
-  # if the latter is non-empty.
-  if [[ -n "$CONF_BIND_KRB_KEYTAB" && -n "$CONF_BIND_KRB_PRINCIPAL" ]]; then
-  bind_krb_keytab="$CONF_BIND_KRB_KEYTAB"
-  bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
-  else
-  bind_key="$CONF_BIND_KEY"
+  # For Kerberos:
+  bind_krb_keytab="${CONF_BIND_KRB_KEYTAB-}"
+  bind_krb_principal="${CONF_BIND_KRB_PRINCIPAL-}"
+  # For key-based authentication:
+  bind_key="${CONF_BIND_KEY-}"
   bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-SHA256}"
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
-  fi
 
   local s
   for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
@@ -2692,15 +2727,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
-  [[ -n "$CONF_VALID_GEAR_SIZES" ]] && isset_valid_gear_sizes() { :; }
+  [[ -n "${CONF_VALID_GEAR_SIZES:+x}" ]] && isset_valid_gear_sizes() { :; }
   broker && valid_gear_sizes="${CONF_VALID_GEAR_SIZES:-small}"
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
-  [[ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ]] && isset_default_gear_capabilities() { :; }
+  [[ -n "${CONF_DEFAULT_GEAR_CAPABILITIES:+x}" ]] && isset_default_gear_capabilities() { :; }
   broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
-  [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
+  [[ -n "${CONF_DEFAULT_GEAR_SIZE:+x}" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
   node_profile="${CONF_NODE_PROFILE:-small}"
@@ -2721,11 +2756,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   sni_proxy_ports="${CONF_SNI_PROXY_PORTS:-$def_ports}"
   let "sni_last_port=$sni_first_port+$sni_proxy_ports-1"
 
+  idle_interval="${CONF_IDLE_INTERVAL-}"
+  node_log_context="${CONF_NODE_LOG_CONTEXT:-false}"
+  metrics_interval="${CONF_METRICS_INTERVAL-}"
+
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
   broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
-  broker && district_mappings=$CONF_DISTRICT_MAPPINGS
+  broker && district_mappings=${CONF_DISTRICT_MAPPINGS-}
 
   local randomized
 
@@ -2783,13 +2822,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   (broker || node || activemq) && mcollective_user="${CONF_MCOLLECTIVE_USER:-mcollective}"
   (broker || node || activemq) && assign_pass mcollective_password "marionette" CONF_MCOLLECTIVE_PASSWORD
 
+  # Enable authentication for MongoDB.
+  if is_true "${CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST:-false}"
+  then enable_datastore_auth='false'
+  else enable_datastore_auth='true'
+  fi
+
   #   These are the username and password of the administrative user
   #   that will be created in the MongoDB datastore. These credentials
   #   are not used by in this script or by OpenShift, but an
   #   administrative user must be added to MongoDB in order for it to
   #   enforce authentication.
   datastore && mongodb_admin_user="${CONF_MONGODB_ADMIN_USER:-admin}"
-  datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD}}
+  datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
   datastore &&  assign_pass mongodb_admin_password "mongopass" tmpvar
 
   #   These are the username and password of the normal user that will
@@ -2797,7 +2842,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   broker application's MongoDB plugin is also configured with these
   #   values.
   (datastore || broker) && mongodb_broker_user="${CONF_MONGODB_BROKER_USER:-openshift}"
-  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD}}
+  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
   (datastore || broker) && assign_pass mongodb_broker_password "mongopass" tmpvar
 
   #   In replicated setup, this is the key that slaves will use to
@@ -2818,8 +2863,12 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
+  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
   assign_pass routing_plugin_pass "routinginfopasswd" CONF_ROUTING_PLUGIN_PASS
+
+  broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
+  broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
@@ -2868,7 +2917,7 @@ validate_preflight()
   fi
 
   # test that subscription parameters are available if needed
-  if [[ "$CONF_INSTALL_METHOD" = rhn ]]; then
+  if [[ "$install_method" = rhn ]]; then
     # Check whether we are already registered with RHN and already have
     # ose-2.2 channels added.  If we are not, we will need RHN
     # credentials so that we can register and add channels ourselves.
@@ -2878,7 +2927,7 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
-      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2886,7 +2935,7 @@ validate_preflight()
     fi
   fi
 
-  if [[ "$CONF_INSTALL_METHOD" = rhsm ]]; then
+  if [[ "$install_method" = rhsm ]]; then
     # Check whether we are already registered with RHSM.  If we are not,
     # we will need credentials so that we can register ourselves.
     #
@@ -2894,7 +2943,7 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
       set +x # Don't log password.
-      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2911,15 +2960,15 @@ validate_preflight()
     # subscription-manager gets to write all of its plentiful output
     # before grep closes the pipeline.  Without it, we will get
     # a harmless but possibly alarming "Broken pipe" error message.
-    if [[ -z "$CONF_SM_REG_POOL" ]] &&
-        ( [[ -n "$CONF_RHN_USER" && -n "$CONF_RHN_PASS" ]] ||
+    if [[ -z "$sm_reg_pool" ]] &&
+        ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [[ "$CONF_INSTALL_METHOD" = yum && -z "$ose_repo_base" ]]; then
+  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]; then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -2968,13 +3017,13 @@ install_rpms()
 configure_host()
 {
   echo "OpenShift: Begin configuring host."
-  is_false "$CONF_NO_NTP" && synchronize_clock
+  is_true "$enable_ntp" && synchronize_clock
   # Note: configure_named must run before configure_controller if we are
   # installing both named and broker on the same host.
   named && configure_named
   configure_network
-  is_false "$CONF_KEEP_NAMESERVERS" && configure_dns_resolution
-  is_false "$CONF_KEEP_HOSTNAME" && configure_hostname
+  is_false "$keep_nameservers" && configure_dns_resolution
+  is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
   sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -559,6 +559,150 @@ configure_rhc()
   set_conf '/etc/openshift/express.conf' libra_server "'${broker_hostname}'"
 }
 
+# Configure the host to use an HTTP or HTTPS proxy for outgoing connections
+# so that Git and cartridge-specific packaging tools work properly.
+configure_outgoing_http_proxy()
+{
+  [[ -n "$outgoing_http_proxy" || -n "$outgoing_https_proxy" ]] || return 0
+
+  if node
+  then
+    # These environment variables should suffice for PERL's cpanm, PHP's
+    # PEAR, Python's easy_install, and Ruby's rubygems.
+    echo "localhost,127.*,*.$domain" > '/etc/openshift/env/no_proxy'
+    # Note that CPAN requires a proper URL, including schema.
+    if [[ -n "$outgoing_http_proxy" ]]
+    then
+      http_proxy_url="$outgoing_http_proxy"
+      if ! [[ "$http_proxy_url" =~ ^https?://* ]]
+      then http_proxy_url="http://$http_proxy_url"
+      fi
+      echo "$http_proxy_url" > '/etc/openshift/env/http_proxy'
+    fi
+    if [[ -n "$outgoing_https_proxy" ]]
+    then
+      https_proxy_url="$outgoing_https_proxy"
+      if ! [[ "$https_proxy_url" =~ ^https?://* ]]
+      then https_proxy_url="https://$https_proxy_url"
+      fi
+      echo "$https_proxy_url" > '/etc/openshift/env/https_proxy'
+    fi
+
+    # Configure NodeJS NPM to use the proxy.
+    mkdir -p '/etc/openshift/skel'
+    printf '%s\n' \
+      "proxy = $outgoing_http_proxy" \
+      "https-proxy = $outgoing_https_proxy" \
+      > '/etc/openshift/skel/.npmrc'
+
+    # Configure Maven for JBoss.
+    # So far all this fancy^H^H^H^H^Had hoc, good-enough parsing is needed only
+    # for Maven, but it could be moved earlier in the function if its results
+    # could be used elsewhere.
+    local http_proxy_auth https_proxy_auth \
+          http_proxy_user http_proxy_pass https_proxy_user https_proxy_pass \
+          http_proxy_host_port https_proxy_host_port \
+          http_proxy_hostname https_proxy_hostname \
+          http_proxy_port https_proxy_port \
+
+    # Strip any leading schemas (schema is inferred from the variable's name).
+    http_proxy_auth="${outgoing_http_proxy#*//}"
+    https_proxy_auth="${outgoing_https_proxy#*//}"
+
+    # Split on '@' into (possibly) authentication credentials and the rest.
+    read http_proxy_auth http_proxy_host_port <<<"${http_proxy_auth//@/ }"
+    read https_proxy_auth https_proxy_host_port <<<"${https_proxy_auth//@/ }"
+
+    if [[ -z "$http_proxy_host_port" ]]
+    then # No credentials were specified.
+      http_proxy_host_port="$http_proxy_auth"
+      http_proxy_auth=
+    else
+      read http_proxy_user http_proxy_pass <<<"${http_proxy_auth//:/ }"
+    fi
+
+    if [[ -z "$https_proxy_host_port" ]]
+    then # No credentials were specified.
+      https_proxy_host_port="$https_proxy_auth"
+      https_proxy_auth=
+    else
+      read https_proxy_user https_proxy_pass <<<"${https_proxy_auth//:/ }"
+    fi
+
+    # Strip any trailing slashes (and possibly more, but there shouldn't be
+    # anything more).
+    http_proxy_host_port="${http_proxy_host_port%/*}"
+    https_proxy_host_port="${https_proxy_host_port%/*}"
+
+    # Split on ':' into hostname and (possibly) port parts.
+    read http_proxy_hostname http_proxy_port <<<"${http_proxy_host_port//:/ }"
+    read https_proxy_hostname https_proxy_port <<<"${https_proxy_host_port//:/ }"
+
+    local proxies_stanza="\
+<settings>
+  <proxies>
+    ${outgoing_http_proxy:+<proxy>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${http_proxy_hostname}</host>
+      ${http_proxy_port:+<port>${http_proxy_port}</port>}
+      ${http_proxy_user:+<username>${http_proxy_user}</username>}
+      ${http_proxy_pass:+<password>${http_proxy_pass}</password>}
+      <nonProxyHosts>localhost|${domain}</nonProxyHosts>
+    </proxy>
+    }
+    ${outgoing_https_proxy:+<proxy>
+      <active>true</active>
+      <protocol>https</protocol>
+      <host>${https_proxy_hostname}</host>
+      ${https_proxy_port:+<port>${https_proxy_port}</port>}
+      ${https_proxy_user:+<username>${https_proxy_user}</username>}
+      ${https_proxy_pass:+<password>${https_proxy_pass}</password>}
+      <nonProxyHosts>localhost|${domain}</nonProxyHosts>
+    </proxy>
+}  </proxies>
+</settings>"
+    # Delete blank lines (this is the slowest part of this function--maybe use
+    # an external tool instead?).
+    shopt -s extglob # for *()
+    proxies_stanza="${proxies_stanza//$'\n'*([[:space:]])$'\n'/$'\n'}"
+    mkdir -p '/etc/openshift/skel/.m2'
+    local settings_xml='/etc/openshift/skel/.m2/settings.xml'
+    if ! [[ -e "$settings_xml" ]] || ! grep -q '<proxies>' "$settings_xml"
+    then
+      echo "$proxies_stanza" >> "$settings_xml"
+    else
+      # Escape newlines in $proxies_stanza so that we can use it in a sed
+      # expression.
+      proxies_stanza="${proxies_stanza//$'\n'/\\$'\n'}"
+      sed -i -e "/<proxies>/,/<\/proxies>/c$proxies_stanza" "$settings_xml"
+    fi
+  fi
+
+  # Configure Git so that downloadable cartridges can work.
+  cat <<EOF > '/etc/gitconfig'
+[http]
+      proxy = $outgoing_https_proxy
+[https]
+      proxy = $outgoing_https_proxy
+
+# git-clone seems to hang with HTTP over a Squid proxy where HTTPS works fine.
+[url "https://"]
+        insteadOf = http://
+
+[http "localhost"]
+      proxy =
+[http "${domain}"]
+      proxy =
+EOF
+
+  # Configure the broker to use the proxy for downloadable cartridges.
+  # Note: There is only one setting in /etc/openshift/broker.conf, HTTP_PROXY,
+  # which the broker uses for both HTTP and HTTPS connetions.  Usually, one will
+  # use an https: URL for downloadable cartridges, so we put that here.
+  broker && set_broker HTTP_PROXY "$outgoing_https_proxy"
+}
+
 # Install broker-specific packages.
 install_broker_pkgs()
 {
@@ -2542,7 +2686,7 @@ set_defaults()
   # The declare statement below is generated by the following command:
   #
   #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
   local setting
@@ -2940,6 +3084,9 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
   broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
 
+  outgoing_http_proxy="${CONF_HTTP_PROXY-}"
+  outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
+
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
 
@@ -3207,6 +3354,7 @@ configure_openshift()
   broker && configure_broker_ssl_cert
   broker && configure_access_keys_on_broker
   broker && configure_rhc
+  { node || broker; } && configure_outgoing_http_proxy
 
   node && configure_port_proxy
   node && configure_gears

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -106,8 +106,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+="${matchingvar##*_}: ${!matchingvar} "
+    [[ "$vprefix" != "$k" ]] && out_string+="${k##*_}"
     out_string+=": ${!k}"
     echo "$out_string"
   done

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -721,6 +721,8 @@ EOF
   # which the broker uses for both HTTP and HTTPS connetions.  Usually, one will
   # use an https: URL for downloadable cartridges, so we put that here.
   broker && set_broker HTTP_PROXY "$outgoing_https_proxy"
+
+  return 0
 }
 
 # Install broker-specific packages.

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -50,9 +50,11 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [[ -n "${!3-}" ]]; then
+  if [[ -n "${!3-}" ]]
+  then
     printf -v "$1" '%s' "${!3}"
-  elif is_true "$no_scramble" ; then
+  elif is_true "$no_scramble"
+  then
     printf -v "$1" '%s' "$2"
   else
     local randomized=$(openssl rand -base64 20)
@@ -78,23 +80,28 @@ display_passwords()
   subs[mongodb]="MongoDB"
   subs[activemq]="ActiveMQ"
 
-  for k in "${!passwords[@]}"; do
+  for k in "${!passwords[@]}"
+  do
     out_string=""
     matchingvar=""
-    for postfix in password password1 pass; do
+    for postfix in password password1 pass
+    do
       vprefix=${k%${postfix}}
       [[ "$vprefix" != "$k" ]] && break
     done
 
-    for v in "${vprefix}user" "${vprefix}user1"; do
-      if [[ -n "${!v+x}" ]]; then
+    for v in "${vprefix}user" "${vprefix}user1"
+    do
+      if [[ -n "${!v+x}" ]]
+      then
         matchingvar=$v
         break
       fi
     done
 
     formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}; do
+    for s in ${!subs[@]}
+    do
       formattedprefix=${formattedprefix//${s}/${subs[$s]}}
     done
 
@@ -116,17 +123,18 @@ configure_repos()
   # Make need_${repo}_repo return false by default.
   local repo
   for repo in optional infra node client_tools extra \
-              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews; do
-      eval "need_${repo}_repo() { false; }"
+              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews
+  do eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$enable_optional_repo" && need_optional_repo() { :; }
 
-  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
-    need_extra_repo() { :; }
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]
+  then need_extra_repo() { :; }
   fi
 
-  if activemq || broker || datastore || named; then
+  if activemq || broker || datastore || named
+  then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
     # packages.  The ose-infrastructure and ose-node channels also include
     # the yum-plugin-priorities package, which is needed for the installation
@@ -144,7 +152,8 @@ configure_repos()
   # install the client tools repo along with the infrastructure repo.
   need_infra_repo && need_client_tools_repo() { :; }
 
-  if node; then
+  if node
+  then
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
@@ -200,12 +209,15 @@ configure_yum_repos()
 configure_ose_yum_repos()
 {
   local repo
-  for repo in infra node jbosseap_cartridge client_tools; do
-    if [[ -n "$ose_repo_base" ]]; then
+  for repo in infra node jbosseap_cartridge client_tools
+  do
+    if [[ -n "$ose_repo_base" ]]
+    then
       local layout=puddle; [[ -n "$cdn_layout" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [[ -n "$ose_extra_repo_base" ]]; then
+    if [[ -n "$ose_extra_repo_base" ]]
+    then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -219,7 +231,8 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]; then
+if [[ -n "${rhel_repo}" ]]
+then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -237,7 +250,8 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]; then
+if [[ -n "${rhel_optional_repo}" ]]
+then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -287,7 +301,8 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]; then
+  if [[ -n "${rhscl_repo_base}" ]]
+  then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -316,7 +331,8 @@ configure_cart_repos()
   # in which case, add a repo base just for them. Use extras if needed for now.
 
   local repo
-  for repo in "${!url[@]}"; do
+  for repo in "${!url[@]}"
+  do
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
@@ -337,7 +353,8 @@ YUM
 configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]; then
+  if [[ -e "${extra_repo_file}" ]]
+  then
       > "${extra_repo_file}"
   fi
 
@@ -354,9 +371,11 @@ configure_extra_repos()
   )
 
   local repo
-  for repo in "${!priority[@]}"; do
+  for repo in "${!priority[@]}"
+  do
     local url="${!repo}"
-    if [[ -n "${url}" ]]; then
+    if [[ -n "${url}" ]]
+    then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -402,7 +421,8 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [[ -n "$rhn_reg_actkey" ]]; then
+  if [[ -n "$rhn_reg_actkey" ]]
+  then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
   else
@@ -423,8 +443,8 @@ configure_rhn_channels()
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
     local repos=('rhel-x86_64-server-6-rhscl-1')
-    if ! need_node_repo || need_infra_repo ; then
-      repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
+    if ! need_node_repo || need_infra_repo
+    then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
     need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.2-node' 'jb-ews-2-x86_64-server-6-rpm')
     need_client_tools_repo && repos+=('rhel-x86_64-server-6-ose-2.2-rhc')
@@ -434,8 +454,8 @@ configure_rhn_channels()
 
     set +x # Don't log password.
     local repo
-    for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    for repo in "${repos[@]}"
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
     done
     set -x
   fi
@@ -466,13 +486,15 @@ configure_rhsm_channels()
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
   local poolid
-  for poolid in ${sm_reg_pool//[, :+\/-]/ }; do
+  for poolid in ${sm_reg_pool//[, :+\/-]/ }
+  do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
   done
 
   # Enable the node or infrastructure repo to enable installing the release RPM
-  if need_node_repo; then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
+  if need_node_repo
+  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
   else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
   fi
   configure_subscription
@@ -490,9 +512,11 @@ yum_install_or_exit()
 {
   echo "OpenShift: yum install $*"
   local count=0
-  time while true; do
+  time while true
+  do
     yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]; then
+    if [[ $count -gt 3 ]]
+    then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -552,8 +576,10 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
 
-  if [[ "$log_to_syslog" = *gears* ]]; then
-    if rpm -q rsyslog ; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
+    if rpm -q rsyslog
+    then
       # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
 erase rsyslog
@@ -584,8 +610,8 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
-    yum $disable_plugin remove -y abrt-addon-python || abort_install
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
 
@@ -1018,13 +1044,14 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [[ -n "${3+x}" && -n "${4+x}" ]]; then
-    userpass="-u ${3} -p ${4} admin"
+  if [[ -n "${3+x}" && -n "${4+x}" ]]
+  then userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [[ -n "${2+x}" ]]; then # test output against regex
+  if [[ -n "${2+x}" ]]
+  then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -1190,7 +1217,8 @@ configure_gears()
   chkconfig openshift-gears on
 
   # configure gear logging
-  if [[ "$log_to_syslog" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
     # make the gear app servers log to syslog by default (overrideable)
     sed -i -e '
       /outputtype\b/I coutputType = syslog
@@ -1257,7 +1285,8 @@ enable_services_on_node()
   firewall_allow[wss]=tcp:8443
 
   # Allow connections to openshift-sni-proxy
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
@@ -1562,8 +1591,8 @@ $networkConnectors
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
                ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
-               $( if is_true "$enable_routing_plugin"; then
-                    echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+               $( if is_true "$enable_routing_plugin"
+                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -1577,7 +1606,8 @@ $networkConnectors
                   <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
-                  $( if is_true "$enable_routing_plugin"; then
+                  $( if is_true "$enable_routing_plugin"
+                     then
                        echo '<authorizationEntry topic="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                        echo '<authorizationEntry queue="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                      fi
@@ -1678,7 +1708,8 @@ configure_named()
 
   # Set up DNS forwarding if so directed.
   local forwarders="recursion no;"
-  if is_true "$enable_dns_forwarding"; then
+  if is_true "$enable_dns_forwarding"
+  then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
     chmod 644 /var/named/forwarders.conf
@@ -1763,7 +1794,8 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [[ -z "$bind_key" ]]; then
+  if [[ -z "$bind_key" ]]
+  then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -1833,10 +1865,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
-    echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else
-    echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
+  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 
@@ -1848,17 +1879,19 @@ configure_hosts_dns()
   # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
 
-  if [[ -z "$named_entries" ]]; then
+  if [[ -z "$named_entries" ]]
+  then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-  elif [[ "$named_entries" =~ : ]]; then
+  elif [[ "$named_entries" =~ : ]]
+  then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
-    for host_ip in ${named_entries//,/ }; do
-      add_host_to_zone ${host_ip//:/ }
+    for host_ip in ${named_entries//,/ }
+    do add_host_to_zone ${host_ip//:/ }
     done
   else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $named_entries"
@@ -1877,11 +1910,14 @@ register_named_entries()
   local host_ip
   local host
   local ip
-  for host_ip in ${named_entries//,/ }; do
+  for host_ip in ${named_entries//,/ }
+  do
     read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
+    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip; then
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    then
       echo "WARNING: Failed to register host $host with IP $ip"
       failed="true"
     fi
@@ -1896,7 +1932,8 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
   fi
@@ -2081,7 +2118,8 @@ configure_httpd_auth()
 
 configure_routing_plugin()
 {
-  if is_true "$enable_routing_plugin"; then
+  if is_true "$enable_routing_plugin"
+  then
     local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
@@ -2200,10 +2238,10 @@ configure_hostname()
 configure_node()
 {
   local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]; then
-    cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]; then
-    cp "$resrc.${node_profile}" $resrc
+  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
+  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
+  elif [[ -f "$resrc.${node_profile}" ]]
+  then cp "$resrc.${node_profile}" $resrc
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -2213,7 +2251,8 @@ configure_node()
   set_node BROKER_HOST "$broker_hostname"
   set_node EXTERNAL_ETH_DEV "$interface"
 
-  if [[ "$ports_per_gear" != 5 ]]; then
+  if [[ "$ports_per_gear" != 5 ]]
+  then
     set_node PORTS_PER_USER "$ports_per_gear" '' \
      'Number of proxy ports available per gear. Increasing the ports per gear'\
      'requires reducing the number of UIDs the district has so that the ports'\
@@ -2230,7 +2269,8 @@ configure_node()
       ;;
   esac
 
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
@@ -2252,7 +2292,8 @@ configure_node()
 
 configure_node_logs()
 {
-  if [[ "$log_to_syslog" = *node* ]]; then
+  if [[ "$log_to_syslog" = *node* ]]
+  then
     # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
@@ -2267,17 +2308,20 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
-  if [[ "$log_to_syslog" = *frontend* ]]; then
+  if [[ "$log_to_syslog" = *frontend* ]]
+  then
     # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
-  if is_true "$node_log_context"; then
+  if is_true "$node_log_context"
+  then
     # Annotate the frontend logs with UUIDs.
     set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ -n "$metrics_interval" ]]; then
+  if [[ -n "$metrics_interval" ]]
+  then
     # Configure watchman with given the interval.
     set_node WATCHMAN_METRICS_ENABLED 'true'
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
@@ -2303,9 +2347,11 @@ install_rsync_pub_key()
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]; do
+  while [[ `date +%s` -lt $end ]]
+  do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}"); then
+    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    then
       sleep 5
     else
       if ! ssh-keygen -lf /dev/stdin <<< "$cert"
@@ -2626,16 +2672,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # CONF_CDN_REPO_BASE is set.
   cdn_layout="${CONF_CDN_REPO_BASE-}"
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [[ -n "$cdn_repo_base" ]]; then
+  if [[ -n "$cdn_repo_base" ]]
+  then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
@@ -2723,8 +2772,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
 
   local s
-  for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
-    eval "isset_${s}() { false; }"
+  for s in valid_gear_sizes default_gear_capabilities default_gear_size
+  do eval "isset_${s}() { false; }"
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
@@ -2789,7 +2838,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
-  datastore_replicants="$( for repl in ${datastore_replicants//,/ }; do
+  datastore_replicants="$( for repl in ${datastore_replicants//,/ }
+                           do
                              [[ "$repl" =~ : ]] || repl=$repl:27017
                              printf ",%s" "${repl}"
                            done)"
@@ -2897,29 +2947,34 @@ validate_preflight()
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release; then
+  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  then
     echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]] ; then
+  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  then
     echo "OpenShift: SELinux needs to be installed and enabled."
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
-  if ! command -v rpm || ! command -v yum; then
+  if ! command -v rpm || ! command -v yum
+  then
     echo "OpenShift: rpm and yum must be installed."
     preflight_failure=1
   fi
-  if ! rpm -q rpm yum; then
+  if ! rpm -q rpm yum
+  then
     echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
     preflight_failure=1
   fi
 
   # test that subscription parameters are available if needed
-  if [[ "$install_method" = rhn ]]; then
+  if [[ "$install_method" = rhn ]]
+  then
     # Check whether we are already registered with RHN and already have
     # ose-2.2 channels added.  If we are not, we will need RHN
     # credentials so that we can register and add channels ourselves.
@@ -2929,7 +2984,8 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2937,15 +2993,18 @@ validate_preflight()
     fi
   fi
 
-  if [[ "$install_method" = rhsm ]]; then
+  if [[ "$install_method" = rhsm ]]
+  then
     # Check whether we are already registered with RHSM.  If we are not,
     # we will need credentials so that we can register ourselves.
     #
     # Note: With RHSM, we need credentials for registration but not for
     # adding channels.
-    if ! subscription-manager identity | grep -q 'identity is:'; then
+    if ! subscription-manager identity | grep -q 'identity is:'
+    then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -2964,13 +3023,15 @@ validate_preflight()
     # a harmless but possibly alarming "Broken pipe" error message.
     if [[ -z "$sm_reg_pool" ]] &&
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
-          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
+          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
+    then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]; then
+  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
+  then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -2990,12 +3051,11 @@ install_rpms()
   yum $disable_plugin clean all
 
   local count=0
-  while true; do
-    yum $disable_plugin update -y
-    if [[ $? -eq 0 ]]; then
-      break
-    elif [[ $count -gt 3 ]]; then
-      abort_install
+  while true
+  do
+    yum $disable_plugin update -y && break
+    if [[ $count -gt 3 ]]
+    then abort_install
     fi
     let count+=1
   done
@@ -3204,9 +3264,11 @@ configure_districts()
   date +%Y-%m-%d-%H:%M:%S
 
   local restart=$RESTART_NEEDED
-  if is_true "$default_districts"; then
+  if is_true "$default_districts"
+  then
     local p
-    for p in ${valid_gear_sizes//,/ }; do
+    for p in ${valid_gear_sizes//,/ }
+    do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
       oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
@@ -3218,18 +3280,21 @@ configure_districts()
     local nodes
     local district
     local mapping
-    for mapping in ${district_mappings//;/ }; do
+    for mapping in ${district_mappings//;/ }
+    do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
       firstnode=${nodes//,*/}
       # Query the node for the node profile via MCollective.
       profile=""
-      for i in {1..10}; do
+      for i in {1..10}
+      do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
          && break
         sleep 10
       done
-      if [[ -n "$profile" ]]; then
+      if [[ -n "$profile" ]]
+      then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -3250,8 +3315,10 @@ post_deploy()
 {
   echo "OpenShift: Begin post deployment steps."
 
-  if broker; then
-    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size; then
+  if broker
+  then
+    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size
+    then
       update_controller_gear_size_configs
       RESTART_NEEDED=true
     fi
@@ -3310,9 +3377,10 @@ RESTART_NEEDED=false
 RESTART_COMPLETED=false
 
 # Make sure /sbin and /usr/sbin are in PATH
-for admin_path in /sbin /usr/sbin; do
-  if [[ :$PATH: != *:"${admin_path}":* ]] ; then
-    PATH=${PATH}:${admin_path}
+for admin_path in /sbin /usr/sbin
+do
+  if [[ :$PATH: != *:"${admin_path}":* ]]
+  then PATH=${PATH}:${admin_path}
   fi
 done
 

--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -2106,7 +2106,7 @@ configure_hosts_dns()
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-    router && add_host_to_zone "$router_hostname" "$cur_ip_addr"
+    router && add_host_to_zone "$router_hostname" "$cur_ip_addr" "$domain"
   elif [[ "$named_entries" =~ : ]]
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
@@ -2366,6 +2366,8 @@ configure_routing_daemon()
   set_routing_daemon CLOUD_DOMAIN "$domain"
 
   [[ "$router" = nginx ]] && service openshift-routing-daemon start
+
+  return 0
 }
 
 configure_routing_plugin()
@@ -2866,6 +2868,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     do
       eval "$component() { :; }"
     done
+  fi
+
+  if router
+  then
+    if broker || node
+    then abort_install 'The router component cannot be installed on the same host as the broker or node components.'
+    fi
   fi
 
   # Following are some settings used in subsequent steps.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2572,11 +2572,6 @@ EOF
   chown 'apache:apache' "$mcollective_cfg"
   chmod 640 "$mcollective_cfg"
 
-  # Make sure the MCollective client log is created with proper ownership.
-  # If root owns it, the broker (apache user) can't log to it.
-  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
-  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
-
   RESTART_NEEDED=true
 }
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3030,7 +3030,9 @@ fix_broker_routing()
   case "$node_apache_frontend" in
     vhost)
       # node vhost obscures the broker vhost unless we bring the broker conf forward
-      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      if [[ ! -e '/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf' ]]
+      then ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      fi
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3235,11 +3235,11 @@ install_rsync_pub_key()
     if [[ $? -ne 0 ]]; then
       sleep 5
     else
-      ssh-keygen -lf /dev/stdin <<< $cert
+      ssh-keygen -lf /dev/stdin <<< "$cert"
       if [[ $? -ne 0 ]]; then
         break
       else
-        echo $cert >> /root/.ssh/authorized_keys
+        echo "$cert" >> /root/.ssh/authorized_keys
         echo "OpenShift node: SSH key downloaded from broker successfully."
         chmod 644 /root/.ssh/authorized_keys
         return

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -989,7 +989,7 @@ assign_pass()
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
   else
-    randomized=$(openssl rand -base64 20)
+    local randomized=$(openssl rand -base64 20)
     printf -v "$1" '%s' "${randomized//[![:alnum:]]}"
   fi
   passwords[$1]="${!1}"
@@ -998,6 +998,20 @@ assign_pass()
 display_passwords()
 {
   set +x
+  local k
+  local v
+  local s
+  local vprefix
+  local postfix
+  local out_string
+  local matchingvar
+  local formattedprefix
+  local -A subs
+  subs[openshift]="OpenShift"
+  subs[mcollective]="MCollective"
+  subs[mongodb]="MongoDB"
+  subs[activemq]="ActiveMQ"
+
   for k in "${!passwords[@]}"; do
     out_string=""
     matchingvar=""
@@ -1012,12 +1026,6 @@ display_passwords()
         break
       fi
     done
-
-    local -A subs
-    subs[openshift]="OpenShift"
-    subs[mcollective]="MCollective"
-    subs[mongodb]="MongoDB"
-    subs[activemq]="ActiveMQ"
 
     formattedprefix=${vprefix//_/ }
     for s in ${!subs[@]}; do
@@ -1040,6 +1048,7 @@ configure_repos()
   # functions.
 
   # Make need_${repo}_repo return false by default.
+  local repo
   for repo in optional infra node client_tools extra \
               fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews; do
       eval "need_${repo}_repo() { false; }"
@@ -1123,9 +1132,10 @@ configure_yum_repos()
 configure_ose_yum_repos()
 { # define plain yum repos if the parameters are given
   # this can be useful even if the main subscription is via RHN
+  local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [ "$ose_repo_base" != "" ]; then
-      layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+      local layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
     if [ "$ose_extra_repo_base" != "" ]; then
@@ -1174,11 +1184,12 @@ fi
 
 def_ose_yum_repo()
 {
-  repo_base=$1
-  layout=$2  # one of: puddle, extra, cdn
-  channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
+  local repo_base=$1
+  local layout=$2  # one of: puddle, extra, cdn
+  local channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
 
-  declare -A map
+  local -A map
+  local url
   case $layout in
   puddle | extra)
     map=([client_tools]=RHOSE-CLIENT-2.2 [infra]=RHOSE-INFRA-2.2 [node]=RHOSE-NODE-2.2 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.2)
@@ -1249,7 +1260,7 @@ YUM
 
 configure_extra_repos()
 { # add all defined extra repos in one file
-  extra_repo_file=/etc/yum.repos.d/ose_extra.repo
+  local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [ -e "${extra_repo_file}" ]; then
       echo > "${extra_repo_file}"
   fi
@@ -1292,7 +1303,7 @@ configure_subscription()
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
-   roles=""  # we will build the list of roles we need, then enable them.
+   local roles=""  # we will build the list of roles we need, then enable them.
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
@@ -1331,7 +1342,7 @@ configure_rhn_channels()
   if [ $rhn_creds_provided ]
   then
     # Enable the node or infrastructure channel to enable installing the release RPM
-    repos=('rhel-x86_64-server-6-rhscl-1')
+    local repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo ; then
       repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
@@ -1342,6 +1353,7 @@ configure_rhn_channels()
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
     set +x # don't log password
+    local repo
     for repo in "${repos[@]}"; do
       [[ "$(rhn-channel -l)" == *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
     done
@@ -1373,6 +1385,7 @@ configure_rhsm_channels()
   fi
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
+  local poolid
   for poolid in ${CONF_SM_REG_POOL//[, :+\/-]/ }; do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
@@ -1396,17 +1409,17 @@ abort_install()
 yum_install_or_exit()
 {
   echo "OpenShift: yum install $*"
-  COUNT=0
+  local count=0
   time while true; do
     yum install -y $* $disable_plugin
     if [ $? -eq 0 ]; then
       return
-    elif [ $COUNT -gt 3 ]; then
+    elif [ $count -gt 3 ]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
     fi
-    let COUNT+=1
+    let count+=1
   done
 }
 
@@ -1580,6 +1593,8 @@ parse_cartridges()
   # the documentation on the CONF_CARTRIDGES / cartridges options for
   # the rules governing how $cartridges will be passed.
   local pkgs=( )
+  local pkg
+  local cart_spec
   for cart_spec in ${cartridges//,/ }
   do
     if [[ "${cart_spec:0:1}" = - ]]
@@ -1602,6 +1617,7 @@ parse_cartridges()
 
   if metapkgs_optional || metapkgs_recommended
   then
+    local metapkg
     for metapkg in ${meta[@]}
     do
       if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
@@ -1752,6 +1768,8 @@ configure_pam_on_node()
 {
   sed -i -e 's|pam_selinux|pam_openshift|g' /etc/pam.d/sshd
 
+  local t
+  local f
   for f in "runuser" "runuser-l" "sshd" "su" "system-auth-ac"
   do
     t="/etc/pam.d/$f"
@@ -1778,6 +1796,8 @@ configure_pam_on_node()
 
 configure_cgroups_on_node()
 {
+  local t
+  local f
   for f in "runuser" "runuser-l" "sshd" "system-auth-ac"
   do
     t="/etc/pam.d/$f"
@@ -1798,7 +1818,7 @@ configure_cgroups_on_node()
 configure_quotas_on_node()
 {
   # Get the mountpoint for /var/lib/openshift (should be /).
-  geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
+  local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
   if ! [ x"$geardata_mnt" != x ]
   then
@@ -1906,13 +1926,12 @@ execute_mongodb()
   echo "$1"
   echo "---"
 
+  local userpass=
   if [ -n "$3" -a -n "$4" ]; then
     userpass="-u ${3} -p ${4} admin"
-  else
-    userpass=""
   fi
 
-  output="$( echo "$1" | mongo ${userpass} )"
+  local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
   if [ "$2" ]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
@@ -1960,12 +1979,14 @@ configure_datastore_add_replicants()
   time execute_mongodb 'rs.initiate()' '"ok" : 1' ||
     abort_install "OpenShift: Failed to form MongoDB replica set; please do this manually."
 
-  master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
+  local master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
     abort_install "OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually."
 
   configure_datastore_add_users
 
   # Configure the replica set.
+  local i
+  local replicant
   for replicant in ${datastore_replicants//,/ }
   do
     if [[ "$replicant" != "${master_out#host=}" ]]
@@ -2180,8 +2201,10 @@ enable_services_on_broker()
 
 generate_mcollective_pools_configuration()
 {
-  num_replicants=0
-  members=
+  local num_replicants=0
+  local members=
+  local new_member
+  local replicant
   for replicant in ${activemq_replicants//,/ }
   do
     let num_replicants=num_replicants+1
@@ -2203,8 +2226,8 @@ plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
 # https://bugzilla.redhat.com/show_bug.cgi?id=963332
 configure_mcollective_for_activemq_on_broker()
 {
-  MCOLLECTIVE_CFG="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
-  cat <<EOF > $MCOLLECTIVE_CFG
+  local mcollective_cfg="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
+  cat <<EOF > $mcollective_cfg
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2233,8 +2256,8 @@ plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 
 EOF
 
-  chown apache:apache $MCOLLECTIVE_CFG
-  chmod 640 $MCOLLECTIVE_CFG
+  chown apache:apache $mcollective_cfg
+  chmod 640 $mcollective_cfg
 
   # make sure mcollective client log is created with proper ownership.
   # if root owns it, the broker (apache user) can't log to it.
@@ -2295,6 +2318,7 @@ configure_activemq()
   local networkConnectors=
   local authenticationUser_amq=
   function allow_openwire() { false; }
+  local replicant
   for replicant in ${activemq_replicants//,/ }
   do
     if ! [ "$replicant" = "$activemq_hostname" ]
@@ -2565,7 +2589,7 @@ configure_named()
   chmod 640 /etc/rndc.key
 
   # Set up DNS forwarding if so directed.
-  forwarders="recursion no;"
+  local forwarders="recursion no;"
   if is_true "$CONF_FORWARD_DNS"; then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
@@ -2649,11 +2673,11 @@ EOF
 
 configure_named_zone()
 {
-  zone="$1"
+  local zone="$1"
 
   if [ "x$bind_key" = x ]; then
     # Generate a new secret key
-    zone_tolower="${zone,,}"
+    local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
     dnssec-keygen -a ${bind_keyalgorithm} -b ${bind_keysize} -n USER -r /dev/urandom -K /var/named ${zone}
     # $zone may have uppercase letters in it.  However the file that
@@ -2711,10 +2735,10 @@ ensure_domain()
 add_host_to_zone()
 {
   # $1 = host; $2 = ip; [ $3 = zone ]
-  zone="${3:-$hosts_domain}"
-  nsdb="/var/named/dynamic/${zone}.db"
+  local zone="${3:-$hosts_domain}"
+  local nsdb="/var/named/dynamic/${zone}.db"
   # sanity check that $1 isn't an IP, and $2 is.
-  ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
@@ -2735,6 +2759,7 @@ configure_hosts_dns()
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
   elif [[ "$CONF_NAMED_ENTRIES" =~ : ]]; then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
+    local host_ip
     for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
@@ -2747,8 +2772,11 @@ configure_hosts_dns()
 # using oo-register-dns. Not used by default.
 register_named_entries()
 {
-  ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
-  failed="false"
+  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  local failed="false"
+  local host_ip
+  local host
+  local ip
   for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
     read host ip <<<$(echo ${host_ip//:/ })
     if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
@@ -2922,6 +2950,7 @@ configure_httpd_auth()
   if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
   then
     yum_install_or_exit mod_auth_kerb
+    local d
     for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
@@ -2958,7 +2987,7 @@ configure_httpd_auth()
 configure_routing_plugin()
 {
   if is_true "$CONF_ROUTING_PLUGIN"; then
-    conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
+    local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
 ACTIVEMQ_HOST='$activemq_replicants'
@@ -3180,11 +3209,12 @@ install_rsync_pub_key()
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
 
-  WAIT=600
-  END=`date -d "$WAIT seconds" +%s`
-  echo "OpenShift node: will wait for $WAIT seconds to fetch SSH key."
+  local wait=600
+  local end=`date -d "$wait seconds" +%s`
+  echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
-  while [[ `date +%s` -lt $END ]]; do
+  local cert
+  while [[ `date +%s` -lt $end ]]; do
     # try to get key hosted on broker machine
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
     if [ $? -ne 0 ]; then
@@ -3209,6 +3239,8 @@ install_rsync_pub_key()
 echo_installation_intentions()
 {
   echo "The following components should be installed:"
+  local components='broker node named activemq datastore'
+  local component
   for component in $components
   do "$component" && printf '\t%s.\n' "$component"
   done
@@ -3239,6 +3271,8 @@ configure_console_msg()
 # and CONF_BAZ=true in the environment.
 parse_args()
 {
+  local key
+  local word
   for word in "$@"
   do
     key="${word%%\=*}"
@@ -3353,10 +3387,11 @@ set_defaults()
   #
   # The declare statement below is generated by the following command:
   #
-  #   echo declare -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_JBOSSEAP_VERSION]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_ISOLATE_GEARS]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+  #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
+  local setting
   for setting in "${!CONF_@}"
   do
     if ! [[ ${valid_settings[$setting]+1} ]]
@@ -3379,15 +3414,17 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   actions="${CONF_ACTIONS:-do_all_actions}"
 
   # Following are the different components that can be installed:
-  components='broker node named activemq datastore'
+  local components='broker node named activemq datastore'
 
   # By default, each component is _not_ installed.
+  local component
   for component in $components
   do
     eval "$component() { false; }"
   done
 
   # But any or all components may be explicity enabled.
+  local component
   for component in ${CONF_INSTALL_COMPONENTS//,/ }
   do
     case "$component" in
@@ -3398,7 +3435,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   done
 
   # If nothing is explicitly enabled, enable everything.
-  installing_something=0
+  local installing_something=0
   for component in $components
   do
     if "$component"
@@ -3558,6 +3595,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
   fi
 
+  local s
   for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
     eval "isset_${s}() { false; }"
   done
@@ -3598,6 +3636,8 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
   broker && district_mappings=$CONF_DISTRICT_MAPPINGS
+
+  local randomized
 
   # Generate a random salt for the broker authentication.
   randomized=$(openssl rand -base64 20)
@@ -3713,7 +3753,7 @@ init_message()
 validate_preflight()
 {
   echo "OpenShift: Begin preflight validation."
-  preflight_failure=
+  local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
   if ! grep -q "Enterprise.* 6" /etc/redhat-release; then
@@ -3808,15 +3848,15 @@ install_rpms()
   echo "OpenShift: yum update"
   yum $disable_plugin clean all
 
-  COUNT=0
+  local count=0
   while true; do
     yum $disable_plugin update -y
     if [ $? -eq 0 ]; then
       break
-    elif [ $COUNT -gt 3 ]; then
+    elif [ $count -gt 3 ]; then
       abort_install
     fi
-    let COUNT+=1
+    let count+=1
   done
 
   # Install a few packages missing from a minimal RHEL install required by the
@@ -3864,7 +3904,7 @@ configure_host()
 configure_firewall()
 {
   # Disable lokkit.
-  conf='/etc/sysconfig/system-config-firewall'
+  local conf='/etc/sysconfig/system-config-firewall'
   [[ -e "$conf" && "$(< "$conf")" != --disabled ]] && mv "$conf" "${conf}.bak"
   echo '--disabled' > "$conf"
 
@@ -3889,7 +3929,11 @@ EOF
 # Note: This function must be run after configure_firewall.
 configure_firewall_add_rules()
 {
-  rules=""
+  local rules=""
+  local port
+  local prot
+  local rule
+  local svc
   for svc in ${!firewall_allow[@]}
   do
     rules+="$(
@@ -4020,12 +4064,19 @@ configure_districts()
 
   local restart=$RESTART_NEEDED
   if is_true "$default_districts"; then
+    local p
     for p in ${valid_gear_sizes//,/ }; do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
       oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
     done
   else
+    local i
+    local profile
+    local firstnode
+    local nodes
+    local district
+    local mapping
     for mapping in ${district_mappings//;/ }; do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1436,7 +1436,7 @@ configure_rhn_channels()
   then
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
-    local repos=('rhel-x86_64-server-6-rhscl-1')
+    local -a repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo
     then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
@@ -1852,7 +1852,7 @@ parse_cartridges()
   # cartridges that the user instructs us to install ($cartridges).  See
   # the documentation on the CONF_CARTRIDGES / cartridges options for
   # the rules governing how $cartridges will be passed.
-  local pkgs=( )
+  local -a pkgs=( )
   local pkg
   local cart_spec
   for cart_spec in ${cartridges//,/ }

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1397,6 +1397,7 @@ configure_subscription()
    need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
+   # We want word-splitting on $roles.
    oo-admin-yum-validator -o 2.2 --fix-all $roles || : # when fixing, rc is always false
    oo-admin-yum-validator -o 2.2 $roles || abort_install # so check when fixes are done
 
@@ -1415,6 +1416,7 @@ configure_rhn_channels()
   if [[ -n "$rhn_reg_actkey" ]]
   then
     echo 'OpenShift: Register to RHN Classic using an activation key'
+    # We want word-splitting on $rhn_reg_opts.
     rhnreg_ks --force "--activationkey=$rhn_reg_actkey" "--profilename=$rhn_profile_name" $rhn_reg_opts || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
@@ -1711,6 +1713,7 @@ install_broker_pkgs()
   # install policycoreutils-python.
   pkgs="$pkgs policycoreutils-python"
 
+  # We want word-splitting on $pkgs.
   yum_install_or_exit $pkgs
 }
 
@@ -1755,6 +1758,7 @@ YUM
       ;;
   esac
 
+  # We want word-splitting on $pkgs.
   yum_install_or_exit $pkgs
 }
 
@@ -1857,7 +1861,7 @@ parse_cartridges()
     then
       # Remove every package indicated by the cart_spec, or remove the package
       # with name equal to $cart_spec itself if the cart_spec does not map to
-      # anything in $p.
+      # anything in $p.  This means we want word-splitting, so don't quote it.
       for pkg in ${p[${cart_spec:1}]:-${cart_spec:1}}
       do
         for k in "${!pkgs[@]}"
@@ -1865,8 +1869,10 @@ parse_cartridges()
         done
       done
     else
-      # Append all packages indicated by the cart_spec, or append
-      # $cart_spec itself if it does not map to anything in $p.
+      # Append all packages indicated by the cart_spec, or append $cart_spec
+      # itself if it does not map to anything in $p.  We want word-splitting
+      # in case $cart_spec or ${p[$cart_spec]} maps to multiple cartridges, so
+      # don't quote it.
       pkgs+=( ${p[$cart_spec]:-$cart_spec} )
     fi
   done
@@ -1912,6 +1918,7 @@ install_cartridges()
   # still install as much as possible.
   #install_cart_pkgs="${install_cart_pkgs} --skip-broken"
 
+  # We want word-splitting on $install_cart_pkgs.
   yum_install_or_exit $install_cart_pkgs
 }
 
@@ -2235,7 +2242,8 @@ execute_mongodb()
   then userpass="-u $3 -p $4 admin"
   fi
 
-  local output="$( echo "$1" | mongo ${userpass} )"
+  # We want word-splitting on $userpass.
+  local output="$( echo "$1" | mongo $userpass )"
   echo "$output"
   if [[ -n "${2+x}" ]]
   then # test output against regex
@@ -3078,6 +3086,7 @@ configure_hosts_dns()
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
+    # We want word-splitting on $named_entries and $host_ip.
     for host_ip in ${named_entries//,/ }
     do add_host_to_zone ${host_ip//:/ }
     done
@@ -3618,6 +3627,7 @@ echo_installation_intentions()
   echo 'The following components should be installed:'
   local components='broker node named activemq datastore'
   local component
+  # We want word-splitting on $components.
   for component in $components
   do "$component" && printf '\t%s.\n' "$component"
   done
@@ -3665,6 +3675,7 @@ parse_args()
 # Parse the kernel command-line using parse_args.
 parse_kernel_cmdline()
 {
+  # We want word-splitting on the command substitution, so don't quote it.
   parse_args $(cat /proc/cmdline)
   : "${CONF_ABORT_ON_UNRECOGNIZED_SETTINGS:=false}"
 }
@@ -3815,6 +3826,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # If nothing is explicitly enabled, enable everything.
   local installing_something=0
+  # We want word-splitting on $components.
   for component in $components
   do
     if "$component"
@@ -4302,6 +4314,7 @@ install_rpms()
   echo 'OpenShift: Begin installing RPMs.'
   # We often rely on the latest SELinux policy and other updates.
   echo 'OpenShift: yum update'
+  # We want word-splitting (including null-argument removal) on $disable_plugin.
   yum $disable_plugin clean all
 
   local count=0

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2037,6 +2037,10 @@ configure_datastore()
   # Require authentication.
   set_mongodb auth true
 
+  # Workaround for oo-accept-broker, which performs a strict pattern match for
+  # 'auth = true' (with spaces).
+  sed -i -e 's/auth=true/auth = true/' '/etc/mongodb.conf'
+
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1129,9 +1129,10 @@ configure_yum_repos()
   yum_install_or_exit openshift-enterprise-release
 }
 
+# Define plain Yum repos if the parameters are given.
+# This can be useful even if the main subscription is via RHN.
 configure_ose_yum_repos()
-{ # define plain yum repos if the parameters are given
-  # this can be useful even if the main subscription is via RHN
+{
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [[ -n "$ose_repo_base" ]]; then
@@ -1230,8 +1231,9 @@ YUM
   fi
 }
 
+# Add any Yum repositories that are needed for cartridges or their dependencies.
 configure_cart_repos()
-{ # add cartridge (or dependency) repo as needed
+{
   local -A url=(
           [jbosseap]="${jboss_repo_base}/jbeap/${jbosseap_version}/os"
           [jbossews]="${jboss_repo_base}/jbews/2/os"
@@ -1258,8 +1260,9 @@ YUM
   done
 }
 
+# Add all defined extra repos in one file.
 configure_extra_repos()
-{ # add all defined extra repos in one file
+{
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [[ -e "${extra_repo_file}" ]]; then
       echo > "${extra_repo_file}"
@@ -1329,7 +1332,7 @@ configure_rhn_channels()
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
-      set +x # don't log password
+      set +x # Don't log password.
       echo "OpenShift: Register to RHN Classic with username and password"
       echo "rhnreg_ks --force \"--profilename=$profile_name\" --username \"${CONF_RHN_USER}\" ${CONF_RHN_REG_OPTS}"
       rhnreg_ks --force "--profilename=$profile_name" --username "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" ${CONF_RHN_REG_OPTS} || abort_install
@@ -1341,7 +1344,8 @@ configure_rhn_channels()
 
   if [[ -n "$rhn_creds_provided" ]]
   then
-    # Enable the node or infrastructure channel to enable installing the release RPM
+    # Enable the node or infrastructure channel to enable installing the release
+    # RPM.
     local repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo ; then
       repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
@@ -1352,7 +1356,7 @@ configure_rhn_channels()
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
-    set +x # don't log password
+    set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"; do
       [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
@@ -1367,7 +1371,7 @@ configure_rhsm_channels()
 {
   if [[ -n "$rhn_creds_provided" ]]
   then
-    set +x # don't log password
+    set +x # Don't log password.
     echo "OpenShift: Register with RHSM"
     echo "subscription-manager register --force \"--username=$CONF_RHN_USER\" --name \"$profile_name\" ${CONF_RHN_REG_OPTS}"
     subscription-manager register --force "--username=$CONF_RHN_USER" "--password=$CONF_RHN_PASS" --name "$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
@@ -1401,7 +1405,7 @@ configure_rhsm_channels()
 abort_install()
 {
   [[ "$#" -ge 1 ]] && echo "$@"
-  # don't change this; could be used as an automation cue.
+  # Don't change this; it is used as an automation cue.
   echo "OpenShift: Aborting Installation."
   exit 1
 }
@@ -1432,10 +1436,10 @@ install_rhc_pkg()
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
-  # set_conf expects there to be a new line
+  # set_conf expects there to be a new line.
   echo "" >> /etc/openshift/express.conf
 
-  # set up the system express.conf so this broker will be used by default
+  # Set up the system express.conf so this broker will be used by default.
   set_conf /etc/openshift/express.conf libra_server "'${broker_hostname}'"
 }
 
@@ -1473,11 +1477,10 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-container-selinux"
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
-  # technically not needed unless $CONF_SYSLOG includes gears, but it
-  # does not hurt to have them available:
+
   if [[ "$CONF_SYSLOG" = *gears* ]]; then
     if rpm -q rsyslog ; then
-      # RHEL 6.6's rsyslog7 package conflicts with the originaly RHEL 6 package
+      # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
 erase rsyslog
 install rsyslog7 rsyslog7-mmopenshift
@@ -1834,10 +1837,10 @@ configure_quotas_on_node()
     time restorecon "${geardata_mnt}"
     # Generate user quota info for the mount point.
     time quotacheck -cmug "${geardata_mnt}"
-    # fix up selinux label on created quota file
+    # Fix the SELinux label of the created quota file.
     restorecon "${geardata_mnt}"/aquota.user
 
-    # (re)enable quotas
+    # (Re)enable quotas.
     time quotaon "${geardata_mnt}"
   fi
 }
@@ -1916,9 +1919,9 @@ wait_for_mongod()
 }
 
 # $1 = commands
-# $2 = regex to test output
-# $3 = user
-# $4 = password
+# $2 = regex to test output (optional)
+# $3 = user (optional)
+# $4 = password (optional)
 execute_mongodb()
 {
   echo "Running commands on MongoDB:"
@@ -2259,8 +2262,8 @@ EOF
   chown apache:apache $mcollective_cfg
   chmod 640 $mcollective_cfg
 
-  # make sure mcollective client log is created with proper ownership.
-  # if root owns it, the broker (apache user) can't log to it.
+  # Make sure the MCollective client log is created with proper ownership.
+  # If root owns it, the broker (apache user) can't log to it.
   touch /var/log/openshift/broker/ruby193-mcollective-client.log
   chown apache:root /var/log/openshift/broker/ruby193-mcollective-client.log
 
@@ -2722,23 +2725,29 @@ zone "${zone}" IN {
 EOF
 }
 
+# Add a domain to the given hostname if it does not have one.
+# $1 = host
+# $2 = domain
 ensure_domain()
-{ # adds a domain to hostname if it does not have one
-  # $1 = host; $2 = domain
-  if [[ $1 = *.* ]]; then # already FQDN or IP
+{
+  if [[ $1 = *.* ]]
+  then # $1 is already a FQDN or IP address.
     echo "$1"
-  else # needs a domain
+  else # $1 needs a domain appended.
     echo "$1.$2"
   fi
 }
 
+# $1 = host
+# $2 = ip
+# $3 = zone (optional)
 add_host_to_zone()
 {
-  # $1 = host; $2 = ip; [ $3 = zone ]
   local zone="${3:-$hosts_domain}"
   local nsdb="/var/named/dynamic/${zone}.db"
-  # sanity check that $1 isn't an IP, and $2 is.
-  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  # Check that $1 isn't an IP address and that $2 is.
+  # All numbers and dots = IP address (not rigorous).
+  local ip_regex='^[.0-9]+$'
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
@@ -2748,9 +2757,12 @@ add_host_to_zone()
 
 configure_hosts_dns()
 {
-  add_host_to_zone "$named_hostname" "$named_ip_addr" # always define self
-  # glue record for NS host in subdomain:
+  # Always define self.
+  add_host_to_zone "$named_hostname" "$named_ip_addr"
+
+  # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
+
   if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
@@ -2763,7 +2775,7 @@ configure_hosts_dns()
     for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
-  else # if "none" then just don't add anything
+  else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $CONF_NAMED_ENTRIES"
   fi
 }
@@ -2772,7 +2784,8 @@ configure_hosts_dns()
 # using oo-register-dns. Not used by default.
 register_named_entries()
 {
-  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  # All numbers and dots = IP address (not rigorous).
+  local ip_regex='^[.0-9]+$'
   local failed="false"
   local host_ip
   local host
@@ -2864,7 +2877,8 @@ configure_controller()
 
   if [[ ${datastore_replicants} =~ , ]] || ! datastore
   then
-    #mongo installed remotely or replicated, so configure with given hostname(s)
+    # MongoDB may be installed remotely or replicated, so configure it
+    # with the given hostname(s).
     sed -i -e "s/^MONGO_HOST_PORT=.*$/MONGO_HOST_PORT=\"${datastore_replicants}\"/" /etc/openshift/broker.conf
   fi
 
@@ -2891,8 +2905,9 @@ configure_controller()
   RESTART_NEEDED=true
 }
 
+# $1 = ports per gear (optional)
 configure_messaging_plugin()
-{ # 1 optional arg - ports per gear
+{
   local ports="${1:-$ports_per_gear}"
   local pool_size=6000
   let "pool_size=30000/$ports"
@@ -3042,7 +3057,7 @@ configure_access_keys_on_broker()
   # command will not have to ask the user what to do.
   rm -f /root/.ssh/rsync_id_rsa /root/.ssh/rsync_id_rsa.pub
 
-  # Generate a key pair for moving gears between nodes from the broker
+  # Generate a key pair for moving gears between nodes from the broker.
   ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
   cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes. So, we provide it via a standard
@@ -3056,7 +3071,7 @@ configure_access_keys_on_broker()
 
 configure_wildcard_ssl_cert_on_node()
 {
-  # Generate a 2048 bit key and self-signed cert
+  # Generate a 2048 bit key and self-signed cert.
   cat << EOF | openssl req -new -rand /dev/urandom \
 	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
 	-x509 -days 3650 \
@@ -3119,7 +3134,7 @@ configure_node()
       $conf
   if [[ "$ports_per_gear" != 5 ]]; then
     sed -i -e "/PORTS_PER_USER=/ cPORTS_PER_USER=${ports_per_gear}" $conf
-    # if not already there, we need to add it
+    # If PORTS_PER_USER is not already there, we need to add it.
     grep -q '^PORTS_PER_USER' $conf || sed -i -e "$ a\\
 \\
 # Number of proxy ports available per gear. Increasing the ports per gear requires reducing\\
@@ -3160,7 +3175,7 @@ PORTS_PER_USER=${ports_per_gear}
 configure_node_logs()
 {
   if [[ "$CONF_SYSLOG" = *node* ]]; then
-    # send the node platform logs to syslog instead
+    # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
       s/^PLATFORM_LOG_FILE/#PLATFORM_LOG_FILE/
@@ -3175,11 +3190,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
   if [[ "$CONF_SYSLOG" = *frontend* ]]; then
-    # send the frontend logs to syslog (in addition to file)
+    # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
   if is_true "$CONF_NODE_LOG_CONTEXT"; then
-    # annotate the frontend logs with UUIDs
+    # Annotate the frontend logs with UUIDs.
     sed -i -e '
       s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
       s/^.*PLATFORM_LOG_CONTEXT_ATTRS=.*/PLATFORM_LOG_CONTEXT_ATTRS=request_id,app_uuid,container_uuid/
@@ -3187,7 +3202,7 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
   if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
-    # configure watchman with given interval
+    # Configure watchman with given the interval.
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
       s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$CONF_METRICS_INTERVAL/
@@ -3215,7 +3230,7 @@ install_rsync_pub_key()
 
   local cert
   while [[ `date +%s` -lt $end ]]; do
-    # try to get key hosted on broker machine
+    # Try to get the public key from the broker.
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
     if [[ $? -ne 0 ]]; then
       sleep 5
@@ -3327,8 +3342,9 @@ is_false()
   return 1
 }
 
+# Checks $1 or $node_profile and returns true if it contains "xpaas".
 is_xpaas()
-{ # checks first arg or $node_profile, true if contains "xpaas"
+{
   local profile="${1:-$node_profile}"
   [[ "${profile}" = *xpaas* ]]
 }
@@ -3471,8 +3487,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     (*) abort_install "Unrecognized JBoss EAP channel version: ${CONF_JBOSSEAP_VERSION}" ;;
   esac
 
-  # There a no defaults for these. Customers should be using
-  # subscriptions via RHN. Internally we use private systems.
+  # There are no defaults for these.  Customers should be using
+  # subscriptions via RHN.  Internally, we use private systems.
   rhel_repo="${CONF_RHEL_REPO%/}"
   rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
   jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
@@ -3504,16 +3520,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
-  # no need to waste time checking both subscription plugins if using one
+  # There is no need to waste time checking both subscription plugins
+  # if using one is explicitly enabled.
   disable_plugin=""
   [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
   [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
-  # could do the same for "yum" method but it's more likely to surprise someone
+  # We could do the same for "yum" method, but that would be more likely
+  # to surprise someone.
   #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
 
-  # remap subscription parameters used previously
+  # Check for subscription parameters under all previously used setting
+  # names.
   CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
-  set +x # don't log password
+  set +x # Don't log password.
   CONF_RHN_PASS="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-$CONF_RHN_REG_PASS}}"
   if [[ "${CONF_RHN_USER}" && "${CONF_RHN_PASS}" ]]; then
     rhn_creds_provided=true
@@ -3527,7 +3546,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   hosts_domain="${CONF_HOSTS_DOMAIN:-$domain}"
   hosts_domain_keyfile="${CONF_HOSTS_DOMAIN_KEYFILE:-/var/named/${hosts_domain}.key}"
 
-  # hostnames to use for the components (could all resolve to same host)
+  # Hostnames to use for the components (could all resolve to same host).
   broker_hostname=$(ensure_domain "${CONF_BROKER_HOSTNAME:-broker}" "$hosts_domain")
   node_hostname=$(ensure_domain "${CONF_NODE_HOSTNAME:-node}" "$hosts_domain")
   named_hostname=$(ensure_domain "${CONF_NAMED_HOSTNAME:-ns1}" "$hosts_domain")
@@ -3560,7 +3579,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # host.
   node_ip_addr="${CONF_NODE_IP_ADDR:-$cur_ip_addr}"
 
-  # how to label the system when subscribing
+  # How to label the system when subscribing.
   profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
 
   node_apache_frontend="${CONF_NODE_APACHE_FRONTEND:-vhost}"
@@ -3787,7 +3806,7 @@ validate_preflight()
     # adding channels.
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
-      set +x # don't log password
+      set +x # Don't log password.
       if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
@@ -3803,7 +3822,7 @@ validate_preflight()
     # Note: With RHSM, we need credentials for registration but not for
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
-      set +x # don't log password
+      set +x # Don't log password.
       if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
@@ -3844,7 +3863,7 @@ validate_preflight()
 install_rpms()
 {
   echo "OpenShift: Begin installing RPMs."
-  # we often rely on latest selinux policy and other updates
+  # We often rely on the latest SELinux policy and other updates.
   echo "OpenShift: yum update"
   yum $disable_plugin clean all
 
@@ -3886,16 +3905,16 @@ configure_host()
   is_false "$CONF_KEEP_NAMESERVERS" && configure_dns_resolution
   is_false "$CONF_KEEP_HOSTNAME" && configure_hostname
 
-  # minimize grub timeout on startup
+  # Minimize grub timeout on startup.
   sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;
 
-  # Remove VirtualHost from the default httpd ssl.conf to prevent a warning
+  # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall
 
-  # all hosts should enable ssh access
+  # All hosts should enable SSH access.
   firewall_allow[ssh]=tcp:22
   configure_firewall_add_rules
   echo "OpenShift: Completed configuring host."
@@ -3961,13 +3980,13 @@ configure_openshift()
 {
   echo "OpenShift: Begin configuring OpenShift."
 
-  # prepare services the broker and node depend on
+  # Prepare services that the broker and node depend on.
   datastore && configure_datastore
   activemq && configure_activemq
   broker && configure_mcollective_for_activemq_on_broker
   node && configure_mcollective_for_activemq_on_node
 
-  # configure broker and/or node
+  # Configure the broker and/or node.
   broker && enable_services_on_broker
   node && enable_services_on_node
   node && configure_pam_on_node
@@ -4034,7 +4053,7 @@ restart_services()
   node && is_true "$enable_sni_proxy" && service openshift-sni-proxy restart
   node && service openshift-watchman restart
 
-  # ensure openshift facts are updated
+  # Ensure OpenShift facts are updated.
   node && /etc/cron.minutely/openshift-facts
 
   echo "OpenShift: Completed restarting services."
@@ -4081,7 +4100,7 @@ configure_districts()
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
       firstnode=${nodes//,*/}
-      # query the node for the node profile via mcollective
+      # Query the node for the node profile via MCollective.
       profile=""
       for i in {1..10}; do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
@@ -4100,7 +4119,7 @@ configure_districts()
       fi
     done
   fi
-  # configuring districts should not normally require a service restart
+  # Configuring districts should not normally require a service restart.
   RESTART_NEEDED=$restart
 
   date +%Y-%m-%d-%H:%M:%S
@@ -4119,7 +4138,7 @@ post_deploy()
 
     $RESTART_NEEDED && restart_services && RESTART_COMPLETED=true
 
-    # import cartridges
+    # Import cartridges.
     oo-admin-ctl-cartridge -c import-node --activate --obsolete
 
     configure_districts
@@ -4131,10 +4150,10 @@ post_deploy()
 }
 
 do_all_actions()
-{ # Avoid adding or removing these top-level actions.
-  # oo-install invokes these individually in separate phases.
-  # So, they should not assume the others ran previously in
-  # the same invocation.
+{
+  # Avoid adding or removing these top-level actions.  oo-install invokes these
+  # individually in separate phases, so they should not assume the others ran
+  # previously in the same invocation.
   init_message
   validate_preflight
   configure_repos

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -4692,7 +4692,7 @@ do
   [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 
 # In the case of a kickstart, some services will not be able to start, and the
 # host will automatically reboot anyway after the kickstart script completes.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1544,7 +1544,7 @@ install_router_pkgs()
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
-  # set_conf expects there to be a new line.
+  # set_conf expects there to be a newline character on the last line.
   echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
@@ -1588,9 +1588,9 @@ configure_outgoing_http_proxy()
       > '/etc/openshift/skel/.npmrc'
 
     # Configure Maven for JBoss.
-    # So far all this fancy^H^H^H^H^Had hoc, good-enough parsing is needed only
-    # for Maven, but it could be moved earlier in the function if its results
-    # could be used elsewhere.
+    # So far we only need to parse the URL for Maven, but it could be moved
+    # earlier in this function if future additions to this function have some
+    # use for the URL components.
     local http_proxy_auth https_proxy_auth \
           http_proxy_user http_proxy_pass https_proxy_user https_proxy_pass \
           http_proxy_host_port https_proxy_host_port \

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1113,7 +1113,7 @@ display_passwords()
 
 configure_repos()
 {
-  echo "OpenShift: Begin configuring repos."
+  echo 'OpenShift: Begin configuring repos.'
   # Determine which channels we need and define corresponding predicate
   # functions.
 
@@ -1186,7 +1186,7 @@ configure_repos()
       ;;
   esac
 
-  echo "OpenShift: Completed configuring repos."
+  echo 'OpenShift: Completed configuring repos.'
 }
 
 configure_yum_repos()
@@ -1600,15 +1600,15 @@ configure_outgoing_http_proxy()
     https_proxy_auth="${outgoing_https_proxy#*//}"
 
     # Split on '@' into (possibly) authentication credentials and the rest.
-    read http_proxy_auth http_proxy_host_port <<<"${http_proxy_auth//@/ }"
-    read https_proxy_auth https_proxy_host_port <<<"${https_proxy_auth//@/ }"
+    read http_proxy_auth http_proxy_host_port <<< "${http_proxy_auth//@/ }"
+    read https_proxy_auth https_proxy_host_port <<< "${https_proxy_auth//@/ }"
 
     if [[ -z "$http_proxy_host_port" ]]
     then # No credentials were specified.
       http_proxy_host_port="$http_proxy_auth"
       http_proxy_auth=
     else
-      read http_proxy_user http_proxy_pass <<<"${http_proxy_auth//:/ }"
+      read http_proxy_user http_proxy_pass <<< "${http_proxy_auth//:/ }"
     fi
 
     if [[ -z "$https_proxy_host_port" ]]
@@ -1616,7 +1616,7 @@ configure_outgoing_http_proxy()
       https_proxy_host_port="$https_proxy_auth"
       https_proxy_auth=
     else
-      read https_proxy_user https_proxy_pass <<<"${https_proxy_auth//:/ }"
+      read https_proxy_user https_proxy_pass <<< "${https_proxy_auth//:/ }"
     fi
 
     # Strip any trailing slashes (and possibly more, but there shouldn't be
@@ -1625,8 +1625,8 @@ configure_outgoing_http_proxy()
     https_proxy_host_port="${https_proxy_host_port%/*}"
 
     # Split on ':' into hostname and (possibly) port parts.
-    read http_proxy_hostname http_proxy_port <<<"${http_proxy_host_port//:/ }"
-    read https_proxy_hostname https_proxy_port <<<"${https_proxy_host_port//:/ }"
+    read http_proxy_hostname http_proxy_port <<< "${http_proxy_host_port//:/ }"
+    read https_proxy_hostname https_proxy_port <<< "${https_proxy_host_port//:/ }"
 
     local proxies_stanza="\
 <settings>
@@ -1763,7 +1763,7 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  if grep 'Enterprise Linux Server release 6.4' '/etc/redhat-release' && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
   then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
@@ -1876,7 +1876,7 @@ parse_cartridges()
     local metapkg
     for metapkg in "${meta[@]}"
     do
-      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      if [[ "${pkgs[@]}" =~ "-$metapkg" ]]
       then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
@@ -2089,8 +2089,8 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
-  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/tmp.conf'
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/shm.conf'
 }
 
 configure_cgroups_on_node()
@@ -2677,7 +2677,7 @@ configure_activemq()
 EOF
   fi
 
-  cat <<EOF > /etc/activemq/activemq.xml
+  cat <<EOF > '/etc/activemq/activemq.xml'
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
@@ -3100,7 +3100,7 @@ register_named_entries()
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<"${host_ip//:/ }"
+    read host ip <<< "${host_ip//:/ }"
     if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
@@ -3141,9 +3141,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
-  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-${interface}.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -3398,8 +3398,8 @@ configure_router()
       #
       # These files should be copies of /etc/pki/tls/certs/localhost.crt and
       # /etc/pki/tls/private/localhost.key, respectively, from a node host.
-      if [[ -e /etc/pki/tls/certs/node.example.com.crt &&
-            -e /etc/pki/tls/private/node.example.com.key ]]
+      if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
+            -e '/etc/pki/tls/private/node.example.com.key' ]]
       then
         service nginx16-nginx start
       fi
@@ -3422,7 +3422,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker.
   ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
-  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* '/etc/openshift/'
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
   cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
@@ -3502,7 +3502,7 @@ configure_node()
      'allocated to all UIDs fit in the proxy port range.'
   fi
 
-  local conf=/etc/openshift/node.conf
+  local conf='/etc/openshift/node.conf'
   case "$node_apache_frontend" in
     mod_rewrite)
       sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
@@ -3522,12 +3522,12 @@ configure_node()
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > '/etc/openshift/env/OPENSHIFT_BROKER_HOST'
+  echo "$domain" > '/etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN'
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf
+      '/etc/httpd/conf.d/000001_openshift_origin_node_servername.conf'
 
   configure_node_logs
   RESTART_NEEDED=true
@@ -3548,7 +3548,7 @@ configure_node_logs()
 PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
-    ' /etc/openshift/node.conf
+    ' '/etc/openshift/node.conf'
     echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
@@ -3992,10 +3992,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # ActiveMQ service are assumed to be the current host if we are
   # installing the component now or the broker host otherwise.
   if named
-  then
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
-  else
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
+  then named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
+  else named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
   fi
 
   # The nameservers to which named on the broker will forward requests.
@@ -4059,10 +4057,10 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   metrics_interval="${CONF_METRICS_INTERVAL-}"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
-  broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
+  broker && default_districts="${CONF_DEFAULT_DISTRICTS:-true}"
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
-  broker && district_mappings=${CONF_DISTRICT_MAPPINGS-}
+  broker && district_mappings="${CONF_DISTRICT_MAPPINGS-}"
 
   local randomized
 
@@ -4507,7 +4505,7 @@ restart_services()
 run_diagnostics()
 {
   echo 'OpenShift: Begin running oo-diagnostics.'
-  date +%Y-%m-%d-%H:%M:%S
+  date '+%Y-%m-%d-%H:%M:%S'
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -949,6 +949,24 @@
 ########################################################################
 
 
+set -euo pipefail
+
+annotate()
+{
+  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+}
+trap 'echo "Finished with exitcode $?" >&4' EXIT
+# <> redirection requires disabling posix.
+set +o posix
+exec 5>&1 \
+  1<> >(annotate O >&5) \
+  2<> >(annotate E >&5) \
+  3<> >(annotate D >&5) \
+  4<> >(annotate I >&5) \
+  5>&-
+BASH_XTRACEFD=3
+echo "Started $0 $*" >&4
+
 
 ########################################################################
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -465,6 +465,21 @@
 #   other means.
 #CONF_NO_NTP=true
 
+# http_proxy / CONF_HTTP_PROXY
+# https_proxy / CONF_HTTPS_PROXY
+#   Default: none
+#   Setting these options causes the installation script to configure the PaaS
+#   to use the specified proxy or proxies for access to external resources via
+#   HTTP and HTTPS.  For example, /etc/gitconfig will be written on broker and
+#   node hosts, which both need Git to clone downloadable cartridges, and
+#   /etc/openshift/env/HTTP_PROXY, /etc/openshift/env/HTTPS_PROXY, and
+#   /etc/openshift/env/NO_PROXY (to exclude internal addresses) will be written
+#   as appropriate so that gears will have the corresponding environment
+#   variables, which may be needed for cartridge-specific package repositories
+#   (e.g., Maven for JBoss, NPM for NodeJS, and Pear for PHP).
+#CONF_HTTP_PROXY='http://10.0.0.1:80/'
+#CONF_HTTPS_PROXY='https://10.0.0.1:443/'
+
 #----------------------------------------------------------#
 #                          Brokers                         #
 #----------------------------------------------------------#
@@ -1485,6 +1500,150 @@ configure_rhc()
 
   # Set up the system express.conf so this broker will be used by default.
   set_conf '/etc/openshift/express.conf' libra_server "'${broker_hostname}'"
+}
+
+# Configure the host to use an HTTP or HTTPS proxy for outgoing connections
+# so that Git and cartridge-specific packaging tools work properly.
+configure_outgoing_http_proxy()
+{
+  [[ -n "$outgoing_http_proxy" || -n "$outgoing_https_proxy" ]] || return 0
+
+  if node
+  then
+    # These environment variables should suffice for PERL's cpanm, PHP's
+    # PEAR, Python's easy_install, and Ruby's rubygems.
+    echo "localhost,127.*,*.$domain" > '/etc/openshift/env/no_proxy'
+    # Note that CPAN requires a proper URL, including schema.
+    if [[ -n "$outgoing_http_proxy" ]]
+    then
+      http_proxy_url="$outgoing_http_proxy"
+      if ! [[ "$http_proxy_url" =~ ^https?://* ]]
+      then http_proxy_url="http://$http_proxy_url"
+      fi
+      echo "$http_proxy_url" > '/etc/openshift/env/http_proxy'
+    fi
+    if [[ -n "$outgoing_https_proxy" ]]
+    then
+      https_proxy_url="$outgoing_https_proxy"
+      if ! [[ "$https_proxy_url" =~ ^https?://* ]]
+      then https_proxy_url="https://$https_proxy_url"
+      fi
+      echo "$https_proxy_url" > '/etc/openshift/env/https_proxy'
+    fi
+
+    # Configure NodeJS NPM to use the proxy.
+    mkdir -p '/etc/openshift/skel'
+    printf '%s\n' \
+      "proxy = $outgoing_http_proxy" \
+      "https-proxy = $outgoing_https_proxy" \
+      > '/etc/openshift/skel/.npmrc'
+
+    # Configure Maven for JBoss.
+    # So far all this fancy^H^H^H^H^Had hoc, good-enough parsing is needed only
+    # for Maven, but it could be moved earlier in the function if its results
+    # could be used elsewhere.
+    local http_proxy_auth https_proxy_auth \
+          http_proxy_user http_proxy_pass https_proxy_user https_proxy_pass \
+          http_proxy_host_port https_proxy_host_port \
+          http_proxy_hostname https_proxy_hostname \
+          http_proxy_port https_proxy_port \
+
+    # Strip any leading schemas (schema is inferred from the variable's name).
+    http_proxy_auth="${outgoing_http_proxy#*//}"
+    https_proxy_auth="${outgoing_https_proxy#*//}"
+
+    # Split on '@' into (possibly) authentication credentials and the rest.
+    read http_proxy_auth http_proxy_host_port <<<"${http_proxy_auth//@/ }"
+    read https_proxy_auth https_proxy_host_port <<<"${https_proxy_auth//@/ }"
+
+    if [[ -z "$http_proxy_host_port" ]]
+    then # No credentials were specified.
+      http_proxy_host_port="$http_proxy_auth"
+      http_proxy_auth=
+    else
+      read http_proxy_user http_proxy_pass <<<"${http_proxy_auth//:/ }"
+    fi
+
+    if [[ -z "$https_proxy_host_port" ]]
+    then # No credentials were specified.
+      https_proxy_host_port="$https_proxy_auth"
+      https_proxy_auth=
+    else
+      read https_proxy_user https_proxy_pass <<<"${https_proxy_auth//:/ }"
+    fi
+
+    # Strip any trailing slashes (and possibly more, but there shouldn't be
+    # anything more).
+    http_proxy_host_port="${http_proxy_host_port%/*}"
+    https_proxy_host_port="${https_proxy_host_port%/*}"
+
+    # Split on ':' into hostname and (possibly) port parts.
+    read http_proxy_hostname http_proxy_port <<<"${http_proxy_host_port//:/ }"
+    read https_proxy_hostname https_proxy_port <<<"${https_proxy_host_port//:/ }"
+
+    local proxies_stanza="\
+<settings>
+  <proxies>
+    ${outgoing_http_proxy:+<proxy>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${http_proxy_hostname}</host>
+      ${http_proxy_port:+<port>${http_proxy_port}</port>}
+      ${http_proxy_user:+<username>${http_proxy_user}</username>}
+      ${http_proxy_pass:+<password>${http_proxy_pass}</password>}
+      <nonProxyHosts>localhost|${domain}</nonProxyHosts>
+    </proxy>
+    }
+    ${outgoing_https_proxy:+<proxy>
+      <active>true</active>
+      <protocol>https</protocol>
+      <host>${https_proxy_hostname}</host>
+      ${https_proxy_port:+<port>${https_proxy_port}</port>}
+      ${https_proxy_user:+<username>${https_proxy_user}</username>}
+      ${https_proxy_pass:+<password>${https_proxy_pass}</password>}
+      <nonProxyHosts>localhost|${domain}</nonProxyHosts>
+    </proxy>
+}  </proxies>
+</settings>"
+    # Delete blank lines (this is the slowest part of this function--maybe use
+    # an external tool instead?).
+    shopt -s extglob # for *()
+    proxies_stanza="${proxies_stanza//$'\n'*([[:space:]])$'\n'/$'\n'}"
+    mkdir -p '/etc/openshift/skel/.m2'
+    local settings_xml='/etc/openshift/skel/.m2/settings.xml'
+    if ! [[ -e "$settings_xml" ]] || ! grep -q '<proxies>' "$settings_xml"
+    then
+      echo "$proxies_stanza" >> "$settings_xml"
+    else
+      # Escape newlines in $proxies_stanza so that we can use it in a sed
+      # expression.
+      proxies_stanza="${proxies_stanza//$'\n'/\\$'\n'}"
+      sed -i -e "/<proxies>/,/<\/proxies>/c$proxies_stanza" "$settings_xml"
+    fi
+  fi
+
+  # Configure Git so that downloadable cartridges can work.
+  cat <<EOF > '/etc/gitconfig'
+[http]
+      proxy = $outgoing_https_proxy
+[https]
+      proxy = $outgoing_https_proxy
+
+# git-clone seems to hang with HTTP over a Squid proxy where HTTPS works fine.
+[url "https://"]
+        insteadOf = http://
+
+[http "localhost"]
+      proxy =
+[http "${domain}"]
+      proxy =
+EOF
+
+  # Configure the broker to use the proxy for downloadable cartridges.
+  # Note: There is only one setting in /etc/openshift/broker.conf, HTTP_PROXY,
+  # which the broker uses for both HTTP and HTTPS connetions.  Usually, one will
+  # use an https: URL for downloadable cartridges, so we put that here.
+  broker && set_broker HTTP_PROXY "$outgoing_https_proxy"
 }
 
 # Install broker-specific packages.
@@ -3470,7 +3629,7 @@ set_defaults()
   # The declare statement below is generated by the following command:
   #
   #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
   local setting
@@ -3868,6 +4027,9 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
   broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
 
+  outgoing_http_proxy="${CONF_HTTP_PROXY-}"
+  outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
+
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
 
@@ -4135,6 +4297,7 @@ configure_openshift()
   broker && configure_broker_ssl_cert
   broker && configure_access_keys_on_broker
   broker && configure_rhc
+  { node || broker; } && configure_outgoing_http_proxy
 
   node && configure_port_proxy
   node && configure_gears

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1917,14 +1917,25 @@ install_cartridges()
 # given value to the setting.  If it does not, then comment out any
 # existing setting and add the given setting.
 #
-# The search pattern is /^\s*name\s*=\s*['"]?value\['"]?s*(|#.*)$/.  The added
-# line will be in the form 'name=value' or, if a non-empty short comment is
-# specified, 'name=value # short comment'.  Note that quotation marks are
-# tolerated when checking whether the setting is already present, but are not
-# added when adding the setting unless they are explicitly passed in with the
-# value.  If a long comment is specified using the fifth and possibly subsequent
-# arguments, a blank line followed by '# long comment' (one line per argument)
-# will be added before the line for the setting itself.
+# If the setting is found with the given value in the configuration file, then
+# this function does not modify the file.  The search pattern used is
+# /^\s*name\s*=\s*['"]?value\['"]?\s*(|#.*)$/.
+#
+# If the setting is found with a value other than the one specified, then the
+# existing setting is commented out and the new setting is added after the old,
+# with any short comment that is specified.  The added line will be in the form
+# 'name=value' or, if a non-empty short comment is specified, 'name=value
+# # short comment'.
+#
+# If the setting is not found in the file, then the new setting is appended to
+# the end of the file, with any short and long comments that are specified.
+# If a long comment is specified using the fifth and possibly subsequent
+# arguments, then a blank line followed by '# long comment' (one line per
+# argument) will be added before the line for the setting itself.
+#
+# Note that quotation marks are tolerated when checking whether the setting is
+# already present, but are not added when adding the setting unless they are
+# explicitly passed in as part of the value.
 #
 # $1 = configuration file's filename
 # $2 = setting name
@@ -1933,17 +1944,39 @@ install_cartridges()
 # $5- = long comment (optional)
 set_conf()
 {
-  if ! grep -q "^\\s*$2\\s*=\\s*['\"]\\?$3['\"]\\?\\s*\\(\\|#.*\\)$" "$1"
-  then
-    sed -i -e "s/^\\s*$2\\s*=\\s*/#&/" "$1"
-    if [[ -n "${5-}" ]]
-    then
-      echo >> "$1"
-      args=( "$@" )
-      printf '# %s\n' "${args[@]:4}" >> "$1"
-    fi
-    echo "$2=$3${4:+ #$4}" >> "$1"
-  fi
+  local file="$1" setting="$2" value="$3" shortcomment="${4-}"
+  local newsetting="${setting}=${value//\//\\/}${shortcomment:+ #$shortcomment}"
+  shift 4 || shift 3
+  local longcomment=
+  (( $# > 0 )) && printf -v longcomment '# %s\\\n' "$@"
+
+  sed -i -e "
+    :a
+      # Check whether the setting already exists with the specified value.  If
+      # it does, jump to :b.
+      /^\\s*${setting}\\s*=\\s*['\"]\\?${value//\//\\/}['\"]\\?\\s*\\(\\|#.*\\)\$/bb
+
+      # Check whether the setting already exists but with the a value other than
+      # the specified one.  If it does, then comment out the old setting, add
+      # a new setting with the specified value after the old setting, and jump
+      # to :b.
+      s/^\\(\\s*\\)#\\?\\(\\s*${setting}\\s*=[^\\n]*\\)/\\1#\\2\\n${newsetting}/;tb
+
+      # Neither of the previous two checks were positive, so check whether we
+      # have reached the end of the file, and if so, append the new setting
+      # along with any long comment that has been specified.
+      \$a \\
+${longcomment:+\\
+$longcomment}$newsetting
+
+      # Loop and repeat the above checks.
+      n
+      ba
+    :b
+      # Loop until the end of the file, without modifying the stream.
+      n
+      bb
+    " "$file"
 }
 
 set_mongodb() { set_conf /etc/mongodb.conf "$@"; }

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -984,9 +984,11 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [[ -n "${!3-}" ]]; then
+  if [[ -n "${!3-}" ]]
+  then
     printf -v "$1" '%s' "${!3}"
-  elif is_true "$no_scramble" ; then
+  elif is_true "$no_scramble"
+  then
     printf -v "$1" '%s' "$2"
   else
     local randomized=$(openssl rand -base64 20)
@@ -1012,23 +1014,28 @@ display_passwords()
   subs[mongodb]="MongoDB"
   subs[activemq]="ActiveMQ"
 
-  for k in "${!passwords[@]}"; do
+  for k in "${!passwords[@]}"
+  do
     out_string=""
     matchingvar=""
-    for postfix in password password1 pass; do
+    for postfix in password password1 pass
+    do
       vprefix=${k%${postfix}}
       [[ "$vprefix" != "$k" ]] && break
     done
 
-    for v in "${vprefix}user" "${vprefix}user1"; do
-      if [[ -n "${!v+x}" ]]; then
+    for v in "${vprefix}user" "${vprefix}user1"
+    do
+      if [[ -n "${!v+x}" ]]
+      then
         matchingvar=$v
         break
       fi
     done
 
     formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}; do
+    for s in ${!subs[@]}
+    do
       formattedprefix=${formattedprefix//${s}/${subs[$s]}}
     done
 
@@ -1050,17 +1057,18 @@ configure_repos()
   # Make need_${repo}_repo return false by default.
   local repo
   for repo in optional infra node client_tools extra \
-              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews; do
-      eval "need_${repo}_repo() { false; }"
+              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews
+  do eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$enable_optional_repo" && need_optional_repo() { :; }
 
-  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
-    need_extra_repo() { :; }
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]
+  then need_extra_repo() { :; }
   fi
 
-  if activemq || broker || datastore || named; then
+  if activemq || broker || datastore || named
+  then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
     # packages.  The ose-infrastructure and ose-node channels also include
     # the yum-plugin-priorities package, which is needed for the installation
@@ -1078,7 +1086,8 @@ configure_repos()
   # install the client tools repo along with the infrastructure repo.
   need_infra_repo && need_client_tools_repo() { :; }
 
-  if node; then
+  if node
+  then
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
@@ -1134,12 +1143,15 @@ configure_yum_repos()
 configure_ose_yum_repos()
 {
   local repo
-  for repo in infra node jbosseap_cartridge client_tools; do
-    if [[ -n "$ose_repo_base" ]]; then
+  for repo in infra node jbosseap_cartridge client_tools
+  do
+    if [[ -n "$ose_repo_base" ]]
+    then
       local layout=puddle; [[ -n "$cdn_layout" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [[ -n "$ose_extra_repo_base" ]]; then
+    if [[ -n "$ose_extra_repo_base" ]]
+    then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -1153,7 +1165,8 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]; then
+if [[ -n "${rhel_repo}" ]]
+then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -1170,7 +1183,8 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]; then
+if [[ -n "${rhel_optional_repo}" ]]
+then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -1218,7 +1232,8 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]; then
+  if [[ -n "${rhscl_repo_base}" ]]
+  then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -1246,7 +1261,8 @@ configure_cart_repos()
   # in which case, add a repo base just for them. Use extras if needed for now.
 
   local repo
-  for repo in "${!url[@]}"; do
+  for repo in "${!url[@]}"
+  do
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
@@ -1266,7 +1282,8 @@ YUM
 configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]; then
+  if [[ -e "${extra_repo_file}" ]]
+  then
       > "${extra_repo_file}"
   fi
 
@@ -1283,9 +1300,11 @@ configure_extra_repos()
   )
 
   local repo
-  for repo in "${!priority[@]}"; do
+  for repo in "${!priority[@]}"
+  do
     local url="${!repo}"
-    if [[ -n "${url}" ]]; then
+    if [[ -n "${url}" ]]
+    then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -1330,7 +1349,8 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [[ -n "$rhn_reg_actkey" ]]; then
+  if [[ -n "$rhn_reg_actkey" ]]
+  then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
   else
@@ -1351,8 +1371,8 @@ configure_rhn_channels()
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
     local repos=('rhel-x86_64-server-6-rhscl-1')
-    if ! need_node_repo || need_infra_repo ; then
-      repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
+    if ! need_node_repo || need_infra_repo
+    then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
     need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.2-node' 'jb-ews-2-x86_64-server-6-rpm')
     need_client_tools_repo && repos+=('rhel-x86_64-server-6-ose-2.2-rhc')
@@ -1362,8 +1382,8 @@ configure_rhn_channels()
 
     set +x # Don't log password.
     local repo
-    for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    for repo in "${repos[@]}"
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
     done
     set -x
   fi
@@ -1394,13 +1414,15 @@ configure_rhsm_channels()
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
   local poolid
-  for poolid in ${sm_reg_pool//[, :+\/-]/ }; do
+  for poolid in ${sm_reg_pool//[, :+\/-]/ }
+  do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
   done
 
   # Enable the node or infrastructure repo to enable installing the release RPM
-  if need_node_repo; then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
+  if need_node_repo
+  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
   else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
   fi
   configure_subscription
@@ -1418,9 +1440,11 @@ yum_install_or_exit()
 {
   echo "OpenShift: yum install $*"
   local count=0
-  time while true; do
+  time while true
+  do
     yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]; then
+    if [[ $count -gt 3 ]]
+    then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -1480,8 +1504,10 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
 
-  if [[ "$log_to_syslog" = *gears* ]]; then
-    if rpm -q rsyslog ; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
+    if rpm -q rsyslog
+    then
       # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
 erase rsyslog
@@ -1512,8 +1538,8 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
-    yum $disable_plugin remove -y abrt-addon-python || abort_install
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
 
@@ -1946,13 +1972,14 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [[ -n "${3+x}" && -n "${4+x}" ]]; then
-    userpass="-u ${3} -p ${4} admin"
+  if [[ -n "${3+x}" && -n "${4+x}" ]]
+  then userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [[ -n "${2+x}" ]]; then # test output against regex
+  if [[ -n "${2+x}" ]]
+  then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -2118,7 +2145,8 @@ configure_gears()
   chkconfig openshift-gears on
 
   # configure gear logging
-  if [[ "$log_to_syslog" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
     # make the gear app servers log to syslog by default (overrideable)
     sed -i -e '
       /outputtype\b/I coutputType = syslog
@@ -2185,7 +2213,8 @@ enable_services_on_node()
   firewall_allow[wss]=tcp:8443
 
   # Allow connections to openshift-sni-proxy
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
@@ -2490,8 +2519,8 @@ $networkConnectors
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
                ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
-               $( if is_true "$enable_routing_plugin"; then
-                    echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+               $( if is_true "$enable_routing_plugin"
+                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -2505,7 +2534,8 @@ $networkConnectors
                   <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
-                  $( if is_true "$enable_routing_plugin"; then
+                  $( if is_true "$enable_routing_plugin"
+                     then
                        echo '<authorizationEntry topic="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                        echo '<authorizationEntry queue="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                      fi
@@ -2606,7 +2636,8 @@ configure_named()
 
   # Set up DNS forwarding if so directed.
   local forwarders="recursion no;"
-  if is_true "$enable_dns_forwarding"; then
+  if is_true "$enable_dns_forwarding"
+  then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
     chmod 644 /var/named/forwarders.conf
@@ -2691,7 +2722,8 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [[ -z "$bind_key" ]]; then
+  if [[ -z "$bind_key" ]]
+  then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -2761,10 +2793,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
-    echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else
-    echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
+  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 
@@ -2776,17 +2807,19 @@ configure_hosts_dns()
   # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
 
-  if [[ -z "$named_entries" ]]; then
+  if [[ -z "$named_entries" ]]
+  then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-  elif [[ "$named_entries" =~ : ]]; then
+  elif [[ "$named_entries" =~ : ]]
+  then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
-    for host_ip in ${named_entries//,/ }; do
-      add_host_to_zone ${host_ip//:/ }
+    for host_ip in ${named_entries//,/ }
+    do add_host_to_zone ${host_ip//:/ }
     done
   else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $named_entries"
@@ -2805,11 +2838,14 @@ register_named_entries()
   local host_ip
   local host
   local ip
-  for host_ip in ${named_entries//,/ }; do
+  for host_ip in ${named_entries//,/ }
+  do
     read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
+    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip; then
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    then
       echo "WARNING: Failed to register host $host with IP $ip"
       failed="true"
     fi
@@ -2824,7 +2860,8 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
   fi
@@ -3009,7 +3046,8 @@ configure_httpd_auth()
 
 configure_routing_plugin()
 {
-  if is_true "$enable_routing_plugin"; then
+  if is_true "$enable_routing_plugin"
+  then
     local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
@@ -3128,10 +3166,10 @@ configure_hostname()
 configure_node()
 {
   local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]; then
-    cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]; then
-    cp "$resrc.${node_profile}" $resrc
+  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
+  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
+  elif [[ -f "$resrc.${node_profile}" ]]
+  then cp "$resrc.${node_profile}" $resrc
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -3141,7 +3179,8 @@ configure_node()
   set_node BROKER_HOST "$broker_hostname"
   set_node EXTERNAL_ETH_DEV "$interface"
 
-  if [[ "$ports_per_gear" != 5 ]]; then
+  if [[ "$ports_per_gear" != 5 ]]
+  then
     set_node PORTS_PER_USER "$ports_per_gear" '' \
      'Number of proxy ports available per gear. Increasing the ports per gear'\
      'requires reducing the number of UIDs the district has so that the ports'\
@@ -3158,7 +3197,8 @@ configure_node()
       ;;
   esac
 
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
@@ -3180,7 +3220,8 @@ configure_node()
 
 configure_node_logs()
 {
-  if [[ "$log_to_syslog" = *node* ]]; then
+  if [[ "$log_to_syslog" = *node* ]]
+  then
     # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
@@ -3195,17 +3236,20 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
-  if [[ "$log_to_syslog" = *frontend* ]]; then
+  if [[ "$log_to_syslog" = *frontend* ]]
+  then
     # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
-  if is_true "$node_log_context"; then
+  if is_true "$node_log_context"
+  then
     # Annotate the frontend logs with UUIDs.
     set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ -n "$metrics_interval" ]]; then
+  if [[ -n "$metrics_interval" ]]
+  then
     # Configure watchman with given the interval.
     set_node WATCHMAN_METRICS_ENABLED 'true'
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
@@ -3231,9 +3275,11 @@ install_rsync_pub_key()
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]; do
+  while [[ `date +%s` -lt $end ]]
+  do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}"); then
+    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    then
       sleep 5
     else
       if ! ssh-keygen -lf /dev/stdin <<< "$cert"
@@ -3554,16 +3600,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # CONF_CDN_REPO_BASE is set.
   cdn_layout="${CONF_CDN_REPO_BASE-}"
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [[ -n "$cdn_repo_base" ]]; then
+  if [[ -n "$cdn_repo_base" ]]
+  then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
@@ -3651,8 +3700,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
 
   local s
-  for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
-    eval "isset_${s}() { false; }"
+  for s in valid_gear_sizes default_gear_capabilities default_gear_size
+  do eval "isset_${s}() { false; }"
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
@@ -3717,7 +3766,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
-  datastore_replicants="$( for repl in ${datastore_replicants//,/ }; do
+  datastore_replicants="$( for repl in ${datastore_replicants//,/ }
+                           do
                              [[ "$repl" =~ : ]] || repl=$repl:27017
                              printf ",%s" "${repl}"
                            done)"
@@ -3825,29 +3875,34 @@ validate_preflight()
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release; then
+  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  then
     echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]] ; then
+  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  then
     echo "OpenShift: SELinux needs to be installed and enabled."
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
-  if ! command -v rpm || ! command -v yum; then
+  if ! command -v rpm || ! command -v yum
+  then
     echo "OpenShift: rpm and yum must be installed."
     preflight_failure=1
   fi
-  if ! rpm -q rpm yum; then
+  if ! rpm -q rpm yum
+  then
     echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
     preflight_failure=1
   fi
 
   # test that subscription parameters are available if needed
-  if [[ "$install_method" = rhn ]]; then
+  if [[ "$install_method" = rhn ]]
+  then
     # Check whether we are already registered with RHN and already have
     # ose-2.2 channels added.  If we are not, we will need RHN
     # credentials so that we can register and add channels ourselves.
@@ -3857,7 +3912,8 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3865,15 +3921,18 @@ validate_preflight()
     fi
   fi
 
-  if [[ "$install_method" = rhsm ]]; then
+  if [[ "$install_method" = rhsm ]]
+  then
     # Check whether we are already registered with RHSM.  If we are not,
     # we will need credentials so that we can register ourselves.
     #
     # Note: With RHSM, we need credentials for registration but not for
     # adding channels.
-    if ! subscription-manager identity | grep -q 'identity is:'; then
+    if ! subscription-manager identity | grep -q 'identity is:'
+    then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3892,13 +3951,15 @@ validate_preflight()
     # a harmless but possibly alarming "Broken pipe" error message.
     if [[ -z "$sm_reg_pool" ]] &&
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
-          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
+          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
+    then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]; then
+  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
+  then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -3918,12 +3979,11 @@ install_rpms()
   yum $disable_plugin clean all
 
   local count=0
-  while true; do
-    yum $disable_plugin update -y
-    if [[ $? -eq 0 ]]; then
-      break
-    elif [[ $count -gt 3 ]]; then
-      abort_install
+  while true
+  do
+    yum $disable_plugin update -y && break
+    if [[ $count -gt 3 ]]
+    then abort_install
     fi
     let count+=1
   done
@@ -4132,9 +4192,11 @@ configure_districts()
   date +%Y-%m-%d-%H:%M:%S
 
   local restart=$RESTART_NEEDED
-  if is_true "$default_districts"; then
+  if is_true "$default_districts"
+  then
     local p
-    for p in ${valid_gear_sizes//,/ }; do
+    for p in ${valid_gear_sizes//,/ }
+    do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
       oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
@@ -4146,18 +4208,21 @@ configure_districts()
     local nodes
     local district
     local mapping
-    for mapping in ${district_mappings//;/ }; do
+    for mapping in ${district_mappings//;/ }
+    do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
       firstnode=${nodes//,*/}
       # Query the node for the node profile via MCollective.
       profile=""
-      for i in {1..10}; do
+      for i in {1..10}
+      do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
          && break
         sleep 10
       done
-      if [[ -n "$profile" ]]; then
+      if [[ -n "$profile" ]]
+      then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -4178,8 +4243,10 @@ post_deploy()
 {
   echo "OpenShift: Begin post deployment steps."
 
-  if broker; then
-    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size; then
+  if broker
+  then
+    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size
+    then
       update_controller_gear_size_configs
       RESTART_NEEDED=true
     fi
@@ -4238,9 +4305,10 @@ RESTART_NEEDED=false
 RESTART_COMPLETED=false
 
 # Make sure /sbin and /usr/sbin are in PATH
-for admin_path in /sbin /usr/sbin; do
-  if [[ :$PATH: != *:"${admin_path}":* ]] ; then
-    PATH=${PATH}:${admin_path}
+for admin_path in /sbin /usr/sbin
+do
+  if [[ :$PATH: != *:"${admin_path}":* ]]
+  then PATH=${PATH}:${admin_path}
   fi
 done
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -454,7 +454,7 @@
 
 # interface / CONF_INTERFACE
 #   Default: eth0
-#   The network device to configure.  Used by configure_network, 
+#   The network device to configure.  Used by configure_network,
 #   configure_dns_resolution, and configure_node
 #CONF_INTERFACE="eth0"
 
@@ -2866,7 +2866,7 @@ $routingPolicy
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
-        If enabling the web console, you should make sure to require 
+        If enabling the web console, you should make sure to require
         authentication in jetty.xml and configure the admin/user
         passwords in jetty-realm.properties.
 
@@ -3295,7 +3295,7 @@ configure_httpd_auth()
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
           -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
           > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2198,7 +2198,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
+  printf '\nAcceptEnv GIT_SSH\n' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
   sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1016,11 +1016,11 @@ display_passwords()
 
   for k in "${!passwords[@]}"
   do
-    out_string=""
-    matchingvar=""
+    out_string=
+    matchingvar=
     for postfix in password password1 pass
     do
-      vprefix=${k%${postfix}}
+      vprefix="${k%$postfix}"
       [[ "$vprefix" != "$k" ]] && break
     done
 
@@ -1028,22 +1028,22 @@ display_passwords()
     do
       if [[ -n "${!v+x}" ]]
       then
-        matchingvar=$v
+        matchingvar="$v"
         break
       fi
     done
 
-    formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}
+    formattedprefix="${vprefix//_/ }"
+    for s in "${!subs[@]}"
     do
-      formattedprefix=${formattedprefix//${s}/${subs[$s]}}
+      formattedprefix="${formattedprefix//${s}/${subs[$s]}}"
     done
 
     out_string+="$formattedprefix"
     [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
     [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
-    echo $out_string
+    echo "$out_string"
   done
   set -x
 }
@@ -1093,16 +1093,16 @@ configure_repos()
 
     # The jbosseap and jbossas cartridges require the jbossas packages
     # in the jbappplatform channel.
-    is_true "${need_jbosseap}" \
+    is_true "$need_jbosseap" \
              && need_jbosseap_cartridge_repo() { :; } \
              && need_jbosseap_repo() { :; }
 
     # The jbossews cartridge requires the tomcat packages in the jb-ews channel.
-    is_true "${need_jbossews}" && need_jbossews_repo() { :; }
+    is_true "$need_jbossews" && need_jbossews_repo() { :; }
 
     # The fuse/amq cartridges require their own channels.
-    is_true "${need_fuse}" && need_fuse_cartridge_repo() { :; }
-    is_true "${need_amq}" && need_amq_cartridge_repo() { :; }
+    is_true "$need_fuse" && need_fuse_cartridge_repo() { :; }
+    is_true "$need_amq" && need_amq_cartridge_repo() { :; }
 
     # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
@@ -1165,17 +1165,17 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]
+if [[ -n "$rhel_repo" ]]
 then
-  cat > /etc/yum.repos.d/rhel.repo <<YUM
+  cat > '/etc/yum.repos.d/rhel.repo' <<YUM
 [rhel6]
 name=RHEL 6 base OS
-baseurl=${rhel_repo}
+baseurl=$rhel_repo
 enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude=tomcat6* ${yum_exclude_pkgs}
+exclude=tomcat6* $yum_exclude_pkgs
 
 YUM
 fi
@@ -1183,17 +1183,17 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]
+if [[ -n "$rhel_optional_repo" ]]
 then
-  cat > /etc/yum.repos.d/rheloptional.repo <<YUM
+  cat > '/etc/yum.repos.d/rheloptional.repo' <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
-baseurl=${rhel_optional_repo}
+baseurl=$rhel_optional_repo
 enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 fi
@@ -1201,20 +1201,20 @@ fi
 
 def_ose_yum_repo()
 {
-  local repo_base=$1
-  local layout=$2  # one of: puddle, extra, cdn
-  local channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
+  local repo_base="$1"
+  local layout="$2"  # one of: puddle, extra, cdn
+  local channel="$3" # one of: client_tools, infra, node, jbosseap_cartridge
 
   local -A map
   local url
-  case $layout in
+  case "$layout" in
   puddle | extra)
     map=([client_tools]=RHOSE-CLIENT-2.2 [infra]=RHOSE-INFRA-2.2 [node]=RHOSE-NODE-2.2 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.2)
-    url="$repo_base/${map[$channel]}/x86_64/os/"
+    url="${repo_base}/${map[$channel]}/x86_64/os/"
     ;;
   cdn | * )
     map=([client_tools]=ose-rhc [infra]=ose-infra [node]=ose-node [jbosseap_cartridge]=ose-jbosseap)
-    url="$repo_base/${map[$channel]}/2.2/os"
+    url="${repo_base}/${map[$channel]}/2.2/os"
     ;;
   esac
   cat > "/etc/yum.repos.d/openshift-${channel}-${layout}.repo" <<YUM
@@ -1225,23 +1225,23 @@ enabled=1
 gpgcheck=0
 priority=10
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 }
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]
+  if [[ -n "$rhscl_repo_base" ]]
   then
-    cat <<YUM > /etc/yum.repos.d/rhscl.repo
+    cat <<YUM > '/etc/yum.repos.d/rhscl.repo'
 [rhscl]
 name=rhscl
 baseurl=${rhscl_repo_base}/rhscl/1/os/
 enabled=1
 priority=10
 gpgcheck=0
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 
@@ -1266,13 +1266,13 @@ configure_cart_repos()
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
-name=${repo}
+name=$repo
 baseurl=${url[$repo]}
 enabled=1
 gpgcheck=0
 priority=30
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
   done
@@ -1281,10 +1281,10 @@ YUM
 # Add all defined extra repos in one file.
 configure_extra_repos()
 {
-  local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]
+  local extra_repo_file='/etc/yum.repos.d/ose_extra.repo'
+  if [[ -e "$extra_repo_file" ]]
   then
-      > "${extra_repo_file}"
+      > "$extra_repo_file"
   fi
 
   local -A priority=(
@@ -1303,17 +1303,17 @@ configure_extra_repos()
   for repo in "${!priority[@]}"
   do
     local url="${!repo}"
-    if [[ -n "${url}" ]]
+    if [[ -n "$url" ]]
     then
-      cat <<YUM >> "${extra_repo_file}"
+      cat <<YUM >> "$extra_repo_file"
 [${repo}]
-name=${repo}
-baseurl=${url}
+name=$repo
+baseurl=$url
 enabled=1
 gpgcheck=0
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} ${yum_exclude_pkgs}
+exclude=${exclude[$repo]} $yum_exclude_pkgs
 
 YUM
     fi
@@ -1327,7 +1327,7 @@ configure_subscription()
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
-   local roles=""  # we will build the list of roles we need, then enable them.
+   local roles=  # we will build the list of roles we need, then enable them.
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
@@ -1351,18 +1351,18 @@ configure_rhn_channels()
 {
   if [[ -n "$rhn_reg_actkey" ]]
   then
-    echo "OpenShift: Register to RHN Classic using an activation key"
-    rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register to RHN Classic using an activation key'
+    rhnreg_ks --force "--activationkey=$rhn_reg_actkey" "--profilename=$rhn_profile_name" $rhn_reg_opts || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # Don't log password.
-      echo "OpenShift: Register to RHN Classic with username and password"
-      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" ${rhn_reg_opts}"
-      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "${rhn_user}" --password "${rhn_pass}" ${rhn_reg_opts} || abort_install
+      echo 'OpenShift: Register to RHN Classic with username and password'
+      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
+      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
       set -x
     else
-      echo "OpenShift: No credentials given for RHN Classic; assuming already configured"
+      echo 'OpenShift: No credentials given for RHN Classic; assuming already configured'
     fi
   fi
 
@@ -1383,7 +1383,7 @@ configure_rhn_channels()
     set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"
-    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
     done
     set -x
   fi
@@ -1396,20 +1396,20 @@ configure_rhsm_channels()
   if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # Don't log password.
-    echo "OpenShift: Register with RHSM"
-    echo "subscription-manager register --force \"--username=$rhn_user\" --name \"$rhn_profile_name\" ${rhn_reg_opts}"
-    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register with RHSM'
+    echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
+    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
     set -x
   else
-    echo "OpenShift: No credentials given for RHSM; assuming already configured"
+    echo 'OpenShift: No credentials given for RHSM; assuming already configured'
   fi
 
-  if [[ -n "${sm_reg_pool}" ]]
+  if [[ -n "$sm_reg_pool" ]]
   then
-    echo "OpenShift: Removing all current subscriptions"
+    echo 'OpenShift: Removing all current subscriptions'
     subscription-manager remove --all
   else
-    echo "OpenShift: No pool ids were given, so none are being registered"
+    echo 'OpenShift: No pool ids were given, so none are being registered'
   fi
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
@@ -1422,17 +1422,17 @@ configure_rhsm_channels()
 
   # Enable the node or infrastructure repo to enable installing the release RPM
   if need_node_repo
-  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
-  else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
+  then subscription-manager repos '--enable=rhel-6-server-ose-2.2-node-rpms' || abort_install
+  else subscription-manager repos '--enable=rhel-6-server-ose-2.2-infra-rpms' || abort_install
   fi
   configure_subscription
 }
 
 abort_install()
 {
-  [[ "$#" -ge 1 ]] && echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$*"
   # Don't change this; it is used as an automation cue.
-  echo "OpenShift: Aborting Installation."
+  echo 'OpenShift: Aborting Installation.'
   exit 1
 }
 
@@ -1442,11 +1442,11 @@ yum_install_or_exit()
   local count=0
   time while true
   do
-    yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]
+    yum install -y "$@" $disable_plugin && return
+    if [[ "$count" -gt 3 ]]
     then
       echo "OpenShift: Command failed: yum install $*"
-      echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
+      echo 'OpenShift: Please ensure relevant repos/subscriptions are configured.'
       abort_install
     fi
     let count+=1
@@ -1463,16 +1463,16 @@ install_rhc_pkg()
 configure_rhc()
 {
   # set_conf expects there to be a new line.
-  echo "" >> /etc/openshift/express.conf
+  echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
-  set_conf /etc/openshift/express.conf libra_server "'${broker_hostname}'"
+  set_conf '/etc/openshift/express.conf' libra_server "'${broker_hostname}'"
 }
 
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  local pkgs="openshift-origin-broker"
+  local pkgs='openshift-origin-broker'
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"
@@ -1492,7 +1492,7 @@ install_broker_pkgs()
 # Install node-specific packages.
 install_node_pkgs()
 {
-  local pkgs="rubygem-openshift-origin-node ruby193-rubygem-passenger-native"
+  local pkgs='rubygem-openshift-origin-node ruby193-rubygem-passenger-native'
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
@@ -1525,7 +1525,7 @@ YUM
       pkgs="$pkgs rubygem-openshift-origin-frontend-apache-vhost"
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -1611,11 +1611,11 @@ parse_cartridges()
   local -a all=( ${p[@]} )
 
   # Set some package groups and aliases to provide shortcuts to the user.
-  p[all]="${all[@]}"
-  p[premium]="${premium[@]}"
-  p[stdframework]="${stdframework[@]}"
-  p[stdaddon]="${stdaddon[@]}"
-  p[standard]="${stdframework[@]} ${stdaddon[@]}"
+  p[all]="${all[*]}"
+  p[premium]="${premium[*]}"
+  p[stdframework]="${stdframework[*]}"
+  p[stdaddon]="${stdaddon[*]}"
+  p[standard]="${stdframework[*]} ${stdaddon[*]}"
   p[jboss]="${p[jbossews]} ${p[jbosseap]}"
   p[postgres]="${p[postgresql]}"
 
@@ -1635,8 +1635,8 @@ parse_cartridges()
       # anything in $p.
       for pkg in ${p[${cart_spec:1}]:-${cart_spec:1}}
       do
-        for k in ${!pkgs[@]}
-        do [[ ${pkgs[$k]} = $pkg ]] && unset "pkgs[$k]"
+        for k in "${!pkgs[@]}"
+        do [[ "${pkgs[$k]}" = "$pkg" ]] && unset "pkgs[$k]"
         done
       done
     else
@@ -1649,12 +1649,12 @@ parse_cartridges()
   if metapkgs_optional || metapkgs_recommended
   then
     local metapkg
-    for metapkg in ${meta[@]}
+    for metapkg in "${meta[@]}"
     do
       if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
       then
-        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
-        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
+        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
+        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
       fi
     done
   fi
@@ -1662,13 +1662,13 @@ parse_cartridges()
   # Set need_<cart>=1 if $pkgs includes the relevant cartridge,
   # need_<cart>=0 otherwise, so that configure_repos will enable
   # only the appropriate channels.
-  need_jbosseap=0; [[ "${pkgs[@]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
-  need_jbossews=0; [[ "${pkgs[@]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
+  need_jbosseap=0; [[ "${pkgs[*]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
+  need_jbossews=0; [[ "${pkgs[*]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
     # fuse is "special" because there's also a fuse-builder cart that can be used with
     # either fuse or amq and doesn't necessarily imply either. It comes from either of
     # those two channels; assume if desired they will have one of those channels already.
-  need_fuse=0;     [[ "${pkgs[@]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
-  need_amq=0;      [[ "${pkgs[@]}" = *"${p[amq]}"* ]] && need_amq=1
+  need_fuse=0;     [[ "${pkgs[*]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
+  need_amq=0;      [[ "${pkgs[*]}" = *"${p[amq]}"* ]] && need_amq=1
 
   # Uniquify (and, as a side effect, sort) pkgs and assign the result to
   # install_cart_pkgs for install_cartridges to use.
@@ -1687,7 +1687,7 @@ install_cartridges()
   # still install as much as possible.
   #install_cart_pkgs="${install_cart_pkgs} --skip-broken"
 
-  yum_install_or_exit "${install_cart_pkgs}"
+  yum_install_or_exit $install_cart_pkgs
 }
 
 # Given the filename of a configuration file, the name of a setting,
@@ -1760,9 +1760,9 @@ configure_selinux_policy_on_broker()
   fixfiles -R ruby193-rubygem-passenger restore
   fixfiles -R ruby193-mod_passenger restore
 
-  restorecon -rv /var/run
+  restorecon -rv '/var/run'
   # This should cover everything in the SCL, including passenger
-  time restorecon -rv /opt
+  time restorecon -rv '/opt'
 }
 
 # Fix up SELinux policy on the node.
@@ -1798,31 +1798,31 @@ configure_selinux_policy_on_node()
   ) | semanage -i -
 
 
-  restorecon -rv /var/run
-  time restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
+  restorecon -rv '/var/run'
+  time restorecon -rv '/var/lib/openshift' '/etc/httpd/conf.d/openshift'
   # disallow gear users from seeing what other gears exist
-  chmod 0751 /var/lib/openshift
+  chmod 0751 '/var/lib/openshift'
 }
 
 configure_pam_on_node()
 {
-  sed -i -e 's|pam_selinux|pam_openshift|g' /etc/pam.d/sshd
+  sed -i -e 's|pam_selinux|pam_openshift|g' '/etc/pam.d/sshd'
 
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "su" "system-auth-ac"
+  for f in runuser runuser-l sshd su system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_namespace.so" "$t"
+    if ! grep -q 'pam_namespace.so' "$t"
     then
       # We add two rules.  The first checks whether the user's shell is
       # /usr/bin/oo-trap-user, which indicates that this is a gear user,
       # and skips the second rule if it is not.
-      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
+      echo -e 'session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user' >> "$t"
 
       # The second rule enables polyinstantiation so that the user gets
       # private /tmp and /dev/shm directories.
-      echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
+      echo -e 'session\t\trequired\tpam_namespace.so no_unmount_on_close' >> "$t"
     fi
   done
 
@@ -1830,27 +1830,27 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo "/tmp        \$HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/tmp.conf
-  echo "/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
 }
 
 configure_cgroups_on_node()
 {
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "system-auth-ac"
+  for f in runuser runuser-l sshd system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_cgroup" "$t"
+    if ! grep -q 'pam_cgroup' "$t"
     then
-      echo -e "session\t\toptional\tpam_cgroup.so" >> "$t"
+      echo -e 'session\t\toptional\tpam_cgroup.so' >> "$t"
     fi
   done
 
-  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf /etc/cgconfig.conf
-  restorecon -rv /etc/cgconfig.conf
-  mkdir -p /cgroup
-  restorecon -rv /cgroup
+  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf '/etc/cgconfig.conf'
+  restorecon -rv '/etc/cgconfig.conf'
+  mkdir -p '/cgroup'
+  restorecon -rv '/cgroup'
   chkconfig cgconfig on
   chkconfig cgred on
 }
@@ -1858,45 +1858,45 @@ configure_cgroups_on_node()
 configure_quotas_on_node()
 {
   # Get the mountpoint for /var/lib/openshift (should be /).
-  local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
+  local geardata_mnt=$(df -P '/var/lib/openshift' 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
   if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
     # Enable user quotas for the filesystem housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" '/etc/fstab'
     # Remount to enable quotas immediately.
-    mount -o remount "${geardata_mnt}"
+    mount -o remount "$geardata_mnt"
 
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
-    time restorecon "${geardata_mnt}"
+    time restorecon "$geardata_mnt"
 
     # quotacheck fails if quotas are enabled.
-    quotaoff "${geardata_mnt}"
+    quotaoff "$geardata_mnt"
 
     # Generate user quota info for the mount point.
-    time quotacheck -cmug "${geardata_mnt}"
+    time quotacheck -cmug "$geardata_mnt"
 
     # Fix the SELinux label of the created quota file.
-    restorecon "${geardata_mnt}"/aquota.user
+    restorecon "${geardata_mnt}/aquota.user"
 
     # (Re)enable quotas.
-    time quotaon "${geardata_mnt}"
+    time quotaon "$geardata_mnt"
   fi
 }
 
 configure_idler_on_node()
 {
   [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return 0
-  cat <<CRON > /etc/cron.hourly/auto-idler
+  cat <<CRON > '/etc/cron.hourly/auto-idler'
 (
   /usr/sbin/oo-last-access
-  /usr/sbin/oo-auto-idler idle --interval $idle_interval
-) >> /var/log/openshift/node/auto-idler.log 2>&1
+  /usr/sbin/oo-auto-idler idle --interval "$idle_interval"
+) >> '/var/log/openshift/node/auto-idler.log' 2>&1
 CRON
-  chmod +x /etc/cron.hourly/auto-idler
+  chmod +x '/etc/cron.hourly/auto-idler'
 }
 
 # $1 = setting name
@@ -1904,25 +1904,25 @@ CRON
 # $3 = long comment
 set_sysctl()
 {
-  set_conf /etc/sysctl.conf "$1" "$2" '' "$3"
+  set_conf '/etc/sysctl.conf' "$1" "$2" '' "$3"
 }
 
 # Turn some sysctl knobs.
 configure_sysctl_on_node()
 {
-  set_sysctl kernel.sem '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
+  set_sysctl 'kernel.sem' '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
 
-  set_sysctl net.ipv4.ip_local_port_range '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_local_port_range' '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
 
-  set_sysctl net.netfilter.nf_conntrack_max 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
+  set_sysctl 'net.netfilter.nf_conntrack_max' 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_forward' 1 'Enable forwarding for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
+  set_sysctl 'net.ipv4.conf.all.route_localnet' 1 'Allow the OpenShift port proxy to route using loopback addresses.'
 
   # As recommended elsewhere and investigated at length in https://bugzilla.redhat.com/show_bug.cgi?id=1085115
   # this is a safe, effective way to keep lots of short requests from exhausting the connection table.
-  set_sysctl net.ipv4.tcp_tw_reuse 1 'Reuse closed connections quickly.' 
+  set_sysctl 'net.ipv4.tcp_tw_reuse' 1 'Reuse closed connections quickly.'
 }
 
 
@@ -1931,11 +1931,11 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
-  sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config
-  sed -i -e "s/^#MaxStartups .*$/MaxStartups 40/" /etc/ssh/sshd_config
+  sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'
+  sed -i -e 's/^#MaxStartups .*$/MaxStartups 40/' '/etc/ssh/sshd_config'
 
   RESTART_NEEDED=true
 }
@@ -1966,14 +1966,14 @@ wait_for_mongod()
 # $4 = password (optional)
 execute_mongodb()
 {
-  echo "Running commands on MongoDB:"
-  echo "---"
+  echo 'Running commands on MongoDB:'
+  echo '---'
   echo "$1"
-  echo "---"
+  echo '---'
 
   local userpass=
   if [[ -n "${3+x}" && -n "${4+x}" ]]
-  then userpass="-u ${3} -p ${4} admin"
+  then userpass="-u $3 -p $4 admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
@@ -1993,7 +1993,7 @@ configure_datastore_add_users()
   wait_for_mongod
 
   time execute_mongodb "$(
-    if [[ ${datastore_replicants} =~ , ]]
+    if [[ "$datastore_replicants" =~ , ]]
     then
       echo 'while (rs.isMaster().primary == null) { sleep(5); }'
     fi
@@ -2006,7 +2006,7 @@ configure_datastore_add_users()
     fi
 
     # Add the user that the broker will use.
-    echo "use ${mongodb_name}"
+    echo "use $mongodb_name"
     echo "db.addUser('${mongodb_broker_user}', '${mongodb_broker_password}')"
   )"
   set -x
@@ -2023,10 +2023,10 @@ configure_datastore_add_replicants()
 
   # initiate the replica set with just this host
   time execute_mongodb 'rs.initiate()' '"ok" : 1' ||
-    abort_install "OpenShift: Failed to form MongoDB replica set; please do this manually."
+    abort_install 'OpenShift: Failed to form MongoDB replica set; please do this manually.'
 
   local master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
-    abort_install "OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually."
+    abort_install 'OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually.'
 
   configure_datastore_add_users
 
@@ -2044,15 +2044,15 @@ configure_datastore_add_replicants()
       for i in {1..10}
       do
         echo "Attempting to connect to ${replicant}..."
-        if echo "" | mongo $replicant
+        if echo | mongo "$replicant"
         then
           break
         fi
         sleep 60
       done
 
-      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' ${mongodb_admin_user} ${mongodb_admin_password} ||
-        abort_install "OpenShift: Failed to add ${replicant} to replica set; please verify the replica set manually"
+      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' "$mongodb_admin_user" "$mongodb_admin_password" ||
+        abort_install "OpenShift: Failed to add $replicant to replica set; please verify the replica set manually"
     fi
   done
 
@@ -2071,7 +2071,7 @@ configure_datastore()
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 
-  if [[ ${datastore_replicants} =~ , ]]
+  if [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will be part of a replicated setup.
 
@@ -2082,21 +2082,21 @@ configure_datastore()
     set_mongodb journal true
 
     # Enable replication.
-    set_mongodb replSet "${mongodb_replset}"
+    set_mongodb replSet "$mongodb_replset"
 
     # Configure a key for the replica set.
-    set_mongodb keyFile /etc/mongodb.keyfile
+    set_mongodb keyFile '/etc/mongodb.keyfile'
 
-    rm -f /etc/mongodb.keyfile
-    echo "${mongodb_key}" > /etc/mongodb.keyfile
-    chown -v mongodb.mongodb /etc/mongodb.keyfile
-    chmod -v 400 /etc/mongodb.keyfile
+    rm -f '/etc/mongodb.keyfile'
+    echo "$mongodb_key" > '/etc/mongodb.keyfile'
+    chown -v 'mongodb.mongodb' '/etc/mongodb.keyfile'
+    chmod -v 400 '/etc/mongodb.keyfile'
   fi
 
   # If mongod is running on a separate host from the broker OR
   # we are configuring a replica set, open up the firewall to allow
   # other broker or datastore hosts to connect.
-  if broker && ! [[ ${datastore_replicants} =~ , ]]
+  if broker && ! [[ "$datastore_replicants" =~ , ]]
   then
     echo 'The broker and data store are on the same host.'
     echo 'Skipping firewall and mongod configuration;'
@@ -2105,10 +2105,10 @@ configure_datastore()
     echo 'The data store needs to be accessible externally.'
 
     echo 'Configuring the firewall to allow connections to mongod...'
-    firewall_allow[mongodb]=tcp:27017
+    firewall_allow[mongodb]='tcp:27017'
 
     echo 'Configuring mongod to listen on all interfaces...'
-    set_mongodb bind_ip 0.0.0.0
+    set_mongodb bind_ip '0.0.0.0'
   fi
 
   # Configure mongod to start on boot.
@@ -2117,7 +2117,7 @@ configure_datastore()
   # Start mongod so we can perform some administration now.
   service mongod start
 
-  if ! [[ ${datastore_replicants} =~ , ]]
+  if ! [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will _not_ be part of a replicated setup.
     configure_datastore_add_users
@@ -2134,9 +2134,9 @@ configure_port_proxy()
 {
   chkconfig openshift-iptables-port-proxy on
   sed -i '/:OUTPUT ACCEPT \[.*\]/a \
-:rhc-app-comm - [0:0]' /etc/sysconfig/iptables
+:rhc-app-comm - [0:0]' '/etc/sysconfig/iptables'
   sed -i '/-A INPUT -i lo -j ACCEPT/a \
--A INPUT -j rhc-app-comm' /etc/sysconfig/iptables
+-A INPUT -j rhc-app-comm' '/etc/sysconfig/iptables'
 }
 
 configure_gears()
@@ -2151,7 +2151,7 @@ configure_gears()
     sed -i -e '
       /outputtype\b/I coutputType = syslog
       /outputtypefromenviron/I coutputTypeFromEnviron = true
-    ' /etc/openshift/logshifter.conf
+    ' '/etc/openshift/logshifter.conf'
     # use rsyslog7 so we can annotate
     # disable some of the stock options shipped
     sed -i -e '
@@ -2160,9 +2160,9 @@ configure_gears()
       /ModLoad imjournal/ s/^/#/    # imjournal module is not even available...
       /IMJournalStateFile/ s/^/#/
       /OmitLocalLogging/ s/^/#/
-    ' /etc/rsyslog.conf
+    ' '/etc/rsyslog.conf'
     # enable custom log format via imuxsock
-    cat <<'LOGCONF' >> /etc/rsyslog.d/imuxsock-and-openshift-gears.conf
+    cat <<'LOGCONF' >> '/etc/rsyslog.d/imuxsock-and-openshift-gears.conf'
 # load the modules as necessary for gear logs to be annotated
 module(load="imuxsock" SysSock.Annotate="on" SysSock.ParseTrusted="on" SysSock.UsePIDFromSystem="on")
 module(load="mmopenshift")
@@ -2205,12 +2205,12 @@ LOGCONF
 # Enable services to start on boot for the node.
 enable_services_on_node()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   # Allow connections to openshift-node-web-proxy
-  firewall_allow[ws]=tcp:8000
-  firewall_allow[wss]=tcp:8443
+  firewall_allow[ws]='tcp:8000'
+  firewall_allow[wss]='tcp:8443'
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"
@@ -2234,8 +2234,8 @@ enable_services_on_node()
 # Enable services to start on boot for the broker and fix up some issues.
 enable_services_on_broker()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   chkconfig httpd on
   chkconfig network on
@@ -2253,10 +2253,10 @@ generate_mcollective_pools_configuration()
   for replicant in ${activemq_replicants//,/ }
   do
     let num_replicants=num_replicants+1
-    new_member="plugin.activemq.pool.${num_replicants}.host = ${replicant}
+    new_member="plugin.activemq.pool.${num_replicants}.host = $replicant
 plugin.activemq.pool.${num_replicants}.port = 61613
-plugin.activemq.pool.${num_replicants}.user = ${mcollective_user}
-plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
+plugin.activemq.pool.${num_replicants}.user = $mcollective_user
+plugin.activemq.pool.${num_replicants}.password = $mcollective_password
 "
     members="${members}${new_member}"
   done
@@ -2271,8 +2271,8 @@ plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
 # https://bugzilla.redhat.com/show_bug.cgi?id=963332
 configure_mcollective_for_activemq_on_broker()
 {
-  local mcollective_cfg="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
-  cat <<EOF > $mcollective_cfg
+  local mcollective_cfg='/opt/rh/ruby193/root/etc/mcollective/client.cfg'
+  cat <<EOF > "$mcollective_cfg"
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2301,13 +2301,13 @@ plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 
 EOF
 
-  chown apache:apache $mcollective_cfg
-  chmod 640 $mcollective_cfg
+  chown 'apache:apache' "$mcollective_cfg"
+  chmod 640 "$mcollective_cfg"
 
   # Make sure the MCollective client log is created with proper ownership.
   # If root owns it, the broker (apache user) can't log to it.
-  touch /var/log/openshift/broker/ruby193-mcollective-client.log
-  chown apache:root /var/log/openshift/broker/ruby193-mcollective-client.log
+  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
+  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
 
   RESTART_NEEDED=true
 }
@@ -2316,7 +2316,7 @@ EOF
 # Configure mcollective on the node to use ActiveMQ.
 configure_mcollective_for_activemq_on_node()
 {
-  cat <<EOF > /opt/rh/ruby193/root/etc/mcollective/server.cfg
+  cat <<EOF > '/opt/rh/ruby193/root/etc/mcollective/server.cfg'
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2397,7 +2397,7 @@ configure_activemq()
   networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
 
   local schedulerSupport= routingPolicy=
-  if is_true "${enable_routing_plugin}"
+  if is_true "$enable_routing_plugin"
   then
     schedulerSupport='schedulerSupport="true"'
     IFS= read -r -d '' routingPolicy <<'EOF' || :
@@ -2517,10 +2517,10 @@ $networkConnectors
           <simpleAuthenticationPlugin>
              <users>
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
-               ${authenticationUser_amq}
+               $authenticationUser_amq
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
                $( if is_true "$enable_routing_plugin"
-                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+                  then echo "<authenticationUser username=\"${routing_plugin_user}\" password=\"${routing_plugin_pass}\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -2544,7 +2544,7 @@ $networkConnectors
               </authorizationMap>
             </map>
           </authorizationPlugin>
-${routingPolicy}
+$routingPolicy
         </plugins>
 
           <!--
@@ -2612,8 +2612,8 @@ ${routingPolicy}
 EOF
 
   # Allow connections to ActiveMQ.
-  firewall_allow[stomp]=tcp:61613
-  allow_openwire && firewall_allow[openwire]=tcp:61616
+  firewall_allow[stomp]='tcp:61613'
+  allow_openwire && firewall_allow[openwire]='tcp:61616'
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -2629,18 +2629,18 @@ install_named_pkgs()
 configure_named()
 {
   # Ensure we have a key for service named status to communicate with BIND.
-  rndc-confgen -a -r /dev/urandom
+  rndc-confgen -a -r '/dev/urandom'
   restorecon /etc/rndc.* /etc/named.*
-  chown root:named /etc/rndc.key
-  chmod 640 /etc/rndc.key
+  chown 'root:named' '/etc/rndc.key'
+  chmod 640 '/etc/rndc.key'
 
   # Set up DNS forwarding if so directed.
-  local forwarders="recursion no;"
+  local forwarders='recursion no;'
   if is_true "$enable_dns_forwarding"
   then
-    echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
-    restorecon /var/named/forwarders.conf
-    chmod 644 /var/named/forwarders.conf
+    echo "forwarders { ${nameservers} } ;" > '/var/named/forwarders.conf'
+    restorecon '/var/named/forwarders.conf'
+    chmod 644 '/var/named/forwarders.conf'
     forwarders='// set forwarding to the next nearest server (from DHCP response)
 	forward only;
         include "forwarders.conf";
@@ -2650,15 +2650,15 @@ configure_named()
 
   # Install the configuration file for the OpenShift Enterprise domain
   # name.
-  rm -rf /var/named/dynamic
-  mkdir -p /var/named/dynamic
+  rm -rf '/var/named/dynamic'
+  mkdir -p '/var/named/dynamic'
 
-  chgrp named -R /var/named
-  chown named -R /var/named/dynamic
-  restorecon -rv /var/named
+  chgrp named -R '/var/named'
+  chown named -R '/var/named/dynamic'
+  restorecon -rv '/var/named'
 
   # Replace named.conf.
-  cat <<EOF > /etc/named.conf
+  cat <<EOF > '/etc/named.conf'
 // named.conf
 //
 // Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
@@ -2699,8 +2699,8 @@ controls {
 
 include "/etc/named.rfc1912.zones";
 EOF
-  chown root:named /etc/named.conf
-  chcon system_u:object_r:named_conf_t:s0 -v /etc/named.conf
+  chown 'root:named' '/etc/named.conf'
+  chcon 'system_u:object_r:named_conf_t:s0' -v '/etc/named.conf'
 
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
@@ -2711,7 +2711,7 @@ EOF
   configure_hosts_dns
 
   # Configure named to start on boot.
-  firewall_allow[dns]=tcp:53,udp:53
+  firewall_allow[dns]='tcp:53,udp:53'
   chkconfig named on
 
   # Start named so we can perform some updates immediately.
@@ -2726,46 +2726,46 @@ configure_named_zone()
   then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
-    rm -f /var/named/K${zone_tolower}*
-    dnssec-keygen -a ${bind_keyalgorithm} -b ${bind_keysize} -n USER -r /dev/urandom -K /var/named ${zone}
+    rm -f "/var/named/K${zone_tolower}"*
+    dnssec-keygen -a "$bind_keyalgorithm" -b "$bind_keysize" -n USER -r '/dev/urandom' -K '/var/named' "$zone"
     # $zone may have uppercase letters in it.  However the file that
     # dnssec-keygen creates will have the zone in lowercase.
-    bind_key="$(grep Key: /var/named/K${zone_tolower}*.private | cut -d ' ' -f 2)"
-    rm -f /var/named/K${zone_tolower}*
+    bind_key="$(grep 'Key:' "/var/named/K${zone_tolower}"*.private | cut -d ' ' -f 2)"
+    rm -f "/var/named/K${zone_tolower}"*
   fi
 
   # Install the key where BIND and oo-register-dns expect it.
-  cat <<EOF > /var/named/${zone}.key
-key ${zone} {
+  cat <<EOF > "/var/named/${zone}.key"
+key $zone {
   algorithm "${bind_keyalgorithm}";
   secret "${bind_key}";
 };
 EOF
 
   # Create the initial BIND database.
-  cat <<EOF > /var/named/dynamic/${zone}.db
+  cat <<EOF > "/var/named/dynamic/${zone}.db"
 \$ORIGIN .
 \$TTL 1	; 1 seconds (for testing only)
-${zone}		IN SOA	$named_hostname. hostmaster.$zone. (
+${zone}		IN SOA	${named_hostname}. hostmaster.${zone}. (
 				2011112904 ; serial
 				60         ; refresh (1 minute)
 				15         ; retry (15 seconds)
 				1800       ; expire (30 minutes)
 				10         ; minimum (10 seconds)
 				)
-				IN NS	$named_hostname.
-				IN MX	10 mail.$zone.
+				IN NS	${named_hostname}.
+				IN MX	10 mail.${zone}.
 \$ORIGIN ${zone}.
 EOF
 
   # Add a record for the zone to named conf
-  cat <<EOF >> /etc/named.conf
+  cat <<EOF >> '/etc/named.conf'
 include "${zone}.key";
 
 zone "${zone}" IN {
 	type master;
 	file "dynamic/${zone}.db";
-	allow-update { key ${zone} ; } ;
+	allow-update { key $zone ; } ;
 };
 EOF
 }
@@ -2775,7 +2775,7 @@ EOF
 # $2 = domain
 ensure_domain()
 {
-  if [[ $1 = *.* ]]
+  if [[ "$1" = *.* ]]
   then # $1 is already a FQDN or IP address.
     echo "$1"
   else # $1 needs a domain appended.
@@ -2793,9 +2793,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  if [[ "$1" =~ $ip_regex || ! "$2" =~ $ip_regex ]]
   then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  else echo "${1%.${zone}}			IN A	$2" >> "$nsdb"
   fi
 }
 
@@ -2834,23 +2834,23 @@ register_named_entries()
 {
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  local failed="false"
+  local failed=false
   local host_ip
   local host
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    read host ip <<<"${host_ip//:/ }"
+    if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "$hosts_domain_keyfile" -n "$ip"
     then
       echo "WARNING: Failed to register host $host with IP $ip"
-      failed="true"
+      failed=true
     fi
   done
-  is_false "$failed" && echo "OpenShift: Completed updating host DNS entries."
+  "$failed" && echo 'OpenShift: Completed updating host DNS entries.'
   return 0
 }
 
@@ -2860,7 +2860,7 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  if grep -q IPADDR "/etc/sysconfig/network-scripts/ifcfg-$interface"
   then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
@@ -2878,12 +2878,12 @@ configure_dns_resolution()
   # will resolve public addresses even when our private named is
   # nonfunctional.  However, our private named must appear first in
   # order for hostnames private to our OpenShift PaaS to resolve.
-  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
+  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -2906,7 +2906,7 @@ configure_controller()
 {
   if [[ -z "$broker_auth_salt" ]]
   then
-    echo "Warning: broker authentication salt is empty!"
+    echo 'Warning: broker authentication salt is empty!'
   fi
 
   # Configure the broker with the correct domain name, and use random salt
@@ -2922,7 +2922,7 @@ configure_controller()
   # Configure the session secret for the console
   set_console SESSION_SECRET "$console_session_secret"
 
-  if [[ ${datastore_replicants} =~ , ]] || ! datastore
+  if [[ "$datastore_replicants" =~ , ]] || ! datastore
   then
     # MongoDB may be installed remotely or replicated, so configure it
     # with the given hostname(s).
@@ -2941,8 +2941,8 @@ configure_controller()
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
-  sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf
+  sed -i -e "s/ServerName .*\$/ServerName ${hostname}/" \
+      '/etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf'
 
   # Configure the broker service to start on boot.
   chkconfig openshift-broker on
@@ -2958,7 +2958,7 @@ configure_messaging_plugin()
   local pool_size=6000
   let "pool_size=30000/$ports"
 
-  local file=/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
+  local file='/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf'
   cp "$file"{.example,}
   set_conf "$file" DISTRICTS_FIRST_UID "$district_first_uid"
   set_conf "$file" DISTRICTS_MAX_CAPACITY "$pool_size"
@@ -2976,21 +2976,21 @@ configure_dns_plugin()
     echo 'after installation.'
   fi
 
-  mkdir -p /etc/openshift/plugins.d
-  cat <<EOF > /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+  mkdir -p '/etc/openshift/plugins.d'
+  cat <<EOF > '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
   if [[ -z "$bind_krb_keytab" ]]
   then
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KEYNAME="${domain}"
 BIND_KEYVALUE="${bind_key}"
 BIND_KEYALGORITHM="${bind_keyalgorithm}"
 EOF
   else
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KRB_PRINCIPAL="${bind_krb_principal}"
 BIND_KRB_KEYTAB="${bind_krb_keytab}"
 EOF
@@ -3003,7 +3003,7 @@ EOF
 configure_httpd_auth()
 {
   # Configure the broker to use the remote-user authentication plugin.
-  cp -p /etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf{.example,}
+  cp -p '/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf'{.example,}
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
@@ -3011,27 +3011,28 @@ configure_httpd_auth()
   then
     yum_install_or_exit mod_auth_kerb
     local d
-    for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
+    for d in '/var/www/openshift/broker/httpd/conf.d' '/var/www/openshift/console/httpd/conf.d'
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
-        -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
+          -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
+	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return
   fi
 
   # Install the Apache Basic Authentication configuration file.
-  cp -p /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
-  cp -p /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
   # The above configuration file configures Apache to use
   # /etc/openshift/htpasswd for its password file.
   #
   # Here we create a test user:
-  htpasswd -bc /etc/openshift/htpasswd "$openshift_user1" "$openshift_password1"
+  htpasswd -bc '/etc/openshift/htpasswd' "$openshift_user1" "$openshift_password1"
   #
   # Use the following command to add more users:
   #
@@ -3048,12 +3049,12 @@ configure_routing_plugin()
 {
   if is_true "$enable_routing_plugin"
   then
-    local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
-    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
+    local conffile='/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf'
+    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' "${conffile}.example" > "$conffile"
     cat <<EOF >> "$conffile"
-ACTIVEMQ_HOST='$activemq_replicants'
-ACTIVEMQ_USERNAME='$routing_plugin_user'
-ACTIVEMQ_PASSWORD='$routing_plugin_pass'
+ACTIVEMQ_HOST='${activemq_replicants}'
+ACTIVEMQ_USERNAME='${routing_plugin_user}'
+ACTIVEMQ_PASSWORD='${routing_plugin_pass}'
 EOF
     RESTART_NEEDED=true
   fi
@@ -3072,7 +3073,7 @@ fix_broker_routing()
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past
-      cat <<EOF >> /var/lib/openshift/.httpd.d/nodes.txt
+      cat <<EOF >> '/var/lib/openshift/.httpd.d/nodes.txt'
 __default__ REDIRECT:/console
 __default__/rsync_id_rsa.pub NOPROXY
 __default__/console TOHTTPS:127.0.0.1:8118/console
@@ -3081,12 +3082,12 @@ __default__/admin-console TOHTTPS:127.0.0.1:8080/admin-console
 __default__/assets TOHTTPS:127.0.0.1:8080/assets
 EOF
 
-      httxt2dbm -f DB -i /etc/httpd/conf.d/openshift/nodes.txt -o /etc/httpd/conf.d/openshift/nodes.db
-      chown root:apache /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
-      chmod 750 /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
+      httxt2dbm -f DB -i '/etc/httpd/conf.d/openshift/nodes.txt' -o '/etc/httpd/conf.d/openshift/nodes.db'
+      chown 'root:apache' '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
+      chmod 750 '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -3096,21 +3097,21 @@ configure_access_keys_on_broker()
 {
   # Generate a broker access key for remote apps (Jenkins) to access
   # the broker.
-  echo "${broker_auth_priv_key}" > /etc/openshift/server_priv.pem
-  openssl rsa -in /etc/openshift/server_priv.pem -pubout > /etc/openshift/server_pub.pem
-  chown apache:apache /etc/openshift/server_pub.pem
-  chmod 640 /etc/openshift/server_pub.pem
+  echo "$broker_auth_priv_key" > '/etc/openshift/server_priv.pem'
+  openssl rsa -in '/etc/openshift/server_priv.pem' -pubout > '/etc/openshift/server_pub.pem'
+  chown 'apache:apache' '/etc/openshift/server_pub.pem'
+  chmod 640 '/etc/openshift/server_pub.pem'
 
   # If a key pair already exists, delete it so that the ssh-keygen
   # command will not have to ask the user what to do.
-  rm -f /root/.ssh/rsync_id_rsa /root/.ssh/rsync_id_rsa.pub
+  rm -f '/root/.ssh/rsync_id_rsa' '/root/.ssh/rsync_id_rsa.pub'
 
   # Generate a key pair for moving gears between nodes from the broker.
-  ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
+  ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
   cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
-  cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
+  cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
   # The node install script can retrieve this or it can be performed manually:
   #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
@@ -3121,16 +3122,16 @@ configure_wildcard_ssl_cert_on_node()
 {
   # Generate a 2048 bit key and self-signed cert.
   cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-*.${domain}
-root@${domain}
+*.$domain
+root@$domain
 EOF
 
 }
@@ -3138,17 +3139,17 @@ EOF
 configure_broker_ssl_cert()
 {
   # Generate a 2048 bit key and self-signed cert
-  cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+  cat << EOF | openssl req -new -rand '/dev/urandom' \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-${broker_hostname}
-root@${domain}
+$broker_hostname
+root@$domain
 EOF
 }
 
@@ -3157,19 +3158,19 @@ configure_hostname()
 {
   if [[ ! "$hostname" =~ ^[0-9.]*$ ]]  # hostname is not just an IP
   then
-    set_conf /etc/sysconfig/network HOSTNAME "$hostname"
-    hostname "${hostname}"
+    set_conf '/etc/sysconfig/network' HOSTNAME "$hostname"
+    hostname "$hostname"
   fi
 }
 
 # Set some parameters in the OpenShift node configuration files.
 configure_node()
 {
-  local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
-  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]
-  then cp "$resrc.${node_profile}" $resrc
+  local resrc='/etc/openshift/resource_limits.conf'
+  if [[ -f "${resrc}.${node_profile}.${node_host_type}" ]]
+  then cp "${resrc}.${node_profile}.${node_host_type}" "$resrc"
+  elif [[ -f "${resrc}.${node_profile}" ]]
+  then cp "${resrc}.${node_profile}" "$resrc"
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -3190,25 +3191,25 @@ configure_node()
   local conf=/etc/openshift/node.conf
   case "$node_apache_frontend" in
     mod_rewrite)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
       ;;
     vhost)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" "$conf"
       ;;
   esac
 
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
-      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' "$conf" ||
+      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' "$conf"
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo $broker_hostname > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo $domain > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
+  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
@@ -3234,24 +3235,24 @@ PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
-    echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
+    echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
   then
     # Send the frontend logs to syslog (in addition to file).
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' '/etc/sysconfig/httpd'
   fi
   if is_true "$node_log_context"
   then
     # Annotate the frontend logs with UUIDs.
-    set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
+    set_node PLATFORM_LOG_CONTEXT_ENABLED 1
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' '/etc/sysconfig/httpd'
   fi
   if [[ -n "$metrics_interval" ]]
   then
     # Configure watchman with given the interval.
-    set_node WATCHMAN_METRICS_ENABLED 'true'
+    set_node WATCHMAN_METRICS_ENABLED true
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
   fi
 }
@@ -3267,40 +3268,40 @@ update_openshift_facts_on_node()
 # public key (if available) and add it to node's authorized keys.
 install_rsync_pub_key()
 {
-  mkdir -p /root/.ssh
-  chmod 700 /root/.ssh
+  mkdir -p '/root/.ssh'
+  chmod 700 '/root/.ssh'
 
   local wait=600
   local end=`date -d "$wait seconds" +%s`
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]
+  while [[ `date +%s` -lt "$end" ]]
   do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    if ! cert="$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=$node_hostname")"
     then
       sleep 5
     else
-      if ! ssh-keygen -lf /dev/stdin <<< "$cert"
+      if ! ssh-keygen -lf '/dev/stdin' <<< "$cert"
       then
         break
       else
-        echo "$cert" >> /root/.ssh/authorized_keys
-        echo "OpenShift node: SSH key downloaded from broker successfully."
-        chmod 644 /root/.ssh/authorized_keys
+        echo "$cert" >> '/root/.ssh/authorized_keys'
+        echo 'OpenShift node: SSH key downloaded from broker successfully.'
+        chmod 644 '/root/.ssh/authorized_keys'
         return
       fi
     fi
   done
 
-  echo "OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually."
+  echo 'OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually.'
 
 }
 
 echo_installation_intentions()
 {
-  echo "The following components should be installed:"
+  echo 'The following components should be installed:'
   local components='broker node named activemq datastore'
   local component
   for component in $components
@@ -3318,10 +3319,10 @@ echo_installation_intentions()
 configure_console_msg()
 {
   # add the IP to /etc/issue for convenience
-  echo "Install-time IP address: ${cur_ip_addr}" >> /etc/issue
-  echo_installation_intentions >> /etc/issue
-  echo "Check /root/anaconda-post.log to see the %post output." >> /etc/issue
-  echo >> /etc/issue
+  echo "Install-time IP address: $cur_ip_addr" >> '/etc/issue'
+  echo_installation_intentions >> '/etc/issue'
+  echo 'Check /root/anaconda-post.log to see the %post output.' >> '/etc/issue'
+  echo >> '/etc/issue'
 }
 
 
@@ -3361,12 +3362,12 @@ parse_cmdline()
 
 metapkgs_optional()
 {
-  [[ ${metapkgs,,} =~ 'optional' ]]
+  [[ "${metapkgs,,}" =~ 'optional' ]]
 }
 
 metapkgs_recommended()
 {
-  metapkgs_optional || [[ ${metapkgs,,} =~ 'recommended' ]]
+  metapkgs_optional || [[ "${metapkgs,,}" =~ 'recommended' ]]
 }
 
 is_true()
@@ -3393,7 +3394,7 @@ is_false()
 is_xpaas()
 {
   local profile="${1:-$node_profile}"
-  [[ "${profile}" = *xpaas* ]]
+  [[ "$profile" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -3507,7 +3508,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [[ $installing_something = 0 ]]
+  if [[ "$installing_something" = 0 ]]
   then
     for component in $components
     do
@@ -3605,13 +3606,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
-    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
+    rhel_optional_repo="${rhel_optional_repo:-${cdn_repo_base}/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    if [[ "$cdn_repo_base" = "$ose_repo_base" ]]
     then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  elif [[ "$rhel_repo" = "${ose_repo_base}/os" ]]
   then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
@@ -3710,7 +3711,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
   [[ -n "${CONF_DEFAULT_GEAR_CAPABILITIES:+x}" ]] && isset_default_gear_capabilities() { :; }
-  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
+  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-$valid_gear_sizes}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
   [[ -n "${CONF_DEFAULT_GEAR_SIZE:+x}" ]] && isset_default_gear_size() { :; }
@@ -3724,7 +3725,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
   let "district_uid_pool=30000/$ports_per_gear"
-  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
+  let "district_last_uid=${district_first_uid}+${district_uid_pool}-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -3748,28 +3749,28 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Generate a random salt for the broker authentication.
   randomized=$(openssl rand -base64 20)
-  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-${randomized}}"
+  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-$randomized}"
 
   # Generate a random session secret for broker sessions.
   randomized=$(openssl rand -hex 64)
-  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-${randomized}}"
+  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-$randomized}"
 
   # Generate a random session secret for console sessions.
   randomized=$(openssl rand -hex 64)
-  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-${randomized}}"
+  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-$randomized}"
 
   # Generate a new 2048 bit RSA keypair for broker authentication if
   # CONF_BROKER_AUTH_PRIV_KEY not set
   broker && broker_auth_priv_key="${CONF_BROKER_AUTH_PRIV_KEY:-$(openssl genrsa 2048)}"
 
   # If no list of replicants is provided, assume there is only one datastore host.
-  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
+  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-${datastore_hostname}:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
   datastore_replicants="$( for repl in ${datastore_replicants//,/ }
                            do
-                             [[ "$repl" =~ : ]] || repl=$repl:27017
-                             printf ",%s" "${repl}"
+                             [[ "$repl" =~ : ]] || repl="${repl}:27017"
+                             printf ',%s' "$repl"
                            done)"
   datastore_replicants="${datastore_replicants:1}"
 
@@ -3793,18 +3794,18 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   ActiveMQ broker replicants to communicate with one another.  The
   #   amq user is enabled only if replicants are specified using the
   #   activemq_replicants.setting
-  activemq && assign_pass activemq_amq_user_password "password" CONF_ACTIVEMQ_AMQ_USER_PASSWORD
+  activemq && assign_pass activemq_amq_user_password password CONF_ACTIVEMQ_AMQ_USER_PASSWORD
 
   #   This is the user and password shared between broker and node for
   #   communicating over the mcollective topic channels in ActiveMQ.
   #   Must be the same on all broker and node hosts.
   (broker || node || activemq) && mcollective_user="${CONF_MCOLLECTIVE_USER:-mcollective}"
-  (broker || node || activemq) && assign_pass mcollective_password "marionette" CONF_MCOLLECTIVE_PASSWORD
+  (broker || node || activemq) && assign_pass mcollective_password marionette CONF_MCOLLECTIVE_PASSWORD
 
   # Enable authentication for MongoDB.
   if is_true "${CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST:-false}"
-  then enable_datastore_auth='false'
-  else enable_datastore_auth='true'
+  then enable_datastore_auth=false
+  else enable_datastore_auth=true
   fi
 
   #   These are the username and password of the administrative user
@@ -3814,19 +3815,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   enforce authentication.
   datastore && mongodb_admin_user="${CONF_MONGODB_ADMIN_USER:-admin}"
   datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  datastore &&  assign_pass mongodb_admin_password "mongopass" tmpvar
+  datastore &&  assign_pass mongodb_admin_password mongopass tmpvar
 
   #   These are the username and password of the normal user that will
   #   be created for the broker to connect to the MongoDB datastore. The
   #   broker application's MongoDB plugin is also configured with these
   #   values.
   (datastore || broker) && mongodb_broker_user="${CONF_MONGODB_BROKER_USER:-openshift}"
-  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  (datastore || broker) && assign_pass mongodb_broker_password "mongopass" tmpvar
+  (datastore || broker) && tmpvar="${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}"
+  (datastore || broker) && assign_pass mongodb_broker_password mongopass tmpvar
 
   #   In replicated setup, this is the key that slaves will use to
   #   authenticate with the master.
-  datastore && assign_pass mongodb_key "OSEnterprise" CONF_MONGODB_KEY
+  datastore && assign_pass mongodb_key OSEnterprise CONF_MONGODB_KEY
 
   #   In replicated setup, this is the name of the replica set.
   mongodb_replset="${CONF_MONGODB_REPLSET:-ose}"
@@ -3839,12 +3840,12 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   file as a demo/test user. You will likely want to remove it after
   #   installation (or just use a different auth method).
   broker && openshift_user1="${CONF_OPENSHIFT_USER1:-demo}"
-  broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
+  broker && assign_pass openshift_password1 changeme CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
   enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  assign_pass routing_plugin_pass "routinginfopasswd" CONF_ROUTING_PLUGIN_PASS
+  assign_pass routing_plugin_pass routinginfopasswd CONF_ROUTING_PLUGIN_PASS
 
   broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
   broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
@@ -3871,32 +3872,32 @@ init_message()
 
 validate_preflight()
 {
-  echo "OpenShift: Begin preflight validation."
+  echo 'OpenShift: Begin preflight validation.'
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  if ! grep -q 'Enterprise.* 6' /etc/redhat-release
   then
-    echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
+    echo 'OpenShift: This process needs to begin with Enterprise Linux 6 installed.'
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  if ! command -v getenforce || ! [[ "$(getenforce)" =~ Enforcing|Permissive ]]
   then
-    echo "OpenShift: SELinux needs to be installed and enabled."
+    echo 'OpenShift: SELinux needs to be installed and enabled.'
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
   if ! command -v rpm || ! command -v yum
   then
-    echo "OpenShift: rpm and yum must be installed."
+    echo 'OpenShift: rpm and yum must be installed.'
     preflight_failure=1
   fi
   if ! rpm -q rpm yum
   then
-    echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
+    echo 'OpenShift: rpm command failed; there may be a problem with the RPM DB.'
     preflight_failure=1
   fi
 
@@ -3909,12 +3910,12 @@ validate_preflight()
     #
     # Note: With RHN, we need credentials both for registration and
     # adding channels.
-    if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
+    if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhn requires an RHN user and password."
+        echo 'OpenShift: Install method rhn requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3933,7 +3934,7 @@ validate_preflight()
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhsm requires an RHN user and password."
+        echo 'OpenShift: Install method rhsm requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3953,14 +3954,14 @@ validate_preflight()
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
     then
-      echo "OpenShift: Install method rhsm requires a poolid."
+      echo 'OpenShift: Install method rhsm requires a poolid.'
       preflight_failure=1
     fi
   fi
 
   if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
   then
-    echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
+    echo 'OpenShift: Install method yum requires providing URLs for at least OpenShift repos.'
     preflight_failure=1
   fi
 
@@ -3968,21 +3969,21 @@ validate_preflight()
   # ... ?
 
   [[ -n "$preflight_failure" ]] && abort_install
-  echo "OpenShift: Completed preflight validation."
+  echo 'OpenShift: Completed preflight validation.'
 }
 
 install_rpms()
 {
-  echo "OpenShift: Begin installing RPMs."
+  echo 'OpenShift: Begin installing RPMs.'
   # We often rely on the latest SELinux policy and other updates.
-  echo "OpenShift: yum update"
+  echo 'OpenShift: yum update'
   yum $disable_plugin clean all
 
   local count=0
   while true
   do
     yum $disable_plugin update -y && break
-    if [[ $count -gt 3 ]]
+    if [[ "$count" -gt 3 ]]
     then abort_install
     fi
     let count+=1
@@ -4001,12 +4002,12 @@ install_rpms()
   node && install_cartridges
   node && remove_abrt_addon_python
   broker && install_rhc_pkg
-  echo "OpenShift: Completed installing RPMs."
+  echo 'OpenShift: Completed installing RPMs.'
 }
 
 configure_host()
 {
-  echo "OpenShift: Begin configuring host."
+  echo 'OpenShift: Begin configuring host.'
   is_true "$enable_ntp" && synchronize_clock
   # Note: configure_named must run before configure_controller if we are
   # installing both named and broker on the same host.
@@ -4016,18 +4017,18 @@ configure_host()
   is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
-  set_conf /etc/grub.conf timeout 1
+  set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
+  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall
 
   # All hosts should enable SSH access.
-  firewall_allow[ssh]=tcp:22
+  firewall_allow[ssh]='tcp:22'
   configure_firewall_add_rules
-  echo "OpenShift: Completed configuring host."
+  echo 'OpenShift: Completed configuring host.'
 }
 
 configure_firewall()
@@ -4038,7 +4039,7 @@ configure_firewall()
   echo '--disabled' > "$conf"
 
   # Configure iptables.
-cat > /etc/sysconfig/iptables <<'EOF'
+cat > '/etc/sysconfig/iptables' <<'EOF'
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
@@ -4058,12 +4059,12 @@ EOF
 # Note: This function must be run after configure_firewall.
 configure_firewall_add_rules()
 {
-  local rules=""
+  local rules=
   local port
   local prot
   local rule
   local svc
-  for svc in ${!firewall_allow[@]}
+  for svc in "${!firewall_allow[@]}"
   do
     rules+="$(
       for rule in ${firewall_allow[$svc]//,/ }
@@ -4078,7 +4079,7 @@ configure_firewall_add_rules()
 
   # Insert the rules specified by ${firewall_allow[@]} before the first
   # REJECT rule in the INPUT chain.
-  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" /etc/sysconfig/iptables
+  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" '/etc/sysconfig/iptables'
 }
 
 configure_gear_isolation_firewall()
@@ -4088,7 +4089,7 @@ configure_gear_isolation_firewall()
 
 configure_openshift()
 {
-  echo "OpenShift: Begin configuring OpenShift."
+  echo 'OpenShift: Begin configuring OpenShift.'
 
   # Prepare services that the broker and node depend on.
   datastore && configure_datastore
@@ -4128,16 +4129,16 @@ configure_openshift()
   node && configure_gear_isolation_firewall
 
   sysctl -p || :
-  restorecon -rv /etc/openshift
+  restorecon -rv '/etc/openshift'
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true
-  echo "OpenShift: Completed configuring OpenShift."
+  echo 'OpenShift: Completed configuring OpenShift.'
 }
 
 restart_services()
 {
-  echo "OpenShift: Begin restarting services."
+  echo 'OpenShift: Begin restarting services.'
 
   service iptables restart
 
@@ -4164,41 +4165,41 @@ restart_services()
   node && service openshift-watchman restart
 
   # Ensure OpenShift facts are updated.
-  node && /etc/cron.minutely/openshift-facts
+  node && '/etc/cron.minutely/openshift-facts'
 
-  echo "OpenShift: Completed restarting services."
+  echo 'OpenShift: Completed restarting services.'
 }
 
 run_diagnostics()
 {
-  echo "OpenShift: Begin running oo-diagnostics."
+  echo 'OpenShift: Begin running oo-diagnostics.'
   date +%Y-%m-%d-%H:%M:%S
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed running oo-diagnostics."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed running oo-diagnostics.'
 }
 
 reboot_after()
 {
-  echo "OpenShift: Rebooting after install."
+  echo 'OpenShift: Rebooting after install.'
   reboot
 }
 
 configure_districts()
 {
-  echo "OpenShift: Configuring districts."
-  date +%Y-%m-%d-%H:%M:%S
+  echo 'OpenShift: Configuring districts.'
+  date '+%Y-%m-%d-%H:%M:%S'
 
-  local restart=$RESTART_NEEDED
+  local restart="$RESTART_NEEDED"
   if is_true "$default_districts"
   then
     local p
     for p in ${valid_gear_sizes//,/ }
     do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
-      oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+      oo-admin-ctl-district -p "$p" -n "default-$p" -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
     done
   else
@@ -4212,12 +4213,12 @@ configure_districts()
     do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
-      firstnode=${nodes//,*/}
+      firstnode="${nodes//,*/}"
       # Query the node for the node profile via MCollective.
-      profile=""
+      profile=
       for i in {1..10}
       do
-        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
+        profile="$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)" \
          && break
         sleep 10
       done
@@ -4225,7 +4226,7 @@ configure_districts()
       then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
-        oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+        oo-admin-ctl-district -p "$profile" -n "$district" -c add-node -i "$nodes" |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
         is_xpaas "$profile" && configure_messaging_plugin  # back to default
       else
         echo "OpenShift: Could not determine gear profile for nodes: ${nodes}, cannot add to district $district"
@@ -4233,15 +4234,15 @@ configure_districts()
     done
   fi
   # Configuring districts should not normally require a service restart.
-  RESTART_NEEDED=$restart
+  RESTART_NEEDED="$restart"
 
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed configuring districts."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed configuring districts.'
 }
 
 post_deploy()
 {
-  echo "OpenShift: Begin post deployment steps."
+  echo 'OpenShift: Begin post deployment steps.'
 
   if broker
   then
@@ -4251,7 +4252,7 @@ post_deploy()
       RESTART_NEEDED=true
     fi
 
-    $RESTART_NEEDED && restart_services && RESTART_COMPLETED=true
+    "$RESTART_NEEDED" && restart_services && RESTART_COMPLETED=true
 
     # Import cartridges.
     oo-admin-ctl-cartridge -c import-node --activate --obsolete
@@ -4261,7 +4262,7 @@ post_deploy()
 
   node && install_rsync_pub_key
 
-  echo "OpenShift: Completed post deployment steps."
+  echo 'OpenShift: Completed post deployment steps.'
 }
 
 do_all_actions()
@@ -4307,8 +4308,8 @@ RESTART_COMPLETED=false
 # Make sure /sbin and /usr/sbin are in PATH
 for admin_path in /sbin /usr/sbin
 do
-  if [[ :$PATH: != *:"${admin_path}":* ]]
-  then PATH=${PATH}:${admin_path}
+  if [[ ":$PATH:" != *:"$admin_path":* ]]
+  then PATH="${PATH}:${admin_path}"
   fi
 done
 
@@ -4318,10 +4319,10 @@ declare -A firewall_allow
 
 set_defaults
 
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 for action in ${actions//,/ }
 do
-  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S
@@ -4330,9 +4331,9 @@ date +%Y-%m-%d-%H:%M:%S
 # host will automatically reboot anyway after the kickstart script completes.
 [[ "$environment" = ks ]] && RESTART_NEEDED=false
 
-$RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
+"$RESTART_NEEDED" && ! "$RESTART_COMPLETED" && restart_services
 
-$PASSWORDS_TO_DISPLAY && display_passwords
+"$PASSWORDS_TO_DISPLAY" && display_passwords
 
 :
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -2935,9 +2935,9 @@ configure_controller()
   set_broker MONGO_DB "$mongodb_name"
 
   # configure broker logs for syslog
-  [[ "$log_to_syslog" = *broker* ]] && \
+  [[ "$log_to_syslog" = *broker* ]] &&
     set_broker SYSLOG_ENABLED true
-  [[ "$log_to_syslog" = *console* ]] && \
+  [[ "$log_to_syslog" = *console* ]] &&
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
@@ -3200,7 +3200,7 @@ configure_node()
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1040,8 +1040,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+="${matchingvar##*_}: ${!matchingvar} "
+    [[ "$vprefix" != "$k" ]] && out_string+="${k##*_}"
     out_string+=": ${!k}"
     echo "$out_string"
   done

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1658,6 +1658,7 @@ configure_outgoing_http_proxy()
     # an external tool instead?).
     shopt -s extglob # for *()
     proxies_stanza="${proxies_stanza//$'\n'*([[:space:]])$'\n'/$'\n'}"
+    shopt -u extglob
     mkdir -p '/etc/openshift/skel/.m2'
     local settings_xml='/etc/openshift/skel/.m2/settings.xml'
     if ! [[ -e "$settings_xml" ]] || ! grep -q '<proxies>' "$settings_xml"

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1265,7 +1265,7 @@ configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [[ -e "${extra_repo_file}" ]]; then
-      echo > "${extra_repo_file}"
+      > "${extra_repo_file}"
   fi
 
   local -A priority=(

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -523,7 +523,8 @@
 # routing_plugin / CONF_ROUTING_PLUGIN
 # routing_plugin_user / CONF_ROUTING_PLUGIN_USER
 # routing_plugin_pass / CONF_ROUTING_PLUGIN_PASS
-#   Default: do not install the sample routing plugin
+#   Default: install the routing plugin if CONF_INSTALL_COMPONENTS includes
+#   "broker" and CONF_ROUTER is non-empty; otherwise, do not install it.
 #   When enabled, the routing plugin publishes routing events to a topic
 #   on the ActiveMQ instance(s) used by OpenShift Enterprise.
 #   For more info: http://red.ht/1eG9lHr
@@ -3338,9 +3339,13 @@ configure_routing_daemon()
   set_routing_daemon ACTIVEMQ_PASSWORD "$routing_plugin_pass"
   set_routing_daemon CLOUD_DOMAIN "$domain"
 
-  [[ "$router" = nginx ]] && service openshift-routing-daemon start
+  # Comment out any settings that are not related to the configured
+  # load-balancer.
+  [[ "$router" != f5 ]] && sed -i -e 's/^\(UPDATE_INTERVAL\|MONITOR_\|VIRTUAL_\|BIGIP_\|LBAAS_\)/#&/' '/etc/openshift/routing-daemon.conf'
+  [[ "$router" != nginx ]] && sed -i -e 's/^NGINX_/#&/' '/etc/openshift/routing-daemon.conf'
 
-  return 0
+  chkconfig openshift-routing-daemon on
+  RESTART_NEEDED=true
 }
 
 configure_routing_plugin()
@@ -3401,17 +3406,8 @@ configure_router()
       firewall_allow[https]='tcp:443'
       firewall_allow[http]='tcp:80'
       setsebool -P httpd_can_network_connect=true
-      # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
-      # and /etc/pki/tls/private/node.example.com.key exist because nginx will
-      # fail to start without them.
-      #
-      # These files should be copies of /etc/pki/tls/certs/localhost.crt and
-      # /etc/pki/tls/private/localhost.key, respectively, from a node host.
-      if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
-            -e '/etc/pki/tls/private/node.example.com.key' ]]
-      then
-        service nginx16-nginx start
-      fi
+      chkconfig nginx16-nginx on
+      RESTART_NEEDED=true
       ;;
   esac
 }
@@ -4178,8 +4174,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker && openshift_user1="${CONF_OPENSHIFT_USER1:-demo}"
   broker && assign_pass openshift_password1 changeme CONF_OPENSHIFT_PASSWORD1
 
+  enable_ha="${CONF_ENABLE_HA-false}"
+  router="${CONF_ROUTER-}"
+
   # auth info for the topic from the sample routing SPI plugin
-  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
+  local default_enable_routing_plugin=false
+  broker && [[ -n "$router" ]] && default_enable_routing_plugin=true
+  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-$default_enable_routing_plugin}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
   assign_pass routing_plugin_pass routinginfopasswd CONF_ROUTING_PLUGIN_PASS
 
@@ -4188,9 +4189,6 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   outgoing_http_proxy="${CONF_HTTP_PROXY-}"
   outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
-
-  enable_ha="${CONF_ENABLE_HA-false}"
-  router="${CONF_ROUTER-}"
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
@@ -4515,6 +4513,23 @@ restart_services()
   node && service openshift-node-web-proxy restart
   node && is_true "$enable_sni_proxy" && service openshift-sni-proxy restart
   node && service openshift-watchman restart
+
+  if router && [[ "$router" = nginx ]]
+  then
+    service openshift-routing-daemon restart
+
+    # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
+    # and /etc/pki/tls/private/node.example.com.key exist because nginx will
+    # fail to start without them.
+    #
+    # These files should be copies of /etc/pki/tls/certs/localhost.crt and
+    # /etc/pki/tls/private/localhost.key, respectively, from a node host.
+    if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
+          -e '/etc/pki/tls/private/node.example.com.key' ]]
+    then
+      service nginx16-nginx restart
+    fi
+  fi
 
   # Ensure OpenShift facts are updated.
   node && '/etc/cron.minutely/openshift-facts'

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1669,30 +1669,39 @@ install_cartridges()
 # given value to the setting.  If it does not, then comment out any
 # existing setting and add the given setting.
 #
-# The search pattern is /^\s*name\s*=\s*value\s*(|#.*)$/.  The
-# added line will be in the form 'name = value' or, if a short comment
-# is specified, 'name = value # short comment'.  If a long comment is
-# specified, a blank line followed by '# long comment' will be added
-# before the line for the setting itself.
+# The search pattern is /^\s*name\s*=\s*['"]?value\['"]?s*(|#.*)$/.  The added
+# line will be in the form 'name=value' or, if a non-empty short comment is
+# specified, 'name=value # short comment'.  Note that quotation marks are
+# tolerated when checking whether the setting is already present, but are not
+# added when adding the setting unless they are explicitly passed in with the
+# value.  If a long comment is specified using the fifth and possibly subsequent
+# arguments, a blank line followed by '# long comment' (one line per argument)
+# will be added before the line for the setting itself.
 #
 # $1 = configuration file's filename
 # $2 = setting name
 # $3 = value
 # $4 = short comment (optional)
-# $5 = long comment (optional)
+# $5- = long comment (optional)
 set_conf()
 {
-  if ! grep -q "^\\s*$2\\s*=\\s*$3\\s*\\(\\|#.*\\)$" "$1"
+  if ! grep -q "^\\s*$2\\s*=\\s*['\"]\\?$3['\"]\\?\\s*\\(\\|#.*\\)$" "$1"
   then
     sed -i -e "s/^\\s*$2\\s*=\\s*/#&/" "$1"
-    if [[ -n "$5" ]]
+    if [[ -n "${5-}" ]]
     then
       echo >> "$1"
-      echo "# $5" >> "$1"
+      args=( "$@" )
+      printf '# %s\n' "${args[@]:4}" >> "$1"
     fi
-    echo "$2 = $3${4:+ #$4}" >> "$1"
+    echo "$2=$3${4:+ #$4}" >> "$1"
   fi
 }
+
+set_mongodb() { set_conf /etc/mongodb.conf "$@"; }
+set_broker() { set_conf /etc/openshift/broker.conf "$@"; }
+set_console() { set_conf /etc/openshift/console.conf "$@"; }
+set_node() { set_conf /etc/openshift/node.conf "$@"; }
 
 # Fix up SELinux policy on the broker.
 configure_selinux_policy_on_broker()
@@ -2021,13 +2030,6 @@ configure_datastore_add_replicants()
   done
 
   set -x
-}
-
-# $1 = setting name
-# $2 = value
-set_mongodb()
-{
-  set_conf /etc/mongodb.conf "$1" "$2"
 }
 
 configure_datastore()
@@ -2815,12 +2817,12 @@ register_named_entries()
 configure_network()
 {
   # Ensure interface is configured to come up on boot
-  sed -i -e 's/ONBOOT="no"/ONBOOT="yes"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+  set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
   if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
-    sed -i -e 's/BOOTPROTO="dhcp"/BOOTPROTO="none"/' /etc/sysconfig/network-scripts/ifcfg-$interface
-    sed -i -e 's/IPV6INIT="yes"/IPV6INIT="no"/' /etc/sysconfig/network-scripts/ifcfg-$interface
+    set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
+    set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
   fi
 }
 
@@ -2851,10 +2853,9 @@ update_controller_gear_size_configs()
 {
   # Configure the valid gear sizes, default gear capabilities and default gear
   # size for the broker
-  sed -i -e "s/^VALID_GEAR_SIZES=.*/VALID_GEAR_SIZES=\"${valid_gear_sizes}\"/" \
-      -e "s/^DEFAULT_GEAR_CAPABILITIES=.*/DEFAULT_GEAR_CAPABILITIES=\"${default_gear_capabilities}\"/" \
-      -e "s/^DEFAULT_GEAR_SIZE=.*/DEFAULT_GEAR_SIZE=\"${default_gear_size}\"/" \
-      /etc/openshift/broker.conf
+  set_broker VALID_GEAR_SIZES "$valid_gear_sizes"
+  set_broker DEFAULT_GEAR_CAPABILITIES "$default_gear_capabilities"
+  set_broker DEFAULT_GEAR_SIZE "$default_gear_size"
 
   RESTART_NEEDED=true
 }
@@ -2869,40 +2870,34 @@ configure_controller()
 
   # Configure the broker with the correct domain name, and use random salt
   # to the data store (the host running MongoDB).
-  sed -i -e "s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/" \
-      /etc/openshift/broker.conf
-  echo AUTH_SALT=${broker_auth_salt} >> /etc/openshift/broker.conf
+  set_broker CLOUD_DOMAIN "$domain"
+  set_broker AUTH_SALT "$broker_auth_salt"
 
   update_controller_gear_size_configs
 
   # Configure the session secret for the broker
-  sed -i -e "s/# SESSION_SECRET=.*$/SESSION_SECRET=${broker_session_secret}/" \
-      /etc/openshift/broker.conf
+  set_broker SESSION_SECRET "$broker_session_secret"
 
   # Configure the session secret for the console
-  if [[ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]]
-  then
-    echo "SESSION_SECRET=${console_session_secret}" >> /etc/openshift/console.conf
-  fi
+  set_console SESSION_SECRET "$console_session_secret"
 
   if [[ ${datastore_replicants} =~ , ]] || ! datastore
   then
     # MongoDB may be installed remotely or replicated, so configure it
     # with the given hostname(s).
-    sed -i -e "s/^MONGO_HOST_PORT=.*$/MONGO_HOST_PORT=\"${datastore_replicants}\"/" /etc/openshift/broker.conf
+    set_broker MONGO_HOST_PORT "$datastore_replicants"
   fi
 
   # configure MongoDB access
-  sed -i -e "s/MONGO_PASSWORD=.*$/MONGO_PASSWORD=\"${mongodb_broker_password}\"/
-            s/MONGO_USER=.*$/MONGO_USER=\"${mongodb_broker_user}\"/
-            s/MONGO_DB=.*$/MONGO_DB=\"${mongodb_name}\"/" \
-      /etc/openshift/broker.conf
+  set_broker MONGO_PASSWORD "$mongodb_broker_password"
+  set_broker MONGO_USER "$mongodb_broker_user"
+  set_broker MONGO_DB "$mongodb_name"
 
   # configure broker logs for syslog
   [[ "$log_to_syslog" = *broker* ]] && \
-    sed -i -e '/SYSLOG_ENABLED=/ cSYSLOG_ENABLED="true"' /etc/openshift/broker.conf
+    set_broker SYSLOG_ENABLED true
   [[ "$log_to_syslog" = *console* ]] && \
-    echo 'SYSLOG_ENABLED="true"' >> /etc/openshift/console.conf
+    set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
@@ -2924,9 +2919,8 @@ configure_messaging_plugin()
 
   local file=/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
   cp "$file"{.example,}
-  sed -i -e "s/DISTRICTS_FIRST_UID=.*/DISTRICTS_FIRST_UID=${district_first_uid}/
-             s/DISTRICTS_MAX_CAPACITY=.*/DISTRICTS_MAX_CAPACITY=${pool_size}/
-            " $file
+  set_conf "$file" DISTRICTS_FIRST_UID "$district_first_uid"
+  set_conf "$file" DISTRICTS_MAX_CAPACITY "$pool_size"
   RESTART_NEEDED=true
 }
 
@@ -3121,7 +3115,7 @@ configure_hostname()
 {
   if [[ ! "$hostname" =~ ^[0-9.]*$ ]]  # hostname is not just an IP
   then
-    sed -i -e "s/HOSTNAME=.*/HOSTNAME=${hostname}/" /etc/sysconfig/network
+    set_conf /etc/sysconfig/network HOSTNAME "$hostname"
     hostname "${hostname}"
   fi
 }
@@ -3135,27 +3129,22 @@ configure_node()
   elif [[ -f "$resrc.${node_profile}" ]]; then
     cp "$resrc.${node_profile}" $resrc
   fi
-  sed -i -e "s/^node_profile=.*$/node_profile=${node_profile_name}/" $resrc
+  set_conf "$resrc" node_profile "$node_profile_name"
 
-  local conf=/etc/openshift/node.conf
-  sed -i -e "s/^PUBLIC_IP=.*$/PUBLIC_IP=${node_ip_addr}/;
-             s/^CLOUD_DOMAIN=.*$/CLOUD_DOMAIN=${domain}/;
-             s/^PUBLIC_HOSTNAME=.*$/PUBLIC_HOSTNAME=${hostname}/;
-             s/^BROKER_HOST=.*$/BROKER_HOST=${broker_hostname}/;
-             s/^[# ]*EXTERNAL_ETH_DEV=.*$/EXTERNAL_ETH_DEV='${interface}'/" \
-      $conf
+  set_node PUBLIC_IP "$node_ip_addr"
+  set_node CLOUD_DOMAIN "$domain"
+  set_node PUBLIC_HOSTNAME "$hostname"
+  set_node BROKER_HOST "$broker_hostname"
+  set_node EXTERNAL_ETH_DEV "$interface"
+
   if [[ "$ports_per_gear" != 5 ]]; then
-    sed -i -e "/PORTS_PER_USER=/ cPORTS_PER_USER=${ports_per_gear}" $conf
-    # If PORTS_PER_USER is not already there, we need to add it.
-    grep -q '^PORTS_PER_USER' $conf || sed -i -e "$ a\\
-\\
-# Number of proxy ports available per gear. Increasing the ports per gear requires reducing\\
-# the number of UIDs the district has so that the ports allocated to all UIDs fit in the\\
-# proxy port range.\\
-PORTS_PER_USER=${ports_per_gear}
-                                                 " $conf
+    set_node PORTS_PER_USER "$ports_per_gear" '' \
+     'Number of proxy ports available per gear. Increasing the ports per gear'\
+     'requires reducing the number of UIDs the district has so that the ports'\
+     'allocated to all UIDs fit in the proxy port range.'
   fi
 
+  local conf=/etc/openshift/node.conf
   case "$node_apache_frontend" in
     mod_rewrite)
       sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" $conf
@@ -3170,7 +3159,8 @@ PORTS_PER_USER=${ports_per_gear}
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
-    sed -i -e "/PROXY_PORTS/ cPROXY_PORTS=${port_list}" /etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf
+    local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'
+    set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
   echo $broker_hostname > /etc/openshift/env/OPENSHIFT_BROKER_HOST
@@ -3207,18 +3197,14 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
   fi
   if is_true "$node_log_context"; then
     # Annotate the frontend logs with UUIDs.
-    sed -i -e '
-      s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
-      s/^.*PLATFORM_LOG_CONTEXT_ATTRS=.*/PLATFORM_LOG_CONTEXT_ATTRS=request_id,app_uuid,container_uuid/
-    ' /etc/openshift/node.conf
+    set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
+    set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
   if [[ -n "$metrics_interval" ]]; then
     # Configure watchman with given the interval.
-    sed -i -e "
-      s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
-      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$metrics_interval/
-    " /etc/openshift/node.conf
+    set_node WATCHMAN_METRICS_ENABLED 'true'
+    set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
   fi
 }
 
@@ -3966,7 +3952,7 @@ configure_host()
   is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
-  sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;
+  set_conf /etc/grub.conf timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1694,6 +1694,8 @@ EOF
   # which the broker uses for both HTTP and HTTPS connetions.  Usually, one will
   # use an https: URL for downloadable cartridges, so we put that here.
   broker && set_broker HTTP_PROXY "$outgoing_https_proxy"
+
+  return 0
 }
 
 # Install broker-specific packages.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1837,8 +1837,13 @@ configure_quotas_on_node()
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
     time restorecon "${geardata_mnt}"
+
+    # quotacheck fails if quotas are enabled.
+    quotaoff "${geardata_mnt}"
+
     # Generate user quota info for the mount point.
     time quotacheck -cmug "${geardata_mnt}"
+
     # Fix the SELinux label of the created quota file.
     restorecon "${geardata_mnt}"/aquota.user
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -956,9 +956,19 @@
 # hardware clock with that.
 synchronize_clock()
 {
+  local need_to_start_ntpd=
+
+  if service ntpd status | grep 'is running'
+  then
+    # Stop ntpd so that ntpdate succeeds.
+    service ntpd stop
+    need_to_start_ntpd=1
+  fi
 
   # Synchronize the system clock using NTP.
   ntpdate clock.redhat.com
+
+  [[ -n "$need_to_start_ntpd" ]] && service ntpd start
 
   # Synchronize the hardware clock to the system clock.
   hwclock --systohc

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -996,21 +996,21 @@
 
 set -euo pipefail
 
-annotate()
-{
-  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
-}
-trap 'echo "Finished with exitcode $?" >&4' EXIT
-# <> redirection requires disabling posix.
-set +o posix
-exec 5>&1 \
-  1<> >(annotate O >&5) \
-  2<> >(annotate E >&5) \
-  3<> >(annotate D >&5) \
-  4<> >(annotate I >&5) \
-  5>&-
-BASH_XTRACEFD=3
-echo "Started $0 $*" >&4
+#annotate()
+#{
+#  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+#}
+#trap 'echo "Finished with exitcode $?" >&4' EXIT
+## <> redirection requires disabling posix.
+#set +o posix
+#exec 5>&1 \
+#  1<> >(annotate O >&5) \
+#  2<> >(annotate E >&5) \
+#  3<> >(annotate D >&5) \
+#  4<> >(annotate I >&5) \
+#  5>&-
+#BASH_XTRACEFD=3
+#echo "Started $0 $*" >&4
 
 
 ########################################################################

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -984,7 +984,7 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [ -n "${!3}" ]; then
+  if [[ -n "${!3}" ]]; then
     printf -v "$1" '%s' "${!3}"
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
@@ -1017,11 +1017,11 @@ display_passwords()
     matchingvar=""
     for postfix in password password1 pass; do
       vprefix=${k%${postfix}}
-      [ "$vprefix" != "$k" ] && break
+      [[ "$vprefix" != "$k" ]] && break
     done
 
     for v in "${vprefix}user" "${vprefix}user1"; do
-      if [ "x${!v}" != "x" ]; then
+      if [[ -n "${!v}" ]]; then
         matchingvar=$v
         break
       fi
@@ -1033,8 +1033,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [ "x$matchingvar" != "x" ] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [ "$vprefix" != "$k" ] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
+    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
     echo $out_string
   done
@@ -1056,7 +1056,7 @@ configure_repos()
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
 
-  if [ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]; then
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
     need_extra_repo() { :; }
   fi
 
@@ -1134,11 +1134,11 @@ configure_ose_yum_repos()
   # this can be useful even if the main subscription is via RHN
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
-    if [ "$ose_repo_base" != "" ]; then
-      local layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+    if [[ -n "$ose_repo_base" ]]; then
+      local layout=puddle; [[ -n "$CONF_CDN_LAYOUT" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [ "$ose_extra_repo_base" != "" ]; then
+    if [[ -n "$ose_extra_repo_base" ]]; then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -1150,7 +1150,7 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [ "${rhel_repo}x" != "x" ]; then
+if [[ -n "${rhel_repo}" ]]; then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -1167,7 +1167,7 @@ fi
 
 configure_optional_repo()
 {
-if [ "${rhel_optional_repo}x" != "x" ]; then
+if [[ -n "${rhel_optional_repo}" ]]; then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -1215,7 +1215,7 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [ "x${rhscl_repo_base}" != "x" ]; then
+  if [[ -n "${rhscl_repo_base}" ]]; then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -1261,7 +1261,7 @@ YUM
 configure_extra_repos()
 { # add all defined extra repos in one file
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [ -e "${extra_repo_file}" ]; then
+  if [[ -e "${extra_repo_file}" ]]; then
       echo > "${extra_repo_file}"
   fi
 
@@ -1280,7 +1280,7 @@ configure_extra_repos()
   local repo
   for repo in "${!priority[@]}"; do
     local url="${!repo}"
-    if [ "${url}x" != "x" ]; then
+    if [[ -n "${url}" ]]; then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -1323,11 +1323,11 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [ "x$CONF_RHN_REG_ACTKEY" != x ]; then
+  if [[ -n "$CONF_RHN_REG_ACTKEY" ]]; then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${CONF_RHN_REG_ACTKEY}" "--profilename=$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
-  else 
-    if [ $rhn_creds_provided ]
+  else
+    if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # don't log password
       echo "OpenShift: Register to RHN Classic with username and password"
@@ -1339,7 +1339,7 @@ configure_rhn_channels()
     fi
   fi
 
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     # Enable the node or infrastructure channel to enable installing the release RPM
     local repos=('rhel-x86_64-server-6-rhscl-1')
@@ -1355,7 +1355,7 @@ configure_rhn_channels()
     set +x # don't log password
     local repo
     for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" == *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
+      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
     done
     set -x
   fi
@@ -1365,7 +1365,7 @@ configure_rhn_channels()
 
 configure_rhsm_channels()
 {
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # don't log password
     echo "OpenShift: Register with RHSM"
@@ -1376,7 +1376,7 @@ configure_rhsm_channels()
     echo "OpenShift: No credentials given for RHSM; assuming already configured"
   fi
 
-  if [[ "${CONF_SM_REG_POOL}" ]]
+  if [[ -n "${CONF_SM_REG_POOL}" ]]
   then
     echo "OpenShift: Removing all current subscriptions"
     subscription-manager remove --all
@@ -1400,7 +1400,7 @@ configure_rhsm_channels()
 
 abort_install()
 {
-  [[ "$@"x == x ]] || echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$@"
   # don't change this; could be used as an automation cue.
   echo "OpenShift: Aborting Installation."
   exit 1
@@ -1412,9 +1412,9 @@ yum_install_or_exit()
   local count=0
   time while true; do
     yum install -y $* $disable_plugin
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       return
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -1820,7 +1820,7 @@ configure_quotas_on_node()
   # Get the mountpoint for /var/lib/openshift (should be /).
   local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
-  if ! [ x"$geardata_mnt" != x ]
+  if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
@@ -1927,13 +1927,13 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [ -n "$3" -a -n "$4" ]; then
+  if [[ -n "$3" && -n "$4" ]]; then
     userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [ "$2" ]; then # test output against regex
+  if [[ -n "$2" ]]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -2321,7 +2321,7 @@ configure_activemq()
   local replicant
   for replicant in ${activemq_replicants//,/ }
   do
-    if ! [ "$replicant" = "$activemq_hostname" ]
+    if [[ "$replicant" != "$activemq_hostname" ]]
     then
       : ${networkConnectors:='        <networkConnectors>'$'\n'}
       : ${authenticationUser_amq:="<authenticationUser username=\"amq\" password=\"${activemq_amq_user_password}\" groups=\"admins,everyone\" />"}
@@ -2658,7 +2658,7 @@ EOF
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
   configure_named_zone "$hosts_domain"
-  [ "$domain" != "$hosts_domain" ] && configure_named_zone "$domain"
+  [[ "$domain" != "$hosts_domain" ]] && configure_named_zone "$domain"
 
   # configure in any hosts as needed
   configure_hosts_dns
@@ -2675,7 +2675,7 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [ "x$bind_key" = x ]; then
+  if [[ -z "$bind_key" ]]; then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -2725,7 +2725,7 @@ EOF
 ensure_domain()
 { # adds a domain to hostname if it does not have one
   # $1 = host; $2 = domain
-  if [[ $1 == *.* ]]; then # already FQDN or IP
+  if [[ $1 = *.* ]]; then # already FQDN or IP
     echo "$1"
   else # needs a domain
     echo "$1.$2"
@@ -2750,8 +2750,8 @@ configure_hosts_dns()
 {
   add_host_to_zone "$named_hostname" "$named_ip_addr" # always define self
   # glue record for NS host in subdomain:
-  [[ "$hosts_domain" == *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
-  if [ -z "$CONF_NAMED_ENTRIES" ]; then
+  [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
+  if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
@@ -2839,7 +2839,7 @@ update_controller_gear_size_configs()
 # Update the controller configuration.
 configure_controller()
 {
-  if [ "x$broker_auth_salt" = "x" ]
+  if [[ -z "$broker_auth_salt" ]]
   then
     echo "Warning: broker authentication salt is empty!"
   fi
@@ -2857,7 +2857,7 @@ configure_controller()
       /etc/openshift/broker.conf
 
   # Configure the session secret for the console
-  if [ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]
+  if [[ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]]
   then
     echo "SESSION_SECRET=${console_session_secret}" >> /etc/openshift/console.conf
   fi
@@ -2908,7 +2908,7 @@ configure_messaging_plugin()
 # Configure the broker to use the BIND DNS plug-in.
 configure_dns_plugin()
 {
-  if [ "x$bind_key" = x ] && [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_key" && -z "$bind_krb_keytab" ]]
   then
     echo 'WARNING: Neither key nor keytab has been set for communication'
     echo 'with BIND. You will need to modify the value of BIND_KEYVALUE'
@@ -2922,7 +2922,7 @@ BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
-  if [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_krb_keytab" ]]
   then
     cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
 BIND_KEYNAME="${domain}"
@@ -2947,7 +2947,7 @@ configure_httpd_auth()
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
-  if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
+  if [[ -n "$CONF_BROKER_KRB_SERVICE_NAME" && -n "$CONF_BROKER_KRB_AUTH_REALMS" ]]
   then
     yum_install_or_exit mod_auth_kerb
     local d
@@ -3186,7 +3186,7 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ "$CONF_METRICS_INTERVAL" != "" ]]; then
+  if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
     # configure watchman with given interval
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
@@ -3217,11 +3217,11 @@ install_rsync_pub_key()
   while [[ `date +%s` -lt $end ]]; do
     # try to get key hosted on broker machine
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
       sleep 5
     else
       ssh-keygen -lf /dev/stdin <<< $cert
-      if [ $? -ne 0 ]; then
+      if [[ $? -ne 0 ]]; then
         break
       else
         echo $cert >> /root/.ssh/authorized_keys
@@ -3311,7 +3311,7 @@ is_true()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 1
+    [[ "$arg" =~ (1|true) ]] || return 1
   done
 
   return 0
@@ -3321,7 +3321,7 @@ is_false()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 0
+    [[ "$arg" =~ (1|true) ]] || return 0
   done
 
   return 1
@@ -3330,7 +3330,7 @@ is_false()
 is_xpaas()
 { # checks first arg or $node_profile, true if contains "xpaas"
   local profile="${1:-$node_profile}"
-  [[ "${profile}" == *xpaas* ]]
+  [[ "${profile}" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -3394,7 +3394,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   local setting
   for setting in "${!CONF_@}"
   do
-    if ! [[ ${valid_settings[$setting]+1} ]]
+    if [[ -z "${valid_settings[$setting]+x}" ]]
     then
       if is_true "$abort_on_unrecognized_settings"
       then
@@ -3404,7 +3404,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       fi
     else
       # The setting is recognized, so check whether a non-empty value is given.
-      [[ ${!setting} ]] || abort_install "Setting is assigned an empty value: $setting"
+      [[ -n "${!setting}" ]] || abort_install "Setting is assigned an empty value: $setting"
     fi
   done
   set -x
@@ -3444,7 +3444,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [ $installing_something = 0 ]
+  if [[ $installing_something = 0 ]]
   then
     for component in $components
     do
@@ -3490,26 +3490,26 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Use CDN layout as the default for all yum repos if this is set.
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [ "x$cdn_repo_base" != "x" ]; then
+  if [[ -n "$cdn_repo_base" ]]; then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [ "${cdn_repo_base}" == "${ose_repo_base}" ]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
       CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [ "${rhel_repo}" == "${ose_repo_base}/os" ]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
     CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
   # no need to waste time checking both subscription plugins if using one
   disable_plugin=""
-  [[ "$CONF_INSTALL_METHOD" == "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
-  [[ "$CONF_INSTALL_METHOD" == "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
+  [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
+  [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
   # could do the same for "yum" method but it's more likely to surprise someone
-  #[[ "$CONF_INSTALL_METHOD" == "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
+  #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
 
   # remap subscription parameters used previously
   CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
@@ -3586,7 +3586,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values
   # are both non-empty, or set $bind_key to the value of $CONF_BIND_KEY
   # if the latter is non-empty.
-  if [ "x$CONF_BIND_KRB_KEYTAB" != x ] && [ "x$CONF_BIND_KRB_PRINCIPAL" != x ] ; then
+  if [[ -n "$CONF_BIND_KRB_KEYTAB" && -n "$CONF_BIND_KRB_PRINCIPAL" ]]; then
   bind_krb_keytab="$CONF_BIND_KRB_KEYTAB"
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
@@ -3601,15 +3601,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
-  [ -n "$CONF_VALID_GEAR_SIZES" ] && isset_valid_gear_sizes() { :; }
+  [[ -n "$CONF_VALID_GEAR_SIZES" ]] && isset_valid_gear_sizes() { :; }
   broker && valid_gear_sizes="${CONF_VALID_GEAR_SIZES:-small}"
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
-  [ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ] && isset_default_gear_capabilities() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ]] && isset_default_gear_capabilities() { :; }
   broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
-  [ -n "$CONF_DEFAULT_GEAR_SIZE" ] && isset_default_gear_size() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
   # Set $node_profile to $CONF_NODE_PROFILE
@@ -3747,7 +3747,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 init_message()
 {
   echo_installation_intentions
-  [ "$environment" = ks ] && configure_console_msg
+  [[ "$environment" = ks ]] && configure_console_msg
 }
 
 validate_preflight()
@@ -3788,7 +3788,7 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3804,7 +3804,7 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3821,15 +3821,15 @@ validate_preflight()
     # subscription-manager gets to write all of its plentiful output
     # before grep closes the pipeline.  Without it, we will get
     # a harmless but possibly alarming "Broken pipe" error message.
-    if [[ ! "$CONF_SM_REG_POOL" ]] &&
-        ( [[ "$CONF_RHN_USER" && "$CONF_RHN_PASS" ]] ||
+    if [[ -z "$CONF_SM_REG_POOL" ]] &&
+        ( [[ -n "$CONF_RHN_USER" && -n "$CONF_RHN_PASS" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [ "$CONF_INSTALL_METHOD" = yum -a ! "$ose_repo_base" ]; then
+  if [[ "$CONF_INSTALL_METHOD" = yum && -z "$ose_repo_base" ]]; then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -3837,7 +3837,7 @@ validate_preflight()
   # Test that known problematic RPMs aren't present
   # ... ?
 
-  [ "$preflight_failure" ] && abort_install
+  [[ -n "$preflight_failure" ]] && abort_install
   echo "OpenShift: Completed preflight validation."
 }
 
@@ -3851,9 +3851,9 @@ install_rpms()
   local count=0
   while true; do
     yum $disable_plugin update -y
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       break
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       abort_install
     fi
     let count+=1
@@ -4085,12 +4085,12 @@ configure_districts()
       profile=""
       for i in {1..10}; do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
-        if [ $? -eq 0 ]; then
+        if [[ $? -eq 0 ]]; then
           break;
         fi
         sleep 10
       done
-      if [ "x$profile" != "x" ]; then
+      if [[ -n "$profile" ]]; then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -4186,7 +4186,7 @@ set_defaults
 date +%Y-%m-%d-%H:%M:%S
 for action in ${actions//,/ }
 do
-  [ "$(type -t "$action")" = function ] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -984,7 +984,7 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [[ -n "${!3}" ]]; then
+  if [[ -n "${!3-}" ]]; then
     printf -v "$1" '%s' "${!3}"
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
@@ -1021,7 +1021,7 @@ display_passwords()
     done
 
     for v in "${vprefix}user" "${vprefix}user1"; do
-      if [[ -n "${!v}" ]]; then
+      if [[ -n "${!v+x}" ]]; then
         matchingvar=$v
         break
       fi
@@ -1054,7 +1054,7 @@ configure_repos()
       eval "need_${repo}_repo() { false; }"
   done
 
-  is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
+  is_true "$enable_optional_repo" && need_optional_repo() { :; }
 
   if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
     need_extra_repo() { :; }
@@ -1102,7 +1102,7 @@ configure_repos()
   # The configure_yum_repos, configure_rhn_channels, and
   # configure_rhsm_channels functions will use the need_${repo}_repo
   # predicate functions define above.
-  case "$CONF_INSTALL_METHOD" in
+  case "$install_method" in
     (yum)
       configure_yum_repos
       ;;
@@ -1136,7 +1136,7 @@ configure_ose_yum_repos()
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [[ -n "$ose_repo_base" ]]; then
-      local layout=puddle; [[ -n "$CONF_CDN_LAYOUT" ]] && layout=cdn
+      local layout=puddle; [[ -n "$cdn_layout" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
     if [[ -n "$ose_extra_repo_base" ]]; then
@@ -1160,7 +1160,7 @@ enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude=tomcat6* ${CONF_YUM_EXCLUDE_PKGS}
+exclude=tomcat6* ${yum_exclude_pkgs}
 
 YUM
 fi
@@ -1177,7 +1177,7 @@ enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 fi
@@ -1209,7 +1209,7 @@ enabled=1
 gpgcheck=0
 priority=10
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 }
@@ -1224,7 +1224,7 @@ baseurl=${rhscl_repo_base}/rhscl/1/os/
 enabled=1
 priority=10
 gpgcheck=0
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
 
@@ -1254,7 +1254,7 @@ enabled=1
 gpgcheck=0
 priority=30
 sslverify=false
-exclude= ${CONF_YUM_EXCLUDE_PKGS}
+exclude= ${yum_exclude_pkgs}
 
 YUM
   done
@@ -1292,7 +1292,7 @@ enabled=1
 gpgcheck=0
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} ${CONF_YUM_EXCLUDE_PKGS}
+exclude=${exclude[$repo]} ${yum_exclude_pkgs}
 
 YUM
     fi
@@ -1310,7 +1310,7 @@ configure_subscription()
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
-   need_jbosseap_cartridge_repo && roles="$roles --role ${jbosseap_yumvalidator_role}"
+   need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
    oo-admin-yum-validator -o 2.2 --fix-all $roles # when fixing, rc is always false
@@ -1326,16 +1326,16 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [[ -n "$CONF_RHN_REG_ACTKEY" ]]; then
+  if [[ -n "$rhn_reg_actkey" ]]; then
     echo "OpenShift: Register to RHN Classic using an activation key"
-    rhnreg_ks --force "--activationkey=${CONF_RHN_REG_ACTKEY}" "--profilename=$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
+    rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # Don't log password.
       echo "OpenShift: Register to RHN Classic with username and password"
-      echo "rhnreg_ks --force \"--profilename=$profile_name\" --username \"${CONF_RHN_USER}\" ${CONF_RHN_REG_OPTS}"
-      rhnreg_ks --force "--profilename=$profile_name" --username "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" ${CONF_RHN_REG_OPTS} || abort_install
+      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" ${rhn_reg_opts}"
+      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "${rhn_user}" --password "${rhn_pass}" ${rhn_reg_opts} || abort_install
       set -x
     else
       echo "OpenShift: No credentials given for RHN Classic; assuming already configured"
@@ -1352,14 +1352,14 @@ configure_rhn_channels()
     fi
     need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.2-node' 'jb-ews-2-x86_64-server-6-rpm')
     need_client_tools_repo && repos+=('rhel-x86_64-server-6-ose-2.2-rhc')
-    need_jbosseap_cartridge_repo && repos+=("rhel-x86_64-server-6-ose-2.2-jbosseap" "jbappplatform-${jbosseap_version}-x86_64-server-6-rpm")
+    need_jbosseap_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbosseap' "jbappplatform-${jbosseap_version}-x86_64-server-6-rpm")
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
     set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
+      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
     done
     set -x
   fi
@@ -1373,14 +1373,14 @@ configure_rhsm_channels()
   then
     set +x # Don't log password.
     echo "OpenShift: Register with RHSM"
-    echo "subscription-manager register --force \"--username=$CONF_RHN_USER\" --name \"$profile_name\" ${CONF_RHN_REG_OPTS}"
-    subscription-manager register --force "--username=$CONF_RHN_USER" "--password=$CONF_RHN_PASS" --name "$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
+    echo "subscription-manager register --force \"--username=$rhn_user\" --name \"$rhn_profile_name\" ${rhn_reg_opts}"
+    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" ${rhn_reg_opts} || abort_install
     set -x
   else
     echo "OpenShift: No credentials given for RHSM; assuming already configured"
   fi
 
-  if [[ -n "${CONF_SM_REG_POOL}" ]]
+  if [[ -n "${sm_reg_pool}" ]]
   then
     echo "OpenShift: Removing all current subscriptions"
     subscription-manager remove --all
@@ -1390,7 +1390,7 @@ configure_rhsm_channels()
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
   local poolid
-  for poolid in ${CONF_SM_REG_POOL//[, :+\/-]/ }; do
+  for poolid in ${sm_reg_pool//[, :+\/-]/ }; do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
   done
@@ -1454,7 +1454,7 @@ install_broker_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-dns-nsupdate"
   pkgs="$pkgs openshift-origin-console"
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
-  is_true "$CONF_ROUTING_PLUGIN" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
+  is_true "$enable_routing_plugin" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
 
   # We use semanage in configure_selinux_policy_on_broker, so we need to
   # install policycoreutils-python.
@@ -1478,7 +1478,7 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
 
-  if [[ "$CONF_SYSLOG" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]; then
     if rpm -q rsyslog ; then
       # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
@@ -1847,11 +1847,11 @@ configure_quotas_on_node()
 
 configure_idler_on_node()
 {
-  [[ "$CONF_IDLE_INTERVAL" =~ ^[[:digit:]]+$ ]] || return
+  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return
   cat <<CRON > /etc/cron.hourly/auto-idler
 (
   /usr/sbin/oo-last-access
-  /usr/sbin/oo-auto-idler idle --interval $CONF_IDLE_INTERVAL
+  /usr/sbin/oo-auto-idler idle --interval $idle_interval
 ) >> /var/log/openshift/node/auto-idler.log 2>&1
 CRON
   chmod +x /etc/cron.hourly/auto-idler
@@ -1930,13 +1930,13 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [[ -n "$3" && -n "$4" ]]; then
+  if [[ -n "${3+x}" && -n "${4+x}" ]]; then
     userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [[ -n "$2" ]]; then # test output against regex
+  if [[ -n "${2+x}" ]]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -1954,7 +1954,7 @@ configure_datastore_add_users()
     then
       echo 'while (rs.isMaster().primary == null) { sleep(5); }'
     fi
-    if is_false "$CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST"
+    if is_true "$enable_datastore_auth"
     then
       # Add an administrative user.
       echo 'use admin'
@@ -2105,7 +2105,7 @@ configure_gears()
   chkconfig openshift-gears on
 
   # configure gear logging
-  if [[ "$CONF_SYSLOG" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]; then
     # make the gear app servers log to syslog by default (overrideable)
     sed -i -e '
       /outputtype\b/I coutputType = syslog
@@ -2181,7 +2181,7 @@ enable_services_on_node()
 
   chkconfig httpd on
   chkconfig network on
-  is_false "$CONF_NO_NTP" && chkconfig ntpd on
+  is_true "$enable_ntp" && chkconfig ntpd on
   chkconfig sshd on
   chkconfig oddjobd on
   chkconfig openshift-node-web-proxy on
@@ -2197,7 +2197,7 @@ enable_services_on_broker()
 
   chkconfig httpd on
   chkconfig network on
-  is_false "$CONF_NO_NTP" && chkconfig ntpd on
+  is_true "$enable_ntp" && chkconfig ntpd on
   chkconfig sshd on
 }
 
@@ -2355,7 +2355,7 @@ configure_activemq()
   networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
 
   local schedulerSupport= routingPolicy=
-  if is_true "${CONF_ROUTING_PLUGIN}"
+  if is_true "${enable_routing_plugin}"
   then
     schedulerSupport='schedulerSupport="true"'
     IFS= read -r -d '' routingPolicy <<'EOF'
@@ -2477,7 +2477,7 @@ $networkConnectors
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
                ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
-               $( if is_true "$CONF_ROUTING_PLUGIN"; then
+               $( if is_true "$enable_routing_plugin"; then
                     echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
@@ -2492,7 +2492,7 @@ $networkConnectors
                   <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
-                  $( if is_true "$CONF_ROUTING_PLUGIN"; then
+                  $( if is_true "$enable_routing_plugin"; then
                        echo '<authorizationEntry topic="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                        echo '<authorizationEntry queue="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                      fi
@@ -2593,7 +2593,7 @@ configure_named()
 
   # Set up DNS forwarding if so directed.
   local forwarders="recursion no;"
-  if is_true "$CONF_FORWARD_DNS"; then
+  if is_true "$enable_dns_forwarding"; then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
     chmod 644 /var/named/forwarders.conf
@@ -2763,20 +2763,20 @@ configure_hosts_dns()
   # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
 
-  if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
+  if [[ -z "$named_entries" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-  elif [[ "$CONF_NAMED_ENTRIES" =~ : ]]; then
+  elif [[ "$named_entries" =~ : ]]; then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
-    for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
+    for host_ip in ${named_entries//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
   else # If "none" is specified, then just don't add anything.
-    echo "Not adding named entries; named_entries = $CONF_NAMED_ENTRIES"
+    echo "Not adding named entries; named_entries = $named_entries"
   fi
 }
 
@@ -2790,7 +2790,7 @@ register_named_entries()
   local host_ip
   local host
   local ip
-  for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
+  for host_ip in ${named_entries//,/ }; do
     read host ip <<<$(echo ${host_ip//:/ })
     if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
@@ -2889,9 +2889,9 @@ configure_controller()
       /etc/openshift/broker.conf
 
   # configure broker logs for syslog
-  [[ "$CONF_SYSLOG" = *broker* ]] && \
+  [[ "$log_to_syslog" = *broker* ]] && \
     sed -i -e '/SYSLOG_ENABLED=/ cSYSLOG_ENABLED="true"' /etc/openshift/broker.conf
-  [[ "$CONF_SYSLOG" = *console* ]] && \
+  [[ "$log_to_syslog" = *console* ]] && \
     echo 'SYSLOG_ENABLED="true"' >> /etc/openshift/console.conf
 
   # Set the ServerName for httpd
@@ -2962,14 +2962,14 @@ configure_httpd_auth()
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
-  if [[ -n "$CONF_BROKER_KRB_SERVICE_NAME" && -n "$CONF_BROKER_KRB_AUTH_REALMS" ]]
+  if [[ -n "$broker_krb_service_name" && -n "$broker_krb_auth_realms" ]]
   then
     yum_install_or_exit mod_auth_kerb
     local d
     for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
     do
-      sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
-        -e "s#KrbAuthRealms.*#KrbAuthRealms ${CONF_BROKER_KRB_AUTH_REALMS}#" \
+      sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
+        -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
 	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
     done
     return
@@ -3001,7 +3001,7 @@ configure_httpd_auth()
 
 configure_routing_plugin()
 {
-  if is_true "$CONF_ROUTING_PLUGIN"; then
+  if is_true "$enable_routing_plugin"; then
     local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
@@ -3174,7 +3174,7 @@ PORTS_PER_USER=${ports_per_gear}
 
 configure_node_logs()
 {
-  if [[ "$CONF_SYSLOG" = *node* ]]; then
+  if [[ "$log_to_syslog" = *node* ]]; then
     # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
@@ -3189,11 +3189,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
-  if [[ "$CONF_SYSLOG" = *frontend* ]]; then
+  if [[ "$log_to_syslog" = *frontend* ]]; then
     # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
-  if is_true "$CONF_NODE_LOG_CONTEXT"; then
+  if is_true "$node_log_context"; then
     # Annotate the frontend logs with UUIDs.
     sed -i -e '
       s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
@@ -3201,11 +3201,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
+  if [[ -n "$metrics_interval" ]]; then
     # Configure watchman with given the interval.
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
-      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$CONF_METRICS_INTERVAL/
+      s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$metrics_interval/
     " /etc/openshift/node.conf
   fi
 }
@@ -3475,76 +3475,27 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   jbosseap_version="${CONF_JBOSSEAP_VERSION:-6.3}"
   # Check jbosseap_version for validity
-  case "${jbosseap_version}" in
+  case "$jbosseap_version" in
       (6.3|6.4)
-          jbosseap_version="${jbosseap_version}"
-          jbosseap_yumvalidator_role="node-eap-${jbosseap_version}"
+          jbosseap_version="$jbosseap_version"
+          jbosseap_yumvalidator_role="node-eap-$jbosseap_version"
           ;;
       (current|6)
           jbosseap_version="6"
-          jbosseap_yumvalidator_role="node-eap"
+          jbosseap_yumvalidator_role='node-eap'
           ;;
-    (*) abort_install "Unrecognized JBoss EAP channel version: ${CONF_JBOSSEAP_VERSION}" ;;
+    (*) abort_install "Unrecognized JBoss EAP channel version: $CONF_JBOSSEAP_VERSION" ;;
   esac
 
-  # There are no defaults for these.  Customers should be using
-  # subscriptions via RHN.  Internally, we use private systems.
-  rhel_repo="${CONF_RHEL_REPO%/}"
-  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
-  jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
-  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
-  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
-  fuse_extra_repo="${CONF_FUSE_EXTRA_REPO%/}"
-  amq_extra_repo="${CONF_AMQ_EXTRA_REPO%/}"
-  rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
-  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
-  rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
-  # Where to find the OpenShift repositories; just the base part before
-  # splitting out into Infrastructure/Node/etc.
-  ose_repo_base="${CONF_OSE_REPO_BASE:-$CONF_REPOS_BASE}"
-  ose_repo_base="${ose_repo_base%/}"
-
-  # Use CDN layout as the default for all yum repos if this is set.
-  cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [[ -n "$cdn_repo_base" ]]; then
-    rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
-    jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
-    rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
-    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
-    ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
-      CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
-    fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
-    CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
-  fi
-  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
-  rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
-  # There is no need to waste time checking both subscription plugins
-  # if using one is explicitly enabled.
-  disable_plugin=""
-  [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
-  [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
-  # We could do the same for "yum" method, but that would be more likely
-  # to surprise someone.
-  #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
-
-  # Check for subscription parameters under all previously used setting
-  # names.
-  CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
-  set +x # Don't log password.
-  CONF_RHN_PASS="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-$CONF_RHN_REG_PASS}}"
-  if [[ "${CONF_RHN_USER}" && "${CONF_RHN_PASS}" ]]; then
-    rhn_creds_provided=true
-  else
-    rhn_creds_provided=false
-  fi
-  set -x
+  named_entries="${CONF_NAMED_ENTRIES-}"
 
   # The domain name for the OpenShift Enterprise installation.
   domain="${CONF_DOMAIN:-example.com}"
   hosts_domain="${CONF_HOSTS_DOMAIN:-$domain}"
   hosts_domain_keyfile="${CONF_HOSTS_DOMAIN_KEYFILE:-/var/named/${hosts_domain}.key}"
+
+  keep_nameservers="${CONF_KEEP_NAMESERVERS:-false}"
+  keep_hostname="${CONF_KEEP_HOSTNAME:-false}"
 
   # Hostnames to use for the components (could all resolve to same host).
   broker_hostname=$(ensure_domain "${CONF_BROKER_HOSTNAME:-broker}" "$hosts_domain")
@@ -3579,8 +3530,91 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # host.
   node_ip_addr="${CONF_NODE_IP_ADDR:-$cur_ip_addr}"
 
-  # How to label the system when subscribing.
-  profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
+  # There are no defaults for these.  Customers should be using
+  # subscriptions via RHN.  Internally, we use private systems.
+  rhel_repo="${CONF_RHEL_REPO%/}"
+  rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
+  jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
+  jbosseap_extra_repo="${CONF_JBOSSEAP_EXTRA_REPO%/}"
+  jbossews_extra_repo="${CONF_JBOSSEWS_EXTRA_REPO%/}"
+  fuse_extra_repo="${CONF_FUSE_EXTRA_REPO%/}"
+  amq_extra_repo="${CONF_AMQ_EXTRA_REPO%/}"
+  rhscl_repo_base="${CONF_RHSCL_REPO_BASE%/}"
+  rhscl_extra_repo="${CONF_RHSCL_EXTRA_REPO%/}"
+  enable_optional_repo="${CONF_OPTIONAL_REPO:-false}"
+  rhel_optional_repo="${CONF_RHEL_OPTIONAL_REPO%/}"
+  yum_exclude_pkgs="${CONF_YUM_EXCLUDE_PKGS-}"
+  # Where to find the OpenShift repositories; just the base part before
+  # splitting out into Infrastructure/Node/etc.
+  ose_repo_base="${CONF_OSE_REPO_BASE:-${CONF_REPOS_BASE-}}"
+  ose_repo_base="${ose_repo_base%/}"
+
+  # By default, do not use CDN layout for Yum repositories, unless
+  # CONF_CDN_REPO_BASE is set.
+  cdn_layout="${CONF_CDN_REPO_BASE-}"
+  cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
+  if [[ -n "$cdn_repo_base" ]]; then
+    rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
+    jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
+    rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
+    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
+    ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
+      cdn_layout=1  # use the CDN layout for OpenShift yum repos
+    fi
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
+    cdn_layout=1  # use the CDN layout for OpenShift yum repos
+  fi
+  ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
+  rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
+
+  install_method="${CONF_INSTALL_METHOD:-none}"
+  # There is no need to waste time checking both subscription plugins
+  # if using one is explicitly enabled.
+  disable_plugin=
+  case "$install_method" in
+    (rhsm)
+      disable_plugin='--disableplugin=rhnplugin'
+      sm_reg_pool="${CONF_SM_REG_POOL-}"
+    ;;
+    (rhn)
+      disable_plugin='--disableplugin=subscription-manager'
+      rhn_reg_actkey="${CONF_RHN_REG_ACTKEY-}"
+    ;;
+    (yum)
+      # We could do the same for "yum" method, but that would be more likely
+      # to surprise someone.
+      #disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
+    ;;
+  esac
+
+  # Note: we use the rhn_user, rhn_pass, rhn_reg_opts, and rhn_profile_name
+  # variables for both RHN and RHSM.
+  if [[ "$install_method" =~ rhn|rhsm ]]
+  then
+    rhn_reg_opts="${CONF_RHN_REG_OPTS-}"
+
+    # Check for subscription parameters under all previously used setting
+    # names.
+    rhn_user="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-${CONF_RHN_REG_NAME-}}}"
+    set +x # Don't log password.
+    rhn_pass="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-${CONF_RHN_REG_PASS-}}}"
+    if [[ -n "$rhn_user" && -n "$rhn_pass" ]]
+    then rhn_creds_provided='true'
+    else rhn_creds_provided='false'
+    fi
+    set -x
+
+    # How to label the system when subscribing.
+    rhn_profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
+  fi
+
+  # Install and enable the ntpd daemon.
+  if is_true "${CONF_NO_NTP:-false}"
+  then enable_ntp='false'
+  else enable_ntp='true'
+  fi
+
 
   node_apache_frontend="${CONF_NODE_APACHE_FRONTEND:-vhost}"
 
@@ -3598,21 +3632,22 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # This should be a list of IP addresses with a semicolon after each.
   nameservers="$(awk '/nameserver/ { printf "%s; ", $2 }' /etc/resolv.conf)"
 
+  # Configure BIND to enable DNS forwarding.
+  enable_dns_forwarding="${CONF_FORWARD_DNS:-false}"
+
+  # Log the specified components to syslog.
+  log_to_syslog="${CONF_SYSLOG-}"
+
   # Main interface to configure
   interface="${CONF_INTERFACE:-eth0}"
 
-  # Set $bind_krb_keytab and $bind_krb_principal to the values of
-  # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values
-  # are both non-empty, or set $bind_key to the value of $CONF_BIND_KEY
-  # if the latter is non-empty.
-  if [[ -n "$CONF_BIND_KRB_KEYTAB" && -n "$CONF_BIND_KRB_PRINCIPAL" ]]; then
-  bind_krb_keytab="$CONF_BIND_KRB_KEYTAB"
-  bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
-  else
-  bind_key="$CONF_BIND_KEY"
+  # For Kerberos:
+  bind_krb_keytab="${CONF_BIND_KRB_KEYTAB-}"
+  bind_krb_principal="${CONF_BIND_KRB_PRINCIPAL-}"
+  # For key-based authentication:
+  bind_key="${CONF_BIND_KEY-}"
   bind_keyalgorithm="${CONF_BIND_KEYALGORITHM:-HMAC-SHA256}"
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
-  fi
 
   local s
   for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
@@ -3620,15 +3655,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
-  [[ -n "$CONF_VALID_GEAR_SIZES" ]] && isset_valid_gear_sizes() { :; }
+  [[ -n "${CONF_VALID_GEAR_SIZES:+x}" ]] && isset_valid_gear_sizes() { :; }
   broker && valid_gear_sizes="${CONF_VALID_GEAR_SIZES:-small}"
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
-  [[ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ]] && isset_default_gear_capabilities() { :; }
+  [[ -n "${CONF_DEFAULT_GEAR_CAPABILITIES:+x}" ]] && isset_default_gear_capabilities() { :; }
   broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
-  [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
+  [[ -n "${CONF_DEFAULT_GEAR_SIZE:+x}" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
   node_profile="${CONF_NODE_PROFILE:-small}"
@@ -3649,11 +3684,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   sni_proxy_ports="${CONF_SNI_PROXY_PORTS:-$def_ports}"
   let "sni_last_port=$sni_first_port+$sni_proxy_ports-1"
 
+  idle_interval="${CONF_IDLE_INTERVAL-}"
+  node_log_context="${CONF_NODE_LOG_CONTEXT:-false}"
+  metrics_interval="${CONF_METRICS_INTERVAL-}"
+
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
   broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
-  broker && district_mappings=$CONF_DISTRICT_MAPPINGS
+  broker && district_mappings=${CONF_DISTRICT_MAPPINGS-}
 
   local randomized
 
@@ -3711,13 +3750,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   (broker || node || activemq) && mcollective_user="${CONF_MCOLLECTIVE_USER:-mcollective}"
   (broker || node || activemq) && assign_pass mcollective_password "marionette" CONF_MCOLLECTIVE_PASSWORD
 
+  # Enable authentication for MongoDB.
+  if is_true "${CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST:-false}"
+  then enable_datastore_auth='false'
+  else enable_datastore_auth='true'
+  fi
+
   #   These are the username and password of the administrative user
   #   that will be created in the MongoDB datastore. These credentials
   #   are not used by in this script or by OpenShift, but an
   #   administrative user must be added to MongoDB in order for it to
   #   enforce authentication.
   datastore && mongodb_admin_user="${CONF_MONGODB_ADMIN_USER:-admin}"
-  datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD}}
+  datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
   datastore &&  assign_pass mongodb_admin_password "mongopass" tmpvar
 
   #   These are the username and password of the normal user that will
@@ -3725,7 +3770,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   broker application's MongoDB plugin is also configured with these
   #   values.
   (datastore || broker) && mongodb_broker_user="${CONF_MONGODB_BROKER_USER:-openshift}"
-  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD}}
+  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
   (datastore || broker) && assign_pass mongodb_broker_password "mongopass" tmpvar
 
   #   In replicated setup, this is the key that slaves will use to
@@ -3746,8 +3791,12 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
+  enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
   assign_pass routing_plugin_pass "routinginfopasswd" CONF_ROUTING_PLUGIN_PASS
+
+  broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
+  broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
 
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
@@ -3796,7 +3845,7 @@ validate_preflight()
   fi
 
   # test that subscription parameters are available if needed
-  if [[ "$CONF_INSTALL_METHOD" = rhn ]]; then
+  if [[ "$install_method" = rhn ]]; then
     # Check whether we are already registered with RHN and already have
     # ose-2.2 channels added.  If we are not, we will need RHN
     # credentials so that we can register and add channels ourselves.
@@ -3806,7 +3855,7 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
-      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3814,7 +3863,7 @@ validate_preflight()
     fi
   fi
 
-  if [[ "$CONF_INSTALL_METHOD" = rhsm ]]; then
+  if [[ "$install_method" = rhsm ]]; then
     # Check whether we are already registered with RHSM.  If we are not,
     # we will need credentials so that we can register ourselves.
     #
@@ -3822,7 +3871,7 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
       set +x # Don't log password.
-      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3839,15 +3888,15 @@ validate_preflight()
     # subscription-manager gets to write all of its plentiful output
     # before grep closes the pipeline.  Without it, we will get
     # a harmless but possibly alarming "Broken pipe" error message.
-    if [[ -z "$CONF_SM_REG_POOL" ]] &&
-        ( [[ -n "$CONF_RHN_USER" && -n "$CONF_RHN_PASS" ]] ||
+    if [[ -z "$sm_reg_pool" ]] &&
+        ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [[ "$CONF_INSTALL_METHOD" = yum && -z "$ose_repo_base" ]]; then
+  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]; then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -3896,13 +3945,13 @@ install_rpms()
 configure_host()
 {
   echo "OpenShift: Begin configuring host."
-  is_false "$CONF_NO_NTP" && synchronize_clock
+  is_true "$enable_ntp" && synchronize_clock
   # Note: configure_named must run before configure_controller if we are
   # installing both named and broker on the same host.
   named && configure_named
   configure_network
-  is_false "$CONF_KEEP_NAMESERVERS" && configure_dns_resolution
-  is_false "$CONF_KEEP_HOSTNAME" && configure_hostname
+  is_false "$keep_nameservers" && configure_dns_resolution
+  is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
   sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -4687,5 +4687,5 @@ date +%Y-%m-%d-%H:%M:%S
 
 "$PASSWORDS_TO_DISPLAY" && display_passwords
 
-:
+exit 0
 

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1419,7 +1419,8 @@ configure_rhn_channels()
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       echo 'OpenShift: Register to RHN Classic with username and password'
       echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
       rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
@@ -1443,7 +1444,8 @@ configure_rhn_channels()
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     local repo
     for repo in "${repos[@]}"
     do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
@@ -1458,7 +1460,8 @@ configure_rhsm_channels()
 {
   if [[ -n "$rhn_creds_provided" ]]
   then
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     echo 'OpenShift: Register with RHSM'
     echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
     subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
@@ -3963,7 +3966,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     # Check for subscription parameters under all previously used setting
     # names.
     rhn_user="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-${CONF_RHN_REG_NAME-}}}"
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     rhn_pass="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-${CONF_RHN_REG_PASS-}}}"
     if [[ -n "$rhn_user" && -n "$rhn_pass" ]]
     then rhn_creds_provided='true'
@@ -4233,7 +4237,8 @@ validate_preflight()
     # adding channels.
     if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhn requires an RHN user and password.'
@@ -4252,7 +4257,8 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhsm requires an RHN user and password.'

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3079,7 +3079,7 @@ configure_hosts_dns()
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-    router && add_host_to_zone "$router_hostname" "$cur_ip_addr"
+    router && add_host_to_zone "$router_hostname" "$cur_ip_addr" "$domain"
   elif [[ "$named_entries" =~ : ]]
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
@@ -3339,6 +3339,8 @@ configure_routing_daemon()
   set_routing_daemon CLOUD_DOMAIN "$domain"
 
   [[ "$router" = nginx ]] && service openshift-routing-daemon start
+
+  return 0
 }
 
 configure_routing_plugin()
@@ -3839,6 +3841,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     do
       eval "$component() { :; }"
     done
+  fi
+
+  if router
+  then
+    if broker || node
+    then abort_install 'The router component cannot be installed on the same host as the broker or node components.'
+    fi
   fi
 
   # Following are some settings used in subsequent steps.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -4020,7 +4020,9 @@ configure_host()
   set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  if broker || node
+  then sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  fi
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1376,7 +1376,7 @@ enabled=1
 gpgcheck=0
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} $yum_exclude_pkgs
+exclude=${exclude[$repo]-} $yum_exclude_pkgs
 
 YUM
     fi

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -3631,8 +3631,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
-  # Set $node_profile to $CONF_NODE_PROFILE
-  node && node_profile="${CONF_NODE_PROFILE:-small}"
+  node_profile="${CONF_NODE_PROFILE:-small}"
   node && node_profile_name="${CONF_NODE_PROFILE_NAME:-$node_profile}"
   node && node_host_type="${CONF_NODE_HOST_TYPE:-m3.xlarge}"
   # determine node port and UID settings

--- a/enterprise/install-scripts/generic/scriptify
+++ b/enterprise/install-scripts/generic/scriptify
@@ -4,7 +4,8 @@
 # and make sure that the last command returns true.
 sed -e '1i #!/bin/bash -x
 /^#Begin Kickstart Script/,/^set -x/ d
-/^%end/ c:
+/^%end/ c \
+exit 0
 ' $1 > $2
 
 sed -i -e 's/^\s*environment=ks/environment=sh/' $2

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1086,8 +1086,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+="${matchingvar##*_}: ${!matchingvar} "
+    [[ "$vprefix" != "$k" ]] && out_string+="${k##*_}"
     out_string+=": ${!k}"
     echo "$out_string"
   done

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1159,7 +1159,7 @@ display_passwords()
 
 configure_repos()
 {
-  echo "OpenShift: Begin configuring repos."
+  echo 'OpenShift: Begin configuring repos.'
   # Determine which channels we need and define corresponding predicate
   # functions.
 
@@ -1232,7 +1232,7 @@ configure_repos()
       ;;
   esac
 
-  echo "OpenShift: Completed configuring repos."
+  echo 'OpenShift: Completed configuring repos.'
 }
 
 configure_yum_repos()
@@ -1646,15 +1646,15 @@ configure_outgoing_http_proxy()
     https_proxy_auth="${outgoing_https_proxy#*//}"
 
     # Split on '@' into (possibly) authentication credentials and the rest.
-    read http_proxy_auth http_proxy_host_port <<<"${http_proxy_auth//@/ }"
-    read https_proxy_auth https_proxy_host_port <<<"${https_proxy_auth//@/ }"
+    read http_proxy_auth http_proxy_host_port <<< "${http_proxy_auth//@/ }"
+    read https_proxy_auth https_proxy_host_port <<< "${https_proxy_auth//@/ }"
 
     if [[ -z "$http_proxy_host_port" ]]
     then # No credentials were specified.
       http_proxy_host_port="$http_proxy_auth"
       http_proxy_auth=
     else
-      read http_proxy_user http_proxy_pass <<<"${http_proxy_auth//:/ }"
+      read http_proxy_user http_proxy_pass <<< "${http_proxy_auth//:/ }"
     fi
 
     if [[ -z "$https_proxy_host_port" ]]
@@ -1662,7 +1662,7 @@ configure_outgoing_http_proxy()
       https_proxy_host_port="$https_proxy_auth"
       https_proxy_auth=
     else
-      read https_proxy_user https_proxy_pass <<<"${https_proxy_auth//:/ }"
+      read https_proxy_user https_proxy_pass <<< "${https_proxy_auth//:/ }"
     fi
 
     # Strip any trailing slashes (and possibly more, but there shouldn't be
@@ -1671,8 +1671,8 @@ configure_outgoing_http_proxy()
     https_proxy_host_port="${https_proxy_host_port%/*}"
 
     # Split on ':' into hostname and (possibly) port parts.
-    read http_proxy_hostname http_proxy_port <<<"${http_proxy_host_port//:/ }"
-    read https_proxy_hostname https_proxy_port <<<"${https_proxy_host_port//:/ }"
+    read http_proxy_hostname http_proxy_port <<< "${http_proxy_host_port//:/ }"
+    read https_proxy_hostname https_proxy_port <<< "${https_proxy_host_port//:/ }"
 
     local proxies_stanza="\
 <settings>
@@ -1809,7 +1809,7 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  if grep 'Enterprise Linux Server release 6.4' '/etc/redhat-release' && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
   then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
@@ -1922,7 +1922,7 @@ parse_cartridges()
     local metapkg
     for metapkg in "${meta[@]}"
     do
-      if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
+      if [[ "${pkgs[@]}" =~ "-$metapkg" ]]
       then
         metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
         metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
@@ -2135,8 +2135,8 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
-  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/tmp.conf'
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > '/etc/security/namespace.d/shm.conf'
 }
 
 configure_cgroups_on_node()
@@ -2723,7 +2723,7 @@ configure_activemq()
 EOF
   fi
 
-  cat <<EOF > /etc/activemq/activemq.xml
+  cat <<EOF > '/etc/activemq/activemq.xml'
 <!--
     Licensed to the Apache Software Foundation (ASF) under one or more
     contributor license agreements.  See the NOTICE file distributed with
@@ -3146,7 +3146,7 @@ register_named_entries()
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<"${host_ip//:/ }"
+    read host ip <<< "${host_ip//:/ }"
     if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
@@ -3187,9 +3187,9 @@ configure_dns_resolution()
   sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
-  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-${interface}.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-${interface}.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -3444,8 +3444,8 @@ configure_router()
       #
       # These files should be copies of /etc/pki/tls/certs/localhost.crt and
       # /etc/pki/tls/private/localhost.key, respectively, from a node host.
-      if [[ -e /etc/pki/tls/certs/node.example.com.crt &&
-            -e /etc/pki/tls/private/node.example.com.key ]]
+      if [[ -e '/etc/pki/tls/certs/node.example.com.crt' &&
+            -e '/etc/pki/tls/private/node.example.com.key' ]]
       then
         service nginx16-nginx start
       fi
@@ -3468,7 +3468,7 @@ configure_access_keys_on_broker()
 
   # Generate a key pair for moving gears between nodes from the broker.
   ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
-  cp /root/.ssh/rsync_id_rsa* /etc/openshift/
+  cp /root/.ssh/rsync_id_rsa* '/etc/openshift/'
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
   cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
@@ -3548,7 +3548,7 @@ configure_node()
      'allocated to all UIDs fit in the proxy port range.'
   fi
 
-  local conf=/etc/openshift/node.conf
+  local conf='/etc/openshift/node.conf'
   case "$node_apache_frontend" in
     mod_rewrite)
       sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
@@ -3568,12 +3568,12 @@ configure_node()
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > '/etc/openshift/env/OPENSHIFT_BROKER_HOST'
+  echo "$domain" > '/etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN'
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000001_openshift_origin_node_servername.conf
+      '/etc/httpd/conf.d/000001_openshift_origin_node_servername.conf'
 
   configure_node_logs
   RESTART_NEEDED=true
@@ -3594,7 +3594,7 @@ configure_node_logs()
 PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
-    ' /etc/openshift/node.conf
+    ' '/etc/openshift/node.conf'
     echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
@@ -4038,10 +4038,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # ActiveMQ service are assumed to be the current host if we are
   # installing the component now or the broker host otherwise.
   if named
-  then
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
-  else
-    named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
+  then named_ip_addr="${CONF_NAMED_IP_ADDR:-$cur_ip_addr}"
+  else named_ip_addr="${CONF_NAMED_IP_ADDR:-$broker_ip_addr}"
   fi
 
   # The nameservers to which named on the broker will forward requests.
@@ -4105,10 +4103,10 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   metrics_interval="${CONF_METRICS_INTERVAL-}"
 
   # Set $default_districts to $CONF_DEFAULT_DISTRICTS
-  broker && default_districts=${CONF_DEFAULT_DISTRICTS:-true}
+  broker && default_districts="${CONF_DEFAULT_DISTRICTS:-true}"
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
-  broker && district_mappings=${CONF_DISTRICT_MAPPINGS-}
+  broker && district_mappings="${CONF_DISTRICT_MAPPINGS-}"
 
   local randomized
 
@@ -4553,7 +4551,7 @@ restart_services()
 run_diagnostics()
 {
   echo 'OpenShift: Begin running oo-diagnostics.'
-  date +%Y-%m-%d-%H:%M:%S
+  date '+%Y-%m-%d-%H:%M:%S'
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2618,11 +2618,6 @@ EOF
   chown 'apache:apache' "$mcollective_cfg"
   chmod 640 "$mcollective_cfg"
 
-  # Make sure the MCollective client log is created with proper ownership.
-  # If root owns it, the broker (apache user) can't log to it.
-  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
-  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
-
   RESTART_NEEDED=true
 }
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3076,7 +3076,9 @@ fix_broker_routing()
   case "$node_apache_frontend" in
     vhost)
       # node vhost obscures the broker vhost unless we bring the broker conf forward
-      ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      if [[ ! -e '/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf' ]]
+      then ln -s /etc/httpd/conf.d/00000{2,0}_openshift_origin_broker_proxy.conf
+      fi
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1482,7 +1482,7 @@ configure_rhn_channels()
   then
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
-    local repos=('rhel-x86_64-server-6-rhscl-1')
+    local -a repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo
     then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
@@ -1898,7 +1898,7 @@ parse_cartridges()
   # cartridges that the user instructs us to install ($cartridges).  See
   # the documentation on the CONF_CARTRIDGES / cartridges options for
   # the rules governing how $cartridges will be passed.
-  local pkgs=( )
+  local -a pkgs=( )
   local pkg
   local cart_spec
   for cart_spec in ${cartridges//,/ }

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1035,7 +1035,7 @@ assign_pass()
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
   else
-    randomized=$(openssl rand -base64 20)
+    local randomized=$(openssl rand -base64 20)
     printf -v "$1" '%s' "${randomized//[![:alnum:]]}"
   fi
   passwords[$1]="${!1}"
@@ -1044,6 +1044,20 @@ assign_pass()
 display_passwords()
 {
   set +x
+  local k
+  local v
+  local s
+  local vprefix
+  local postfix
+  local out_string
+  local matchingvar
+  local formattedprefix
+  local -A subs
+  subs[openshift]="OpenShift"
+  subs[mcollective]="MCollective"
+  subs[mongodb]="MongoDB"
+  subs[activemq]="ActiveMQ"
+
   for k in "${!passwords[@]}"; do
     out_string=""
     matchingvar=""
@@ -1058,12 +1072,6 @@ display_passwords()
         break
       fi
     done
-
-    local -A subs
-    subs[openshift]="OpenShift"
-    subs[mcollective]="MCollective"
-    subs[mongodb]="MongoDB"
-    subs[activemq]="ActiveMQ"
 
     formattedprefix=${vprefix//_/ }
     for s in ${!subs[@]}; do
@@ -1086,6 +1094,7 @@ configure_repos()
   # functions.
 
   # Make need_${repo}_repo return false by default.
+  local repo
   for repo in optional infra node client_tools extra \
               fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews; do
       eval "need_${repo}_repo() { false; }"
@@ -1169,9 +1178,10 @@ configure_yum_repos()
 configure_ose_yum_repos()
 { # define plain yum repos if the parameters are given
   # this can be useful even if the main subscription is via RHN
+  local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [ "$ose_repo_base" != "" ]; then
-      layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+      local layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
     if [ "$ose_extra_repo_base" != "" ]; then
@@ -1220,11 +1230,12 @@ fi
 
 def_ose_yum_repo()
 {
-  repo_base=$1
-  layout=$2  # one of: puddle, extra, cdn
-  channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
+  local repo_base=$1
+  local layout=$2  # one of: puddle, extra, cdn
+  local channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
 
-  declare -A map
+  local -A map
+  local url
   case $layout in
   puddle | extra)
     map=([client_tools]=RHOSE-CLIENT-2.2 [infra]=RHOSE-INFRA-2.2 [node]=RHOSE-NODE-2.2 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.2)
@@ -1295,7 +1306,7 @@ YUM
 
 configure_extra_repos()
 { # add all defined extra repos in one file
-  extra_repo_file=/etc/yum.repos.d/ose_extra.repo
+  local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [ -e "${extra_repo_file}" ]; then
       echo > "${extra_repo_file}"
   fi
@@ -1338,7 +1349,7 @@ configure_subscription()
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
-   roles=""  # we will build the list of roles we need, then enable them.
+   local roles=""  # we will build the list of roles we need, then enable them.
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
@@ -1377,7 +1388,7 @@ configure_rhn_channels()
   if [ $rhn_creds_provided ]
   then
     # Enable the node or infrastructure channel to enable installing the release RPM
-    repos=('rhel-x86_64-server-6-rhscl-1')
+    local repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo ; then
       repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
@@ -1388,6 +1399,7 @@ configure_rhn_channels()
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
     set +x # don't log password
+    local repo
     for repo in "${repos[@]}"; do
       [[ "$(rhn-channel -l)" == *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
     done
@@ -1419,6 +1431,7 @@ configure_rhsm_channels()
   fi
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
+  local poolid
   for poolid in ${CONF_SM_REG_POOL//[, :+\/-]/ }; do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
@@ -1442,17 +1455,17 @@ abort_install()
 yum_install_or_exit()
 {
   echo "OpenShift: yum install $*"
-  COUNT=0
+  local count=0
   time while true; do
     yum install -y $* $disable_plugin
     if [ $? -eq 0 ]; then
       return
-    elif [ $COUNT -gt 3 ]; then
+    elif [ $count -gt 3 ]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
     fi
-    let COUNT+=1
+    let count+=1
   done
 }
 
@@ -1626,6 +1639,8 @@ parse_cartridges()
   # the documentation on the CONF_CARTRIDGES / cartridges options for
   # the rules governing how $cartridges will be passed.
   local pkgs=( )
+  local pkg
+  local cart_spec
   for cart_spec in ${cartridges//,/ }
   do
     if [[ "${cart_spec:0:1}" = - ]]
@@ -1648,6 +1663,7 @@ parse_cartridges()
 
   if metapkgs_optional || metapkgs_recommended
   then
+    local metapkg
     for metapkg in ${meta[@]}
     do
       if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
@@ -1798,6 +1814,8 @@ configure_pam_on_node()
 {
   sed -i -e 's|pam_selinux|pam_openshift|g' /etc/pam.d/sshd
 
+  local t
+  local f
   for f in "runuser" "runuser-l" "sshd" "su" "system-auth-ac"
   do
     t="/etc/pam.d/$f"
@@ -1824,6 +1842,8 @@ configure_pam_on_node()
 
 configure_cgroups_on_node()
 {
+  local t
+  local f
   for f in "runuser" "runuser-l" "sshd" "system-auth-ac"
   do
     t="/etc/pam.d/$f"
@@ -1844,7 +1864,7 @@ configure_cgroups_on_node()
 configure_quotas_on_node()
 {
   # Get the mountpoint for /var/lib/openshift (should be /).
-  geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
+  local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
   if ! [ x"$geardata_mnt" != x ]
   then
@@ -1952,13 +1972,12 @@ execute_mongodb()
   echo "$1"
   echo "---"
 
+  local userpass=
   if [ -n "$3" -a -n "$4" ]; then
     userpass="-u ${3} -p ${4} admin"
-  else
-    userpass=""
   fi
 
-  output="$( echo "$1" | mongo ${userpass} )"
+  local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
   if [ "$2" ]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
@@ -2006,12 +2025,14 @@ configure_datastore_add_replicants()
   time execute_mongodb 'rs.initiate()' '"ok" : 1' ||
     abort_install "OpenShift: Failed to form MongoDB replica set; please do this manually."
 
-  master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
+  local master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
     abort_install "OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually."
 
   configure_datastore_add_users
 
   # Configure the replica set.
+  local i
+  local replicant
   for replicant in ${datastore_replicants//,/ }
   do
     if [[ "$replicant" != "${master_out#host=}" ]]
@@ -2226,8 +2247,10 @@ enable_services_on_broker()
 
 generate_mcollective_pools_configuration()
 {
-  num_replicants=0
-  members=
+  local num_replicants=0
+  local members=
+  local new_member
+  local replicant
   for replicant in ${activemq_replicants//,/ }
   do
     let num_replicants=num_replicants+1
@@ -2249,8 +2272,8 @@ plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
 # https://bugzilla.redhat.com/show_bug.cgi?id=963332
 configure_mcollective_for_activemq_on_broker()
 {
-  MCOLLECTIVE_CFG="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
-  cat <<EOF > $MCOLLECTIVE_CFG
+  local mcollective_cfg="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
+  cat <<EOF > $mcollective_cfg
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2279,8 +2302,8 @@ plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 
 EOF
 
-  chown apache:apache $MCOLLECTIVE_CFG
-  chmod 640 $MCOLLECTIVE_CFG
+  chown apache:apache $mcollective_cfg
+  chmod 640 $mcollective_cfg
 
   # make sure mcollective client log is created with proper ownership.
   # if root owns it, the broker (apache user) can't log to it.
@@ -2341,6 +2364,7 @@ configure_activemq()
   local networkConnectors=
   local authenticationUser_amq=
   function allow_openwire() { false; }
+  local replicant
   for replicant in ${activemq_replicants//,/ }
   do
     if ! [ "$replicant" = "$activemq_hostname" ]
@@ -2611,7 +2635,7 @@ configure_named()
   chmod 640 /etc/rndc.key
 
   # Set up DNS forwarding if so directed.
-  forwarders="recursion no;"
+  local forwarders="recursion no;"
   if is_true "$CONF_FORWARD_DNS"; then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
@@ -2695,11 +2719,11 @@ EOF
 
 configure_named_zone()
 {
-  zone="$1"
+  local zone="$1"
 
   if [ "x$bind_key" = x ]; then
     # Generate a new secret key
-    zone_tolower="${zone,,}"
+    local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
     dnssec-keygen -a ${bind_keyalgorithm} -b ${bind_keysize} -n USER -r /dev/urandom -K /var/named ${zone}
     # $zone may have uppercase letters in it.  However the file that
@@ -2757,10 +2781,10 @@ ensure_domain()
 add_host_to_zone()
 {
   # $1 = host; $2 = ip; [ $3 = zone ]
-  zone="${3:-$hosts_domain}"
-  nsdb="/var/named/dynamic/${zone}.db"
+  local zone="${3:-$hosts_domain}"
+  local nsdb="/var/named/dynamic/${zone}.db"
   # sanity check that $1 isn't an IP, and $2 is.
-  ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
@@ -2781,6 +2805,7 @@ configure_hosts_dns()
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
   elif [[ "$CONF_NAMED_ENTRIES" =~ : ]]; then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
+    local host_ip
     for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
@@ -2793,8 +2818,11 @@ configure_hosts_dns()
 # using oo-register-dns. Not used by default.
 register_named_entries()
 {
-  ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
-  failed="false"
+  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  local failed="false"
+  local host_ip
+  local host
+  local ip
   for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
     read host ip <<<$(echo ${host_ip//:/ })
     if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
@@ -2968,6 +2996,7 @@ configure_httpd_auth()
   if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
   then
     yum_install_or_exit mod_auth_kerb
+    local d
     for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${CONF_BROKER_KRB_SERVICE_NAME}#" \
@@ -3004,7 +3033,7 @@ configure_httpd_auth()
 configure_routing_plugin()
 {
   if is_true "$CONF_ROUTING_PLUGIN"; then
-    conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
+    local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
 ACTIVEMQ_HOST='$activemq_replicants'
@@ -3226,11 +3255,12 @@ install_rsync_pub_key()
   mkdir -p /root/.ssh
   chmod 700 /root/.ssh
 
-  WAIT=600
-  END=`date -d "$WAIT seconds" +%s`
-  echo "OpenShift node: will wait for $WAIT seconds to fetch SSH key."
+  local wait=600
+  local end=`date -d "$wait seconds" +%s`
+  echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
-  while [[ `date +%s` -lt $END ]]; do
+  local cert
+  while [[ `date +%s` -lt $end ]]; do
     # try to get key hosted on broker machine
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
     if [ $? -ne 0 ]; then
@@ -3255,6 +3285,8 @@ install_rsync_pub_key()
 echo_installation_intentions()
 {
   echo "The following components should be installed:"
+  local components='broker node named activemq datastore'
+  local component
   for component in $components
   do "$component" && printf '\t%s.\n' "$component"
   done
@@ -3285,6 +3317,8 @@ configure_console_msg()
 # and CONF_BAZ=true in the environment.
 parse_args()
 {
+  local key
+  local word
   for word in "$@"
   do
     key="${word%%\=*}"
@@ -3399,10 +3433,11 @@ set_defaults()
   #
   # The declare statement below is generated by the following command:
   #
-  #   echo declare -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_JBOSSEAP_VERSION]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_ISOLATE_GEARS]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+  #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
+  local setting
   for setting in "${!CONF_@}"
   do
     if ! [[ ${valid_settings[$setting]+1} ]]
@@ -3425,15 +3460,17 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   actions="${CONF_ACTIONS:-do_all_actions}"
 
   # Following are the different components that can be installed:
-  components='broker node named activemq datastore'
+  local components='broker node named activemq datastore'
 
   # By default, each component is _not_ installed.
+  local component
   for component in $components
   do
     eval "$component() { false; }"
   done
 
   # But any or all components may be explicity enabled.
+  local component
   for component in ${CONF_INSTALL_COMPONENTS//,/ }
   do
     case "$component" in
@@ -3444,7 +3481,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   done
 
   # If nothing is explicitly enabled, enable everything.
-  installing_something=0
+  local installing_something=0
   for component in $components
   do
     if "$component"
@@ -3604,6 +3641,7 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
   fi
 
+  local s
   for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
     eval "isset_${s}() { false; }"
   done
@@ -3644,6 +3682,8 @@ declare -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS
 
   # Set $district_mappings to $CONF_DISTRICT_MAPPINGS
   broker && district_mappings=$CONF_DISTRICT_MAPPINGS
+
+  local randomized
 
   # Generate a random salt for the broker authentication.
   randomized=$(openssl rand -base64 20)
@@ -3759,7 +3799,7 @@ init_message()
 validate_preflight()
 {
   echo "OpenShift: Begin preflight validation."
-  preflight_failure=
+  local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
   if ! grep -q "Enterprise.* 6" /etc/redhat-release; then
@@ -3854,15 +3894,15 @@ install_rpms()
   echo "OpenShift: yum update"
   yum $disable_plugin clean all
 
-  COUNT=0
+  local count=0
   while true; do
     yum $disable_plugin update -y
     if [ $? -eq 0 ]; then
       break
-    elif [ $COUNT -gt 3 ]; then
+    elif [ $count -gt 3 ]; then
       abort_install
     fi
-    let COUNT+=1
+    let count+=1
   done
 
   # Install a few packages missing from a minimal RHEL install required by the
@@ -3910,7 +3950,7 @@ configure_host()
 configure_firewall()
 {
   # Disable lokkit.
-  conf='/etc/sysconfig/system-config-firewall'
+  local conf='/etc/sysconfig/system-config-firewall'
   [[ -e "$conf" && "$(< "$conf")" != --disabled ]] && mv "$conf" "${conf}.bak"
   echo '--disabled' > "$conf"
 
@@ -3935,7 +3975,11 @@ EOF
 # Note: This function must be run after configure_firewall.
 configure_firewall_add_rules()
 {
-  rules=""
+  local rules=""
+  local port
+  local prot
+  local rule
+  local svc
   for svc in ${!firewall_allow[@]}
   do
     rules+="$(
@@ -4066,12 +4110,19 @@ configure_districts()
 
   local restart=$RESTART_NEEDED
   if is_true "$default_districts"; then
+    local p
     for p in ${valid_gear_sizes//,/ }; do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
       oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
     done
   else
+    local i
+    local profile
+    local firstnode
+    local nodes
+    local district
+    local mapping
     for mapping in ${district_mappings//;/ }; do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2981,9 +2981,9 @@ configure_controller()
   set_broker MONGO_DB "$mongodb_name"
 
   # configure broker logs for syslog
-  [[ "$log_to_syslog" = *broker* ]] && \
+  [[ "$log_to_syslog" = *broker* ]] &&
     set_broker SYSLOG_ENABLED true
-  [[ "$log_to_syslog" = *console* ]] && \
+  [[ "$log_to_syslog" = *console* ]] &&
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
@@ -3246,7 +3246,7 @@ configure_node()
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1422,7 +1422,7 @@ enabled=1
 gpgcheck=0
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} $yum_exclude_pkgs
+exclude=${exclude[$repo]-} $yum_exclude_pkgs
 
 YUM
     fi

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1963,14 +1963,25 @@ install_cartridges()
 # given value to the setting.  If it does not, then comment out any
 # existing setting and add the given setting.
 #
-# The search pattern is /^\s*name\s*=\s*['"]?value\['"]?s*(|#.*)$/.  The added
-# line will be in the form 'name=value' or, if a non-empty short comment is
-# specified, 'name=value # short comment'.  Note that quotation marks are
-# tolerated when checking whether the setting is already present, but are not
-# added when adding the setting unless they are explicitly passed in with the
-# value.  If a long comment is specified using the fifth and possibly subsequent
-# arguments, a blank line followed by '# long comment' (one line per argument)
-# will be added before the line for the setting itself.
+# If the setting is found with the given value in the configuration file, then
+# this function does not modify the file.  The search pattern used is
+# /^\s*name\s*=\s*['"]?value\['"]?\s*(|#.*)$/.
+#
+# If the setting is found with a value other than the one specified, then the
+# existing setting is commented out and the new setting is added after the old,
+# with any short comment that is specified.  The added line will be in the form
+# 'name=value' or, if a non-empty short comment is specified, 'name=value
+# # short comment'.
+#
+# If the setting is not found in the file, then the new setting is appended to
+# the end of the file, with any short and long comments that are specified.
+# If a long comment is specified using the fifth and possibly subsequent
+# arguments, then a blank line followed by '# long comment' (one line per
+# argument) will be added before the line for the setting itself.
+#
+# Note that quotation marks are tolerated when checking whether the setting is
+# already present, but are not added when adding the setting unless they are
+# explicitly passed in as part of the value.
 #
 # $1 = configuration file's filename
 # $2 = setting name
@@ -1979,17 +1990,39 @@ install_cartridges()
 # $5- = long comment (optional)
 set_conf()
 {
-  if ! grep -q "^\\s*$2\\s*=\\s*['\"]\\?$3['\"]\\?\\s*\\(\\|#.*\\)$" "$1"
-  then
-    sed -i -e "s/^\\s*$2\\s*=\\s*/#&/" "$1"
-    if [[ -n "${5-}" ]]
-    then
-      echo >> "$1"
-      args=( "$@" )
-      printf '# %s\n' "${args[@]:4}" >> "$1"
-    fi
-    echo "$2=$3${4:+ #$4}" >> "$1"
-  fi
+  local file="$1" setting="$2" value="$3" shortcomment="${4-}"
+  local newsetting="${setting}=${value//\//\\/}${shortcomment:+ #$shortcomment}"
+  shift 4 || shift 3
+  local longcomment=
+  (( $# > 0 )) && printf -v longcomment '# %s\\\n' "$@"
+
+  sed -i -e "
+    :a
+      # Check whether the setting already exists with the specified value.  If
+      # it does, jump to :b.
+      /^\\s*${setting}\\s*=\\s*['\"]\\?${value//\//\\/}['\"]\\?\\s*\\(\\|#.*\\)\$/bb
+
+      # Check whether the setting already exists but with the a value other than
+      # the specified one.  If it does, then comment out the old setting, add
+      # a new setting with the specified value after the old setting, and jump
+      # to :b.
+      s/^\\(\\s*\\)#\\?\\(\\s*${setting}\\s*=[^\\n]*\\)/\\1#\\2\\n${newsetting}/;tb
+
+      # Neither of the previous two checks were positive, so check whether we
+      # have reached the end of the file, and if so, append the new setting
+      # along with any long comment that has been specified.
+      \$a \\
+${longcomment:+\\
+$longcomment}$newsetting
+
+      # Loop and repeat the above checks.
+      n
+      ba
+    :b
+      # Loop until the end of the file, without modifying the stream.
+      n
+      bb
+    " "$file"
 }
 
 set_mongodb() { set_conf /etc/mongodb.conf "$@"; }

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2244,7 +2244,7 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
+  printf '\nAcceptEnv GIT_SSH\n' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
   sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1189,6 +1189,8 @@ configure_ose_yum_repos()
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
+
+  return 0
 }
 
 configure_rhel_repo()
@@ -1359,7 +1361,7 @@ configure_subscription()
    need_jbosseap_cartridge_repo && roles="$roles --role $jbosseap_yumvalidator_role"
    need_fuse_cartridge_repo && roles="$roles --role node-fuse"
    need_amq_cartridge_repo && roles="$roles --role node-amq"
-   oo-admin-yum-validator -o 2.2 --fix-all $roles # when fixing, rc is always false
+   oo-admin-yum-validator -o 2.2 --fix-all $roles || : # when fixing, rc is always false
    oo-admin-yum-validator -o 2.2 $roles || abort_install # so check when fixes are done
 
    # Normally we could just install o-e-release and it would pull in yum-validator;
@@ -1368,6 +1370,8 @@ configure_subscription()
    yum_install_or_exit openshift-enterprise-release
    configure_ose_yum_repos # refresh if overwritten by validator
    need_extra_repo && configure_extra_repos
+
+   return 0
 }
 
 configure_rhn_channels()
@@ -1461,10 +1465,8 @@ yum_install_or_exit()
   echo "OpenShift: yum install $*"
   local count=0
   time while true; do
-    yum install -y $* $disable_plugin
-    if [[ $? -eq 0 ]]; then
-      return
-    elif [[ $count -gt 3 ]]; then
+    yum install -y $* $disable_plugin && return
+    if [[ $count -gt 3 ]]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -1893,7 +1895,7 @@ configure_quotas_on_node()
 
 configure_idler_on_node()
 {
-  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return
+  [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return 0
   cat <<CRON > /etc/cron.hourly/auto-idler
 (
   /usr/sbin/oo-last-access
@@ -2404,7 +2406,7 @@ configure_activemq()
   if is_true "${enable_routing_plugin}"
   then
     schedulerSupport='schedulerSupport="true"'
-    IFS= read -r -d '' routingPolicy <<'EOF'
+    IFS= read -r -d '' routingPolicy <<'EOF' || :
           <redeliveryPlugin fallbackToDeadLetter="true"
                             sendToDlqIfMaxRetriesExceeded="true">
             <redeliveryPolicyMap>
@@ -2824,6 +2826,8 @@ configure_hosts_dns()
   else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $named_entries"
   fi
+
+  return 0
 }
 
 # An alternate method for registering against a running named
@@ -2846,6 +2850,7 @@ register_named_entries()
     fi
   done
   is_false "$failed" && echo "OpenShift: Completed updating host DNS entries."
+  return 0
 }
 
 configure_network()
@@ -3277,12 +3282,11 @@ install_rsync_pub_key()
   local cert
   while [[ `date +%s` -lt $end ]]; do
     # Try to get the public key from the broker.
-    cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
-    if [[ $? -ne 0 ]]; then
+    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}"); then
       sleep 5
     else
-      ssh-keygen -lf /dev/stdin <<< "$cert"
-      if [[ $? -ne 0 ]]; then
+      if ! ssh-keygen -lf /dev/stdin <<< "$cert"
+      then
         break
       else
         echo "$cert" >> /root/.ssh/authorized_keys
@@ -3861,6 +3865,7 @@ init_message()
 {
   echo_installation_intentions
   [[ "$environment" = ks ]] && configure_console_msg
+  return 0
 }
 
 validate_preflight()
@@ -4111,7 +4116,7 @@ configure_openshift()
   configure_firewall_add_rules
   node && configure_gear_isolation_firewall
 
-  sysctl -p
+  sysctl -p || :
   restorecon -rv /etc/openshift
 
   PASSWORDS_TO_DISPLAY=true
@@ -4197,10 +4202,8 @@ configure_districts()
       # Query the node for the node profile via MCollective.
       profile=""
       for i in {1..10}; do
-        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
-        if [[ $? -eq 0 ]]; then
-          break;
-        fi
+        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
+         && break
         sleep 10
       done
       if [[ -n "$profile" ]]; then

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -995,6 +995,24 @@ git
 # the log more useful.
 set -x
 
+set -euo pipefail
+
+annotate()
+{
+  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+}
+trap 'echo "Finished with exitcode $?" >&4' EXIT
+# <> redirection requires disabling posix.
+set +o posix
+exec 5>&1 \
+  1<> >(annotate O >&5) \
+  2<> >(annotate E >&5) \
+  3<> >(annotate D >&5) \
+  4<> >(annotate I >&5) \
+  5>&-
+BASH_XTRACEFD=3
+echo "Started $0 $*" >&4
+
 
 ########################################################################
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1883,8 +1883,13 @@ configure_quotas_on_node()
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
     time restorecon "${geardata_mnt}"
+
+    # quotacheck fails if quotas are enabled.
+    quotaoff "${geardata_mnt}"
+
     # Generate user quota info for the mount point.
     time quotacheck -cmug "${geardata_mnt}"
+
     # Fix the SELinux label of the created quota file.
     restorecon "${geardata_mnt}"/aquota.user
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1175,9 +1175,10 @@ configure_yum_repos()
   yum_install_or_exit openshift-enterprise-release
 }
 
+# Define plain Yum repos if the parameters are given.
+# This can be useful even if the main subscription is via RHN.
 configure_ose_yum_repos()
-{ # define plain yum repos if the parameters are given
-  # this can be useful even if the main subscription is via RHN
+{
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
     if [[ -n "$ose_repo_base" ]]; then
@@ -1276,8 +1277,9 @@ YUM
   fi
 }
 
+# Add any Yum repositories that are needed for cartridges or their dependencies.
 configure_cart_repos()
-{ # add cartridge (or dependency) repo as needed
+{
   local -A url=(
           [jbosseap]="${jboss_repo_base}/jbeap/${jbosseap_version}/os"
           [jbossews]="${jboss_repo_base}/jbews/2/os"
@@ -1304,8 +1306,9 @@ YUM
   done
 }
 
+# Add all defined extra repos in one file.
 configure_extra_repos()
-{ # add all defined extra repos in one file
+{
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [[ -e "${extra_repo_file}" ]]; then
       echo > "${extra_repo_file}"
@@ -1375,7 +1378,7 @@ configure_rhn_channels()
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
-      set +x # don't log password
+      set +x # Don't log password.
       echo "OpenShift: Register to RHN Classic with username and password"
       echo "rhnreg_ks --force \"--profilename=$profile_name\" --username \"${CONF_RHN_USER}\" ${CONF_RHN_REG_OPTS}"
       rhnreg_ks --force "--profilename=$profile_name" --username "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" ${CONF_RHN_REG_OPTS} || abort_install
@@ -1387,7 +1390,8 @@ configure_rhn_channels()
 
   if [[ -n "$rhn_creds_provided" ]]
   then
-    # Enable the node or infrastructure channel to enable installing the release RPM
+    # Enable the node or infrastructure channel to enable installing the release
+    # RPM.
     local repos=('rhel-x86_64-server-6-rhscl-1')
     if ! need_node_repo || need_infra_repo ; then
       repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
@@ -1398,7 +1402,7 @@ configure_rhn_channels()
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
-    set +x # don't log password
+    set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"; do
       [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
@@ -1413,7 +1417,7 @@ configure_rhsm_channels()
 {
   if [[ -n "$rhn_creds_provided" ]]
   then
-    set +x # don't log password
+    set +x # Don't log password.
     echo "OpenShift: Register with RHSM"
     echo "subscription-manager register --force \"--username=$CONF_RHN_USER\" --name \"$profile_name\" ${CONF_RHN_REG_OPTS}"
     subscription-manager register --force "--username=$CONF_RHN_USER" "--password=$CONF_RHN_PASS" --name "$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
@@ -1447,7 +1451,7 @@ configure_rhsm_channels()
 abort_install()
 {
   [[ "$#" -ge 1 ]] && echo "$@"
-  # don't change this; could be used as an automation cue.
+  # Don't change this; it is used as an automation cue.
   echo "OpenShift: Aborting Installation."
   exit 1
 }
@@ -1478,10 +1482,10 @@ install_rhc_pkg()
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
-  # set_conf expects there to be a new line
+  # set_conf expects there to be a new line.
   echo "" >> /etc/openshift/express.conf
 
-  # set up the system express.conf so this broker will be used by default
+  # Set up the system express.conf so this broker will be used by default.
   set_conf /etc/openshift/express.conf libra_server "'${broker_hostname}'"
 }
 
@@ -1519,11 +1523,10 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-container-selinux"
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
-  # technically not needed unless $CONF_SYSLOG includes gears, but it
-  # does not hurt to have them available:
+
   if [[ "$CONF_SYSLOG" = *gears* ]]; then
     if rpm -q rsyslog ; then
-      # RHEL 6.6's rsyslog7 package conflicts with the originaly RHEL 6 package
+      # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
 erase rsyslog
 install rsyslog7 rsyslog7-mmopenshift
@@ -1880,10 +1883,10 @@ configure_quotas_on_node()
     time restorecon "${geardata_mnt}"
     # Generate user quota info for the mount point.
     time quotacheck -cmug "${geardata_mnt}"
-    # fix up selinux label on created quota file
+    # Fix the SELinux label of the created quota file.
     restorecon "${geardata_mnt}"/aquota.user
 
-    # (re)enable quotas
+    # (Re)enable quotas.
     time quotaon "${geardata_mnt}"
   fi
 }
@@ -1962,9 +1965,9 @@ wait_for_mongod()
 }
 
 # $1 = commands
-# $2 = regex to test output
-# $3 = user
-# $4 = password
+# $2 = regex to test output (optional)
+# $3 = user (optional)
+# $4 = password (optional)
 execute_mongodb()
 {
   echo "Running commands on MongoDB:"
@@ -2305,8 +2308,8 @@ EOF
   chown apache:apache $mcollective_cfg
   chmod 640 $mcollective_cfg
 
-  # make sure mcollective client log is created with proper ownership.
-  # if root owns it, the broker (apache user) can't log to it.
+  # Make sure the MCollective client log is created with proper ownership.
+  # If root owns it, the broker (apache user) can't log to it.
   touch /var/log/openshift/broker/ruby193-mcollective-client.log
   chown apache:root /var/log/openshift/broker/ruby193-mcollective-client.log
 
@@ -2768,23 +2771,29 @@ zone "${zone}" IN {
 EOF
 }
 
+# Add a domain to the given hostname if it does not have one.
+# $1 = host
+# $2 = domain
 ensure_domain()
-{ # adds a domain to hostname if it does not have one
-  # $1 = host; $2 = domain
-  if [[ $1 = *.* ]]; then # already FQDN or IP
+{
+  if [[ $1 = *.* ]]
+  then # $1 is already a FQDN or IP address.
     echo "$1"
-  else # needs a domain
+  else # $1 needs a domain appended.
     echo "$1.$2"
   fi
 }
 
+# $1 = host
+# $2 = ip
+# $3 = zone (optional)
 add_host_to_zone()
 {
-  # $1 = host; $2 = ip; [ $3 = zone ]
   local zone="${3:-$hosts_domain}"
   local nsdb="/var/named/dynamic/${zone}.db"
-  # sanity check that $1 isn't an IP, and $2 is.
-  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  # Check that $1 isn't an IP address and that $2 is.
+  # All numbers and dots = IP address (not rigorous).
+  local ip_regex='^[.0-9]+$'
   if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
     echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
   else
@@ -2794,9 +2803,12 @@ add_host_to_zone()
 
 configure_hosts_dns()
 {
-  add_host_to_zone "$named_hostname" "$named_ip_addr" # always define self
-  # glue record for NS host in subdomain:
+  # Always define self.
+  add_host_to_zone "$named_hostname" "$named_ip_addr"
+
+  # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
+
   if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
@@ -2809,7 +2821,7 @@ configure_hosts_dns()
     for host_ip in ${CONF_NAMED_ENTRIES//,/ }; do
       add_host_to_zone ${host_ip//:/ }
     done
-  else # if "none" then just don't add anything
+  else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $CONF_NAMED_ENTRIES"
   fi
 }
@@ -2818,7 +2830,8 @@ configure_hosts_dns()
 # using oo-register-dns. Not used by default.
 register_named_entries()
 {
-  local ip_regex='^[.0-9]+$' # all numbers and dots = IP (not rigorous)
+  # All numbers and dots = IP address (not rigorous).
+  local ip_regex='^[.0-9]+$'
   local failed="false"
   local host_ip
   local host
@@ -2910,7 +2923,8 @@ configure_controller()
 
   if [[ ${datastore_replicants} =~ , ]] || ! datastore
   then
-    #mongo installed remotely or replicated, so configure with given hostname(s)
+    # MongoDB may be installed remotely or replicated, so configure it
+    # with the given hostname(s).
     sed -i -e "s/^MONGO_HOST_PORT=.*$/MONGO_HOST_PORT=\"${datastore_replicants}\"/" /etc/openshift/broker.conf
   fi
 
@@ -2937,8 +2951,9 @@ configure_controller()
   RESTART_NEEDED=true
 }
 
+# $1 = ports per gear (optional)
 configure_messaging_plugin()
-{ # 1 optional arg - ports per gear
+{
   local ports="${1:-$ports_per_gear}"
   local pool_size=6000
   let "pool_size=30000/$ports"
@@ -3088,7 +3103,7 @@ configure_access_keys_on_broker()
   # command will not have to ask the user what to do.
   rm -f /root/.ssh/rsync_id_rsa /root/.ssh/rsync_id_rsa.pub
 
-  # Generate a key pair for moving gears between nodes from the broker
+  # Generate a key pair for moving gears between nodes from the broker.
   ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
   cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes. So, we provide it via a standard
@@ -3102,7 +3117,7 @@ configure_access_keys_on_broker()
 
 configure_wildcard_ssl_cert_on_node()
 {
-  # Generate a 2048 bit key and self-signed cert
+  # Generate a 2048 bit key and self-signed cert.
   cat << EOF | openssl req -new -rand /dev/urandom \
 	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
 	-x509 -days 3650 \
@@ -3165,7 +3180,7 @@ configure_node()
       $conf
   if [[ "$ports_per_gear" != 5 ]]; then
     sed -i -e "/PORTS_PER_USER=/ cPORTS_PER_USER=${ports_per_gear}" $conf
-    # if not already there, we need to add it
+    # If PORTS_PER_USER is not already there, we need to add it.
     grep -q '^PORTS_PER_USER' $conf || sed -i -e "$ a\\
 \\
 # Number of proxy ports available per gear. Increasing the ports per gear requires reducing\\
@@ -3206,7 +3221,7 @@ PORTS_PER_USER=${ports_per_gear}
 configure_node_logs()
 {
   if [[ "$CONF_SYSLOG" = *node* ]]; then
-    # send the node platform logs to syslog instead
+    # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
       s/^PLATFORM_LOG_FILE/#PLATFORM_LOG_FILE/
@@ -3221,11 +3236,11 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
   if [[ "$CONF_SYSLOG" = *frontend* ]]; then
-    # send the frontend logs to syslog (in addition to file)
+    # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
   if is_true "$CONF_NODE_LOG_CONTEXT"; then
-    # annotate the frontend logs with UUIDs
+    # Annotate the frontend logs with UUIDs.
     sed -i -e '
       s/^.*PLATFORM_LOG_CONTEXT_ENABLED=.*/PLATFORM_LOG_CONTEXT_ENABLED=1/
       s/^.*PLATFORM_LOG_CONTEXT_ATTRS=.*/PLATFORM_LOG_CONTEXT_ATTRS=request_id,app_uuid,container_uuid/
@@ -3233,7 +3248,7 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
   if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
-    # configure watchman with given interval
+    # Configure watchman with given the interval.
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
       s/^.*WATCHMAN_METRICS_INTERVAL=.*/WATCHMAN_METRICS_INTERVAL=$CONF_METRICS_INTERVAL/
@@ -3261,7 +3276,7 @@ install_rsync_pub_key()
 
   local cert
   while [[ `date +%s` -lt $end ]]; do
-    # try to get key hosted on broker machine
+    # Try to get the public key from the broker.
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
     if [[ $? -ne 0 ]]; then
       sleep 5
@@ -3373,8 +3388,9 @@ is_false()
   return 1
 }
 
+# Checks $1 or $node_profile and returns true if it contains "xpaas".
 is_xpaas()
-{ # checks first arg or $node_profile, true if contains "xpaas"
+{
   local profile="${1:-$node_profile}"
   [[ "${profile}" = *xpaas* ]]
 }
@@ -3517,8 +3533,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     (*) abort_install "Unrecognized JBoss EAP channel version: ${CONF_JBOSSEAP_VERSION}" ;;
   esac
 
-  # There a no defaults for these. Customers should be using
-  # subscriptions via RHN. Internally we use private systems.
+  # There are no defaults for these.  Customers should be using
+  # subscriptions via RHN.  Internally, we use private systems.
   rhel_repo="${CONF_RHEL_REPO%/}"
   rhel_extra_repo="${CONF_RHEL_EXTRA_REPO%/}"
   jboss_repo_base="${CONF_JBOSS_REPO_BASE%/}"
@@ -3550,16 +3566,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
-  # no need to waste time checking both subscription plugins if using one
+  # There is no need to waste time checking both subscription plugins
+  # if using one is explicitly enabled.
   disable_plugin=""
   [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
   [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
-  # could do the same for "yum" method but it's more likely to surprise someone
+  # We could do the same for "yum" method, but that would be more likely
+  # to surprise someone.
   #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
 
-  # remap subscription parameters used previously
+  # Check for subscription parameters under all previously used setting
+  # names.
   CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
-  set +x # don't log password
+  set +x # Don't log password.
   CONF_RHN_PASS="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-$CONF_RHN_REG_PASS}}"
   if [[ "${CONF_RHN_USER}" && "${CONF_RHN_PASS}" ]]; then
     rhn_creds_provided=true
@@ -3573,7 +3592,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   hosts_domain="${CONF_HOSTS_DOMAIN:-$domain}"
   hosts_domain_keyfile="${CONF_HOSTS_DOMAIN_KEYFILE:-/var/named/${hosts_domain}.key}"
 
-  # hostnames to use for the components (could all resolve to same host)
+  # Hostnames to use for the components (could all resolve to same host).
   broker_hostname=$(ensure_domain "${CONF_BROKER_HOSTNAME:-broker}" "$hosts_domain")
   node_hostname=$(ensure_domain "${CONF_NODE_HOSTNAME:-node}" "$hosts_domain")
   named_hostname=$(ensure_domain "${CONF_NAMED_HOSTNAME:-ns1}" "$hosts_domain")
@@ -3606,7 +3625,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # host.
   node_ip_addr="${CONF_NODE_IP_ADDR:-$cur_ip_addr}"
 
-  # how to label the system when subscribing
+  # How to label the system when subscribing.
   profile_name="${CONF_PROFILE_NAME:-OpenShift-${hostname}-${cur_ip_addr}-${CONF_RHN_USER}}"
 
   node_apache_frontend="${CONF_NODE_APACHE_FRONTEND:-vhost}"
@@ -3833,7 +3852,7 @@ validate_preflight()
     # adding channels.
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
-      set +x # don't log password
+      set +x # Don't log password.
       if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
@@ -3849,7 +3868,7 @@ validate_preflight()
     # Note: With RHSM, we need credentials for registration but not for
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
-      set +x # don't log password
+      set +x # Don't log password.
       if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
@@ -3890,7 +3909,7 @@ validate_preflight()
 install_rpms()
 {
   echo "OpenShift: Begin installing RPMs."
-  # we often rely on latest selinux policy and other updates
+  # We often rely on the latest SELinux policy and other updates.
   echo "OpenShift: yum update"
   yum $disable_plugin clean all
 
@@ -3932,16 +3951,16 @@ configure_host()
   is_false "$CONF_KEEP_NAMESERVERS" && configure_dns_resolution
   is_false "$CONF_KEEP_HOSTNAME" && configure_hostname
 
-  # minimize grub timeout on startup
+  # Minimize grub timeout on startup.
   sed -i -e 's/^timeout=.*/timeout=1/' /etc/grub.conf;
 
-  # Remove VirtualHost from the default httpd ssl.conf to prevent a warning
+  # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
   sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall
 
-  # all hosts should enable ssh access
+  # All hosts should enable SSH access.
   firewall_allow[ssh]=tcp:22
   configure_firewall_add_rules
   echo "OpenShift: Completed configuring host."
@@ -4007,13 +4026,13 @@ configure_openshift()
 {
   echo "OpenShift: Begin configuring OpenShift."
 
-  # prepare services the broker and node depend on
+  # Prepare services that the broker and node depend on.
   datastore && configure_datastore
   activemq && configure_activemq
   broker && configure_mcollective_for_activemq_on_broker
   node && configure_mcollective_for_activemq_on_node
 
-  # configure broker and/or node
+  # Configure the broker and/or node.
   broker && enable_services_on_broker
   node && enable_services_on_node
   node && configure_pam_on_node
@@ -4080,7 +4099,7 @@ restart_services()
   node && is_true "$enable_sni_proxy" && service openshift-sni-proxy restart
   node && service openshift-watchman restart
 
-  # ensure openshift facts are updated
+  # Ensure OpenShift facts are updated.
   node && /etc/cron.minutely/openshift-facts
 
   echo "OpenShift: Completed restarting services."
@@ -4127,7 +4146,7 @@ configure_districts()
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
       firstnode=${nodes//,*/}
-      # query the node for the node profile via mcollective
+      # Query the node for the node profile via MCollective.
       profile=""
       for i in {1..10}; do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
@@ -4146,7 +4165,7 @@ configure_districts()
       fi
     done
   fi
-  # configuring districts should not normally require a service restart
+  # Configuring districts should not normally require a service restart.
   RESTART_NEEDED=$restart
 
   date +%Y-%m-%d-%H:%M:%S
@@ -4165,7 +4184,7 @@ post_deploy()
 
     $RESTART_NEEDED && restart_services && RESTART_COMPLETED=true
 
-    # import cartridges
+    # Import cartridges.
     oo-admin-ctl-cartridge -c import-node --activate --obsolete
 
     configure_districts
@@ -4177,10 +4196,10 @@ post_deploy()
 }
 
 do_all_actions()
-{ # Avoid adding or removing these top-level actions.
-  # oo-install invokes these individually in separate phases.
-  # So, they should not assume the others ran previously in
-  # the same invocation.
+{
+  # Avoid adding or removing these top-level actions.  oo-install invokes these
+  # individually in separate phases, so they should not assume the others ran
+  # previously in the same invocation.
   init_message
   validate_preflight
   configure_repos

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1030,7 +1030,7 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [ -n "${!3}" ]; then
+  if [[ -n "${!3}" ]]; then
     printf -v "$1" '%s' "${!3}"
   elif is_true "$no_scramble" ; then
     printf -v "$1" '%s' "$2"
@@ -1063,11 +1063,11 @@ display_passwords()
     matchingvar=""
     for postfix in password password1 pass; do
       vprefix=${k%${postfix}}
-      [ "$vprefix" != "$k" ] && break
+      [[ "$vprefix" != "$k" ]] && break
     done
 
     for v in "${vprefix}user" "${vprefix}user1"; do
-      if [ "x${!v}" != "x" ]; then
+      if [[ -n "${!v}" ]]; then
         matchingvar=$v
         break
       fi
@@ -1079,8 +1079,8 @@ display_passwords()
     done
 
     out_string+="$formattedprefix"
-    [ "x$matchingvar" != "x" ] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
-    [ "$vprefix" != "$k" ] && out_string+=" ${k##*_}"
+    [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
+    [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
     echo $out_string
   done
@@ -1102,7 +1102,7 @@ configure_repos()
 
   is_true "$CONF_OPTIONAL_REPO" && need_optional_repo() { :; }
 
-  if [ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]; then
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
     need_extra_repo() { :; }
   fi
 
@@ -1180,11 +1180,11 @@ configure_ose_yum_repos()
   # this can be useful even if the main subscription is via RHN
   local repo
   for repo in infra node jbosseap_cartridge client_tools; do
-    if [ "$ose_repo_base" != "" ]; then
-      local layout=puddle; [ -n "$CONF_CDN_LAYOUT" ] && layout=cdn
+    if [[ -n "$ose_repo_base" ]]; then
+      local layout=puddle; [[ -n "$CONF_CDN_LAYOUT" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [ "$ose_extra_repo_base" != "" ]; then
+    if [[ -n "$ose_extra_repo_base" ]]; then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -1196,7 +1196,7 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [ "${rhel_repo}x" != "x" ]; then
+if [[ -n "${rhel_repo}" ]]; then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -1213,7 +1213,7 @@ fi
 
 configure_optional_repo()
 {
-if [ "${rhel_optional_repo}x" != "x" ]; then
+if [[ -n "${rhel_optional_repo}" ]]; then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -1261,7 +1261,7 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [ "x${rhscl_repo_base}" != "x" ]; then
+  if [[ -n "${rhscl_repo_base}" ]]; then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -1307,7 +1307,7 @@ YUM
 configure_extra_repos()
 { # add all defined extra repos in one file
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [ -e "${extra_repo_file}" ]; then
+  if [[ -e "${extra_repo_file}" ]]; then
       echo > "${extra_repo_file}"
   fi
 
@@ -1326,7 +1326,7 @@ configure_extra_repos()
   local repo
   for repo in "${!priority[@]}"; do
     local url="${!repo}"
-    if [ "${url}x" != "x" ]; then
+    if [[ -n "${url}" ]]; then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -1369,11 +1369,11 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [ "x$CONF_RHN_REG_ACTKEY" != x ]; then
+  if [[ -n "$CONF_RHN_REG_ACTKEY" ]]; then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${CONF_RHN_REG_ACTKEY}" "--profilename=$profile_name" ${CONF_RHN_REG_OPTS} || abort_install
-  else 
-    if [ $rhn_creds_provided ]
+  else
+    if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # don't log password
       echo "OpenShift: Register to RHN Classic with username and password"
@@ -1385,7 +1385,7 @@ configure_rhn_channels()
     fi
   fi
 
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     # Enable the node or infrastructure channel to enable installing the release RPM
     local repos=('rhel-x86_64-server-6-rhscl-1')
@@ -1401,7 +1401,7 @@ configure_rhn_channels()
     set +x # don't log password
     local repo
     for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" == *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
+      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${CONF_RHN_USER}" --password "${CONF_RHN_PASS}" || abort_install
     done
     set -x
   fi
@@ -1411,7 +1411,7 @@ configure_rhn_channels()
 
 configure_rhsm_channels()
 {
-  if [ $rhn_creds_provided ]
+  if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # don't log password
     echo "OpenShift: Register with RHSM"
@@ -1422,7 +1422,7 @@ configure_rhsm_channels()
     echo "OpenShift: No credentials given for RHSM; assuming already configured"
   fi
 
-  if [[ "${CONF_SM_REG_POOL}" ]]
+  if [[ -n "${CONF_SM_REG_POOL}" ]]
   then
     echo "OpenShift: Removing all current subscriptions"
     subscription-manager remove --all
@@ -1446,7 +1446,7 @@ configure_rhsm_channels()
 
 abort_install()
 {
-  [[ "$@"x == x ]] || echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$@"
   # don't change this; could be used as an automation cue.
   echo "OpenShift: Aborting Installation."
   exit 1
@@ -1458,9 +1458,9 @@ yum_install_or_exit()
   local count=0
   time while true; do
     yum install -y $* $disable_plugin
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       return
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -1866,7 +1866,7 @@ configure_quotas_on_node()
   # Get the mountpoint for /var/lib/openshift (should be /).
   local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
-  if ! [ x"$geardata_mnt" != x ]
+  if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
@@ -1973,13 +1973,13 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [ -n "$3" -a -n "$4" ]; then
+  if [[ -n "$3" && -n "$4" ]]; then
     userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [ "$2" ]; then # test output against regex
+  if [[ -n "$2" ]]; then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -2367,7 +2367,7 @@ configure_activemq()
   local replicant
   for replicant in ${activemq_replicants//,/ }
   do
-    if ! [ "$replicant" = "$activemq_hostname" ]
+    if [[ "$replicant" != "$activemq_hostname" ]]
     then
       : ${networkConnectors:='        <networkConnectors>'$'\n'}
       : ${authenticationUser_amq:="<authenticationUser username=\"amq\" password=\"${activemq_amq_user_password}\" groups=\"admins,everyone\" />"}
@@ -2704,7 +2704,7 @@ EOF
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
   configure_named_zone "$hosts_domain"
-  [ "$domain" != "$hosts_domain" ] && configure_named_zone "$domain"
+  [[ "$domain" != "$hosts_domain" ]] && configure_named_zone "$domain"
 
   # configure in any hosts as needed
   configure_hosts_dns
@@ -2721,7 +2721,7 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [ "x$bind_key" = x ]; then
+  if [[ -z "$bind_key" ]]; then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -2771,7 +2771,7 @@ EOF
 ensure_domain()
 { # adds a domain to hostname if it does not have one
   # $1 = host; $2 = domain
-  if [[ $1 == *.* ]]; then # already FQDN or IP
+  if [[ $1 = *.* ]]; then # already FQDN or IP
     echo "$1"
   else # needs a domain
     echo "$1.$2"
@@ -2796,8 +2796,8 @@ configure_hosts_dns()
 {
   add_host_to_zone "$named_hostname" "$named_ip_addr" # always define self
   # glue record for NS host in subdomain:
-  [[ "$hosts_domain" == *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
-  if [ -z "$CONF_NAMED_ENTRIES" ]; then
+  [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
+  if [[ -z "$CONF_NAMED_ENTRIES" ]]; then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
@@ -2885,7 +2885,7 @@ update_controller_gear_size_configs()
 # Update the controller configuration.
 configure_controller()
 {
-  if [ "x$broker_auth_salt" = "x" ]
+  if [[ -z "$broker_auth_salt" ]]
   then
     echo "Warning: broker authentication salt is empty!"
   fi
@@ -2903,7 +2903,7 @@ configure_controller()
       /etc/openshift/broker.conf
 
   # Configure the session secret for the console
-  if [ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]
+  if [[ `grep -c SESSION_SECRET /etc/openshift/console.conf` -eq 0 ]]
   then
     echo "SESSION_SECRET=${console_session_secret}" >> /etc/openshift/console.conf
   fi
@@ -2954,7 +2954,7 @@ configure_messaging_plugin()
 # Configure the broker to use the BIND DNS plug-in.
 configure_dns_plugin()
 {
-  if [ "x$bind_key" = x ] && [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_key" && -z "$bind_krb_keytab" ]]
   then
     echo 'WARNING: Neither key nor keytab has been set for communication'
     echo 'with BIND. You will need to modify the value of BIND_KEYVALUE'
@@ -2968,7 +2968,7 @@ BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
-  if [ "x$bind_krb_keytab" = x ]
+  if [[ -z "$bind_krb_keytab" ]]
   then
     cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
 BIND_KEYNAME="${domain}"
@@ -2993,7 +2993,7 @@ configure_httpd_auth()
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
-  if [ -n "$CONF_BROKER_KRB_SERVICE_NAME" ] && [ -n "$CONF_BROKER_KRB_AUTH_REALMS" ]
+  if [[ -n "$CONF_BROKER_KRB_SERVICE_NAME" && -n "$CONF_BROKER_KRB_AUTH_REALMS" ]]
   then
     yum_install_or_exit mod_auth_kerb
     local d
@@ -3232,7 +3232,7 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ "$CONF_METRICS_INTERVAL" != "" ]]; then
+  if [[ -n "$CONF_METRICS_INTERVAL" ]]; then
     # configure watchman with given interval
     sed -i -e "
       s/^.*WATCHMAN_METRICS_ENABLED=.*/WATCHMAN_METRICS_ENABLED=true/
@@ -3263,11 +3263,11 @@ install_rsync_pub_key()
   while [[ `date +%s` -lt $end ]]; do
     # try to get key hosted on broker machine
     cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
-    if [ $? -ne 0 ]; then
+    if [[ $? -ne 0 ]]; then
       sleep 5
     else
       ssh-keygen -lf /dev/stdin <<< $cert
-      if [ $? -ne 0 ]; then
+      if [[ $? -ne 0 ]]; then
         break
       else
         echo $cert >> /root/.ssh/authorized_keys
@@ -3357,7 +3357,7 @@ is_true()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 1
+    [[ "$arg" =~ (1|true) ]] || return 1
   done
 
   return 0
@@ -3367,7 +3367,7 @@ is_false()
 {
   for arg
   do
-    [[ x$arg =~ x(1|true) ]] || return 0
+    [[ "$arg" =~ (1|true) ]] || return 0
   done
 
   return 1
@@ -3376,7 +3376,7 @@ is_false()
 is_xpaas()
 { # checks first arg or $node_profile, true if contains "xpaas"
   local profile="${1:-$node_profile}"
-  [[ "${profile}" == *xpaas* ]]
+  [[ "${profile}" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -3440,7 +3440,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   local setting
   for setting in "${!CONF_@}"
   do
-    if ! [[ ${valid_settings[$setting]+1} ]]
+    if [[ -z "${valid_settings[$setting]+x}" ]]
     then
       if is_true "$abort_on_unrecognized_settings"
       then
@@ -3450,7 +3450,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       fi
     else
       # The setting is recognized, so check whether a non-empty value is given.
-      [[ ${!setting} ]] || abort_install "Setting is assigned an empty value: $setting"
+      [[ -n "${!setting}" ]] || abort_install "Setting is assigned an empty value: $setting"
     fi
   done
   set -x
@@ -3490,7 +3490,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [ $installing_something = 0 ]
+  if [[ $installing_something = 0 ]]
   then
     for component in $components
     do
@@ -3536,26 +3536,26 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Use CDN layout as the default for all yum repos if this is set.
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [ "x$cdn_repo_base" != "x" ]; then
+  if [[ -n "$cdn_repo_base" ]]; then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [ "${cdn_repo_base}" == "${ose_repo_base}" ]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
       CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [ "${rhel_repo}" == "${ose_repo_base}/os" ]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
     CONF_CDN_LAYOUT=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
   rhscl_repo_base="${rhscl_repo_base:-${rhel_repo%/os}}"
   # no need to waste time checking both subscription plugins if using one
   disable_plugin=""
-  [[ "$CONF_INSTALL_METHOD" == "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
-  [[ "$CONF_INSTALL_METHOD" == "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
+  [[ "$CONF_INSTALL_METHOD" = "rhsm" ]] && disable_plugin='--disableplugin=rhnplugin'
+  [[ "$CONF_INSTALL_METHOD" = "rhn" ]] && disable_plugin='--disableplugin=subscription-manager'
   # could do the same for "yum" method but it's more likely to surprise someone
-  #[[ "$CONF_INSTALL_METHOD" == "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
+  #[[ "$CONF_INSTALL_METHOD" = "yum" ]] && disable_plugin='--disableplugin=subscription-manager --disableplugin=rhnplugin'
 
   # remap subscription parameters used previously
   CONF_RHN_USER="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-$CONF_RHN_REG_NAME}}"
@@ -3632,7 +3632,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # $CONF_BIND_KRB_KEYTAB and $CONF_BIND_KRB_PRINCIPAL if these values
   # are both non-empty, or set $bind_key to the value of $CONF_BIND_KEY
   # if the latter is non-empty.
-  if [ "x$CONF_BIND_KRB_KEYTAB" != x ] && [ "x$CONF_BIND_KRB_PRINCIPAL" != x ] ; then
+  if [[ -n "$CONF_BIND_KRB_KEYTAB" && -n "$CONF_BIND_KRB_PRINCIPAL" ]]; then
   bind_krb_keytab="$CONF_BIND_KRB_KEYTAB"
   bind_krb_principal="$CONF_BIND_KRB_PRINCIPAL"
   else
@@ -3647,15 +3647,15 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
-  [ -n "$CONF_VALID_GEAR_SIZES" ] && isset_valid_gear_sizes() { :; }
+  [[ -n "$CONF_VALID_GEAR_SIZES" ]] && isset_valid_gear_sizes() { :; }
   broker && valid_gear_sizes="${CONF_VALID_GEAR_SIZES:-small}"
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
-  [ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ] && isset_default_gear_capabilities() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_CAPABILITIES" ]] && isset_default_gear_capabilities() { :; }
   broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
-  [ -n "$CONF_DEFAULT_GEAR_SIZE" ] && isset_default_gear_size() { :; }
+  [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
   # Set $node_profile to $CONF_NODE_PROFILE
@@ -3793,7 +3793,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 init_message()
 {
   echo_installation_intentions
-  [ "$environment" = ks ] && configure_console_msg
+  [[ "$environment" = ks ]] && configure_console_msg
 }
 
 validate_preflight()
@@ -3834,7 +3834,7 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3850,7 +3850,7 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'; then
       set +x # don't log password
-      if [ ! "$CONF_RHN_USER" -o ! "$CONF_RHN_PASS" ]; then
+      if [[ -z "$CONF_RHN_USER" || -z "$CONF_RHN_PASS" ]]; then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3867,15 +3867,15 @@ validate_preflight()
     # subscription-manager gets to write all of its plentiful output
     # before grep closes the pipeline.  Without it, we will get
     # a harmless but possibly alarming "Broken pipe" error message.
-    if [[ ! "$CONF_SM_REG_POOL" ]] &&
-        ( [[ "$CONF_RHN_USER" && "$CONF_RHN_PASS" ]] ||
+    if [[ -z "$CONF_SM_REG_POOL" ]] &&
+        ( [[ -n "$CONF_RHN_USER" && -n "$CONF_RHN_PASS" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [ "$CONF_INSTALL_METHOD" = yum -a ! "$ose_repo_base" ]; then
+  if [[ "$CONF_INSTALL_METHOD" = yum && -z "$ose_repo_base" ]]; then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -3883,7 +3883,7 @@ validate_preflight()
   # Test that known problematic RPMs aren't present
   # ... ?
 
-  [ "$preflight_failure" ] && abort_install
+  [[ -n "$preflight_failure" ]] && abort_install
   echo "OpenShift: Completed preflight validation."
 }
 
@@ -3897,9 +3897,9 @@ install_rpms()
   local count=0
   while true; do
     yum $disable_plugin update -y
-    if [ $? -eq 0 ]; then
+    if [[ $? -eq 0 ]]; then
       break
-    elif [ $count -gt 3 ]; then
+    elif [[ $count -gt 3 ]]; then
       abort_install
     fi
     let count+=1
@@ -4131,12 +4131,12 @@ configure_districts()
       profile=""
       for i in {1..10}; do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)
-        if [ $? -eq 0 ]; then
+        if [[ $? -eq 0 ]]; then
           break;
         fi
         sleep 10
       done
-      if [ "x$profile" != "x" ]; then
+      if [[ -n "$profile" ]]; then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -4232,7 +4232,7 @@ set_defaults
 date +%Y-%m-%d-%H:%M:%S
 for action in ${actions//,/ }
 do
-  [ "$(type -t "$action")" = function ] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1465,7 +1465,8 @@ configure_rhn_channels()
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       echo 'OpenShift: Register to RHN Classic with username and password'
       echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
       rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
@@ -1489,7 +1490,8 @@ configure_rhn_channels()
     need_fuse_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossfuse')
     need_amq_cartridge_repo && repos+=('rhel-x86_64-server-6-ose-2.2-jbossamq')
 
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     local repo
     for repo in "${repos[@]}"
     do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
@@ -1504,7 +1506,8 @@ configure_rhsm_channels()
 {
   if [[ -n "$rhn_creds_provided" ]]
   then
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     echo 'OpenShift: Register with RHSM'
     echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
     subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
@@ -4009,7 +4012,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     # Check for subscription parameters under all previously used setting
     # names.
     rhn_user="${CONF_RHN_USER:-${CONF_SM_REG_NAME:-${CONF_RHN_REG_NAME-}}}"
-    set +x # Don't log password.
+    # Don't log password.
+    set +x
     rhn_pass="${CONF_RHN_PASS:-${CONF_SM_REG_PASS:-${CONF_RHN_REG_PASS-}}}"
     if [[ -n "$rhn_user" && -n "$rhn_pass" ]]
     then rhn_creds_provided='true'
@@ -4279,7 +4283,8 @@ validate_preflight()
     # adding channels.
     if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhn requires an RHN user and password.'
@@ -4298,7 +4303,8 @@ validate_preflight()
     # adding channels.
     if ! subscription-manager identity | grep -q 'identity is:'
     then
-      set +x # Don't log password.
+      # Don't log password.
+      set +x
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
         echo 'OpenShift: Install method rhsm requires an RHN user and password.'

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -4066,7 +4066,9 @@ configure_host()
   set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  if broker || node
+  then sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
+  fi
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1311,7 +1311,7 @@ configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
   if [[ -e "${extra_repo_file}" ]]; then
-      echo > "${extra_repo_file}"
+      > "${extra_repo_file}"
   fi
 
   local -A priority=(

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3125,7 +3125,7 @@ configure_hosts_dns()
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-    router && add_host_to_zone "$router_hostname" "$cur_ip_addr"
+    router && add_host_to_zone "$router_hostname" "$cur_ip_addr" "$domain"
   elif [[ "$named_entries" =~ : ]]
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
@@ -3385,6 +3385,8 @@ configure_routing_daemon()
   set_routing_daemon CLOUD_DOMAIN "$domain"
 
   [[ "$router" = nginx ]] && service openshift-routing-daemon start
+
+  return 0
 }
 
 configure_routing_plugin()
@@ -3885,6 +3887,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     do
       eval "$component() { :; }"
     done
+  fi
+
+  if router
+  then
+    if broker || node
+    then abort_install 'The router component cannot be installed on the same host as the broker or node components.'
+    fi
   fi
 
   # Following are some settings used in subsequent steps.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1042,21 +1042,21 @@ set -x
 
 set -euo pipefail
 
-annotate()
-{
-  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
-}
-trap 'echo "Finished with exitcode $?" >&4' EXIT
-# <> redirection requires disabling posix.
-set +o posix
-exec 5>&1 \
-  1<> >(annotate O >&5) \
-  2<> >(annotate E >&5) \
-  3<> >(annotate D >&5) \
-  4<> >(annotate I >&5) \
-  5>&-
-BASH_XTRACEFD=3
-echo "Started $0 $*" >&4
+#annotate()
+#{
+#  exec awk "{ print strftime(\"%H:%M:%S $1:\"), \$0; fflush(); }"
+#}
+#trap 'echo "Finished with exitcode $?" >&4' EXIT
+## <> redirection requires disabling posix.
+#set +o posix
+#exec 5>&1 \
+#  1<> >(annotate O >&5) \
+#  2<> >(annotate E >&5) \
+#  3<> >(annotate D >&5) \
+#  4<> >(annotate I >&5) \
+#  5>&-
+#BASH_XTRACEFD=3
+#echo "Started $0 $*" >&4
 
 
 ########################################################################

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -4738,7 +4738,7 @@ do
   [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 
 # In the case of a kickstart, some services will not be able to start, and the
 # host will automatically reboot anyway after the kickstart script completes.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2083,6 +2083,10 @@ configure_datastore()
   # Require authentication.
   set_mongodb auth true
 
+  # Workaround for oo-accept-broker, which performs a strict pattern match for
+  # 'auth = true' (with spaces).
+  sed -i -e 's/auth=true/auth = true/' '/etc/mongodb.conf'
+
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3677,8 +3677,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   [[ -n "$CONF_DEFAULT_GEAR_SIZE" ]] && isset_default_gear_size() { :; }
   broker && default_gear_size="${CONF_DEFAULT_GEAR_SIZE:-${valid_gear_sizes%%,*}}"
 
-  # Set $node_profile to $CONF_NODE_PROFILE
-  node && node_profile="${CONF_NODE_PROFILE:-small}"
+  node_profile="${CONF_NODE_PROFILE:-small}"
   node && node_profile_name="${CONF_NODE_PROFILE_NAME:-$node_profile}"
   node && node_host_type="${CONF_NODE_HOST_TYPE:-m3.xlarge}"
   # determine node port and UID settings

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -3281,11 +3281,11 @@ install_rsync_pub_key()
     if [[ $? -ne 0 ]]; then
       sleep 5
     else
-      ssh-keygen -lf /dev/stdin <<< $cert
+      ssh-keygen -lf /dev/stdin <<< "$cert"
       if [[ $? -ne 0 ]]; then
         break
       else
-        echo $cert >> /root/.ssh/authorized_keys
+        echo "$cert" >> /root/.ssh/authorized_keys
         echo "OpenShift node: SSH key downloaded from broker successfully."
         chmod 644 /root/.ssh/authorized_keys
         return

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1740,6 +1740,8 @@ EOF
   # which the broker uses for both HTTP and HTTPS connetions.  Usually, one will
   # use an https: URL for downloadable cartridges, so we put that here.
   broker && set_broker HTTP_PROXY "$outgoing_https_proxy"
+
+  return 0
 }
 
 # Install broker-specific packages.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1002,9 +1002,19 @@ set -x
 # hardware clock with that.
 synchronize_clock()
 {
+  local need_to_start_ntpd=
+
+  if service ntpd status | grep 'is running'
+  then
+    # Stop ntpd so that ntpdate succeeds.
+    service ntpd stop
+    need_to_start_ntpd=1
+  fi
 
   # Synchronize the system clock using NTP.
   ntpdate clock.redhat.com
+
+  [[ -n "$need_to_start_ntpd" ]] && service ntpd start
 
   # Synchronize the hardware clock to the system clock.
   hwclock --systohc

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1062,11 +1062,11 @@ display_passwords()
 
   for k in "${!passwords[@]}"
   do
-    out_string=""
-    matchingvar=""
+    out_string=
+    matchingvar=
     for postfix in password password1 pass
     do
-      vprefix=${k%${postfix}}
+      vprefix="${k%$postfix}"
       [[ "$vprefix" != "$k" ]] && break
     done
 
@@ -1074,22 +1074,22 @@ display_passwords()
     do
       if [[ -n "${!v+x}" ]]
       then
-        matchingvar=$v
+        matchingvar="$v"
         break
       fi
     done
 
-    formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}
+    formattedprefix="${vprefix//_/ }"
+    for s in "${!subs[@]}"
     do
-      formattedprefix=${formattedprefix//${s}/${subs[$s]}}
+      formattedprefix="${formattedprefix//${s}/${subs[$s]}}"
     done
 
     out_string+="$formattedprefix"
     [[ -n "$matchingvar" ]] && out_string+=" ${matchingvar##*_}: ${!matchingvar}"
     [[ "$vprefix" != "$k" ]] && out_string+=" ${k##*_}"
     out_string+=": ${!k}"
-    echo $out_string
+    echo "$out_string"
   done
   set -x
 }
@@ -1139,16 +1139,16 @@ configure_repos()
 
     # The jbosseap and jbossas cartridges require the jbossas packages
     # in the jbappplatform channel.
-    is_true "${need_jbosseap}" \
+    is_true "$need_jbosseap" \
              && need_jbosseap_cartridge_repo() { :; } \
              && need_jbosseap_repo() { :; }
 
     # The jbossews cartridge requires the tomcat packages in the jb-ews channel.
-    is_true "${need_jbossews}" && need_jbossews_repo() { :; }
+    is_true "$need_jbossews" && need_jbossews_repo() { :; }
 
     # The fuse/amq cartridges require their own channels.
-    is_true "${need_fuse}" && need_fuse_cartridge_repo() { :; }
-    is_true "${need_amq}" && need_amq_cartridge_repo() { :; }
+    is_true "$need_fuse" && need_fuse_cartridge_repo() { :; }
+    is_true "$need_amq" && need_amq_cartridge_repo() { :; }
 
     # The rhscl channel is needed for several cartridge platforms.
     need_rhscl_repo() { :; }
@@ -1211,17 +1211,17 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]
+if [[ -n "$rhel_repo" ]]
 then
-  cat > /etc/yum.repos.d/rhel.repo <<YUM
+  cat > '/etc/yum.repos.d/rhel.repo' <<YUM
 [rhel6]
 name=RHEL 6 base OS
-baseurl=${rhel_repo}
+baseurl=$rhel_repo
 enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude=tomcat6* ${yum_exclude_pkgs}
+exclude=tomcat6* $yum_exclude_pkgs
 
 YUM
 fi
@@ -1229,17 +1229,17 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]
+if [[ -n "$rhel_optional_repo" ]]
 then
-  cat > /etc/yum.repos.d/rheloptional.repo <<YUM
+  cat > '/etc/yum.repos.d/rheloptional.repo' <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
-baseurl=${rhel_optional_repo}
+baseurl=$rhel_optional_repo
 enabled=1
 gpgcheck=0
 priority=20
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 fi
@@ -1247,20 +1247,20 @@ fi
 
 def_ose_yum_repo()
 {
-  local repo_base=$1
-  local layout=$2  # one of: puddle, extra, cdn
-  local channel=$3 # one of: client_tools, infra, node, jbosseap_cartridge
+  local repo_base="$1"
+  local layout="$2"  # one of: puddle, extra, cdn
+  local channel="$3" # one of: client_tools, infra, node, jbosseap_cartridge
 
   local -A map
   local url
-  case $layout in
+  case "$layout" in
   puddle | extra)
     map=([client_tools]=RHOSE-CLIENT-2.2 [infra]=RHOSE-INFRA-2.2 [node]=RHOSE-NODE-2.2 [jbosseap_cartridge]=RHOSE-JBOSSEAP-2.2)
-    url="$repo_base/${map[$channel]}/x86_64/os/"
+    url="${repo_base}/${map[$channel]}/x86_64/os/"
     ;;
   cdn | * )
     map=([client_tools]=ose-rhc [infra]=ose-infra [node]=ose-node [jbosseap_cartridge]=ose-jbosseap)
-    url="$repo_base/${map[$channel]}/2.2/os"
+    url="${repo_base}/${map[$channel]}/2.2/os"
     ;;
   esac
   cat > "/etc/yum.repos.d/openshift-${channel}-${layout}.repo" <<YUM
@@ -1271,23 +1271,23 @@ enabled=1
 gpgcheck=0
 priority=10
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 }
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]
+  if [[ -n "$rhscl_repo_base" ]]
   then
-    cat <<YUM > /etc/yum.repos.d/rhscl.repo
+    cat <<YUM > '/etc/yum.repos.d/rhscl.repo'
 [rhscl]
 name=rhscl
 baseurl=${rhscl_repo_base}/rhscl/1/os/
 enabled=1
 priority=10
 gpgcheck=0
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
 
@@ -1312,13 +1312,13 @@ configure_cart_repos()
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
-name=${repo}
+name=$repo
 baseurl=${url[$repo]}
 enabled=1
 gpgcheck=0
 priority=30
 sslverify=false
-exclude= ${yum_exclude_pkgs}
+exclude= $yum_exclude_pkgs
 
 YUM
   done
@@ -1327,10 +1327,10 @@ YUM
 # Add all defined extra repos in one file.
 configure_extra_repos()
 {
-  local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]
+  local extra_repo_file='/etc/yum.repos.d/ose_extra.repo'
+  if [[ -e "$extra_repo_file" ]]
   then
-      > "${extra_repo_file}"
+      > "$extra_repo_file"
   fi
 
   local -A priority=(
@@ -1349,17 +1349,17 @@ configure_extra_repos()
   for repo in "${!priority[@]}"
   do
     local url="${!repo}"
-    if [[ -n "${url}" ]]
+    if [[ -n "$url" ]]
     then
-      cat <<YUM >> "${extra_repo_file}"
+      cat <<YUM >> "$extra_repo_file"
 [${repo}]
-name=${repo}
-baseurl=${url}
+name=$repo
+baseurl=$url
 enabled=1
 gpgcheck=0
 priority=${priority[$repo]}
 sslverify=false
-exclude=${exclude[$repo]} ${yum_exclude_pkgs}
+exclude=${exclude[$repo]} $yum_exclude_pkgs
 
 YUM
     fi
@@ -1373,7 +1373,7 @@ configure_subscription()
    # install our tool to enable repo/channel configuration
    yum_install_or_exit openshift-enterprise-yum-validator
 
-   local roles=""  # we will build the list of roles we need, then enable them.
+   local roles=  # we will build the list of roles we need, then enable them.
    need_infra_repo && roles="$roles --role broker"
    need_client_tools_repo && roles="$roles --role client"
    need_node_repo && roles="$roles --role node"
@@ -1397,18 +1397,18 @@ configure_rhn_channels()
 {
   if [[ -n "$rhn_reg_actkey" ]]
   then
-    echo "OpenShift: Register to RHN Classic using an activation key"
-    rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register to RHN Classic using an activation key'
+    rhnreg_ks --force "--activationkey=$rhn_reg_actkey" "--profilename=$rhn_profile_name" $rhn_reg_opts || abort_install
   else
     if [[ -n "$rhn_creds_provided" ]]
     then
       set +x # Don't log password.
-      echo "OpenShift: Register to RHN Classic with username and password"
-      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" ${rhn_reg_opts}"
-      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "${rhn_user}" --password "${rhn_pass}" ${rhn_reg_opts} || abort_install
+      echo 'OpenShift: Register to RHN Classic with username and password'
+      echo "rhnreg_ks --force \"--profilename=$rhn_profile_name\" --username \"${rhn_user}\" $rhn_reg_opts"
+      rhnreg_ks --force "--profilename=$rhn_profile_name" --username "$rhn_user" --password "$rhn_pass" $rhn_reg_opts || abort_install
       set -x
     else
-      echo "OpenShift: No credentials given for RHN Classic; assuming already configured"
+      echo 'OpenShift: No credentials given for RHN Classic; assuming already configured'
     fi
   fi
 
@@ -1429,7 +1429,7 @@ configure_rhn_channels()
     set +x # Don't log password.
     local repo
     for repo in "${repos[@]}"
-    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "$rhn_user" --password "$rhn_pass" || abort_install
     done
     set -x
   fi
@@ -1442,20 +1442,20 @@ configure_rhsm_channels()
   if [[ -n "$rhn_creds_provided" ]]
   then
     set +x # Don't log password.
-    echo "OpenShift: Register with RHSM"
-    echo "subscription-manager register --force \"--username=$rhn_user\" --name \"$rhn_profile_name\" ${rhn_reg_opts}"
-    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" ${rhn_reg_opts} || abort_install
+    echo 'OpenShift: Register with RHSM'
+    echo "subscription-manager register --force \"--username=${rhn_user}\" --name \"${rhn_profile_name}\" $rhn_reg_opts"
+    subscription-manager register --force "--username=$rhn_user" "--password=$rhn_pass" --name "$rhn_profile_name" $rhn_reg_opts || abort_install
     set -x
   else
-    echo "OpenShift: No credentials given for RHSM; assuming already configured"
+    echo 'OpenShift: No credentials given for RHSM; assuming already configured'
   fi
 
-  if [[ -n "${sm_reg_pool}" ]]
+  if [[ -n "$sm_reg_pool" ]]
   then
-    echo "OpenShift: Removing all current subscriptions"
+    echo 'OpenShift: Removing all current subscriptions'
     subscription-manager remove --all
   else
-    echo "OpenShift: No pool ids were given, so none are being registered"
+    echo 'OpenShift: No pool ids were given, so none are being registered'
   fi
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
@@ -1468,17 +1468,17 @@ configure_rhsm_channels()
 
   # Enable the node or infrastructure repo to enable installing the release RPM
   if need_node_repo
-  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
-  else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
+  then subscription-manager repos '--enable=rhel-6-server-ose-2.2-node-rpms' || abort_install
+  else subscription-manager repos '--enable=rhel-6-server-ose-2.2-infra-rpms' || abort_install
   fi
   configure_subscription
 }
 
 abort_install()
 {
-  [[ "$#" -ge 1 ]] && echo "$@"
+  [[ "$#" -ge 1 ]] && echo "$*"
   # Don't change this; it is used as an automation cue.
-  echo "OpenShift: Aborting Installation."
+  echo 'OpenShift: Aborting Installation.'
   exit 1
 }
 
@@ -1488,11 +1488,11 @@ yum_install_or_exit()
   local count=0
   time while true
   do
-    yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]
+    yum install -y "$@" $disable_plugin && return
+    if [[ "$count" -gt 3 ]]
     then
       echo "OpenShift: Command failed: yum install $*"
-      echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
+      echo 'OpenShift: Please ensure relevant repos/subscriptions are configured.'
       abort_install
     fi
     let count+=1
@@ -1509,16 +1509,16 @@ install_rhc_pkg()
 configure_rhc()
 {
   # set_conf expects there to be a new line.
-  echo "" >> /etc/openshift/express.conf
+  echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
-  set_conf /etc/openshift/express.conf libra_server "'${broker_hostname}'"
+  set_conf '/etc/openshift/express.conf' libra_server "'${broker_hostname}'"
 }
 
 # Install broker-specific packages.
 install_broker_pkgs()
 {
-  local pkgs="openshift-origin-broker"
+  local pkgs='openshift-origin-broker'
   pkgs="$pkgs openshift-origin-broker-util"
   pkgs="$pkgs rubygem-openshift-origin-msg-broker-mcollective"
   pkgs="$pkgs ruby193-mcollective-client"
@@ -1538,7 +1538,7 @@ install_broker_pkgs()
 # Install node-specific packages.
 install_node_pkgs()
 {
-  local pkgs="rubygem-openshift-origin-node ruby193-rubygem-passenger-native"
+  local pkgs='rubygem-openshift-origin-node ruby193-rubygem-passenger-native'
   pkgs="$pkgs openshift-origin-node-util"
   pkgs="$pkgs ruby193-mcollective openshift-origin-msg-node-mcollective"
 
@@ -1571,7 +1571,7 @@ YUM
       pkgs="$pkgs rubygem-openshift-origin-frontend-apache-vhost"
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -1657,11 +1657,11 @@ parse_cartridges()
   local -a all=( ${p[@]} )
 
   # Set some package groups and aliases to provide shortcuts to the user.
-  p[all]="${all[@]}"
-  p[premium]="${premium[@]}"
-  p[stdframework]="${stdframework[@]}"
-  p[stdaddon]="${stdaddon[@]}"
-  p[standard]="${stdframework[@]} ${stdaddon[@]}"
+  p[all]="${all[*]}"
+  p[premium]="${premium[*]}"
+  p[stdframework]="${stdframework[*]}"
+  p[stdaddon]="${stdaddon[*]}"
+  p[standard]="${stdframework[*]} ${stdaddon[*]}"
   p[jboss]="${p[jbossews]} ${p[jbosseap]}"
   p[postgres]="${p[postgresql]}"
 
@@ -1681,8 +1681,8 @@ parse_cartridges()
       # anything in $p.
       for pkg in ${p[${cart_spec:1}]:-${cart_spec:1}}
       do
-        for k in ${!pkgs[@]}
-        do [[ ${pkgs[$k]} = $pkg ]] && unset "pkgs[$k]"
+        for k in "${!pkgs[@]}"
+        do [[ "${pkgs[$k]}" = "$pkg" ]] && unset "pkgs[$k]"
         done
       done
     else
@@ -1695,12 +1695,12 @@ parse_cartridges()
   if metapkgs_optional || metapkgs_recommended
   then
     local metapkg
-    for metapkg in ${meta[@]}
+    for metapkg in "${meta[@]}"
     do
       if [[ "${pkgs[@]}" =~ "-${metapkg}" ]]
       then
-        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-${metapkg}" )
-        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-${metapkg}" )
+        metapkgs_optional && pkgs+=( "openshift-origin-cartridge-dependencies-optional-$metapkg" )
+        metapkgs_recommended && pkgs+=( "openshift-origin-cartridge-dependencies-recommended-$metapkg" )
       fi
     done
   fi
@@ -1708,13 +1708,13 @@ parse_cartridges()
   # Set need_<cart>=1 if $pkgs includes the relevant cartridge,
   # need_<cart>=0 otherwise, so that configure_repos will enable
   # only the appropriate channels.
-  need_jbosseap=0; [[ "${pkgs[@]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
-  need_jbossews=0; [[ "${pkgs[@]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
+  need_jbosseap=0; [[ "${pkgs[*]}" = *"${p[jbosseap]}"* ]] && need_jbosseap=1
+  need_jbossews=0; [[ "${pkgs[*]}" = *"${p[jbossews]}"* ]] && need_jbossews=1
     # fuse is "special" because there's also a fuse-builder cart that can be used with
     # either fuse or amq and doesn't necessarily imply either. It comes from either of
     # those two channels; assume if desired they will have one of those channels already.
-  need_fuse=0;     [[ "${pkgs[@]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
-  need_amq=0;      [[ "${pkgs[@]}" = *"${p[amq]}"* ]] && need_amq=1
+  need_fuse=0;     [[ "${pkgs[*]}" =~ openshift-origin-cartridge-fuse( |$) ]] && need_fuse=1
+  need_amq=0;      [[ "${pkgs[*]}" = *"${p[amq]}"* ]] && need_amq=1
 
   # Uniquify (and, as a side effect, sort) pkgs and assign the result to
   # install_cart_pkgs for install_cartridges to use.
@@ -1733,7 +1733,7 @@ install_cartridges()
   # still install as much as possible.
   #install_cart_pkgs="${install_cart_pkgs} --skip-broken"
 
-  yum_install_or_exit "${install_cart_pkgs}"
+  yum_install_or_exit $install_cart_pkgs
 }
 
 # Given the filename of a configuration file, the name of a setting,
@@ -1806,9 +1806,9 @@ configure_selinux_policy_on_broker()
   fixfiles -R ruby193-rubygem-passenger restore
   fixfiles -R ruby193-mod_passenger restore
 
-  restorecon -rv /var/run
+  restorecon -rv '/var/run'
   # This should cover everything in the SCL, including passenger
-  time restorecon -rv /opt
+  time restorecon -rv '/opt'
 }
 
 # Fix up SELinux policy on the node.
@@ -1844,31 +1844,31 @@ configure_selinux_policy_on_node()
   ) | semanage -i -
 
 
-  restorecon -rv /var/run
-  time restorecon -rv /var/lib/openshift /etc/httpd/conf.d/openshift
+  restorecon -rv '/var/run'
+  time restorecon -rv '/var/lib/openshift' '/etc/httpd/conf.d/openshift'
   # disallow gear users from seeing what other gears exist
-  chmod 0751 /var/lib/openshift
+  chmod 0751 '/var/lib/openshift'
 }
 
 configure_pam_on_node()
 {
-  sed -i -e 's|pam_selinux|pam_openshift|g' /etc/pam.d/sshd
+  sed -i -e 's|pam_selinux|pam_openshift|g' '/etc/pam.d/sshd'
 
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "su" "system-auth-ac"
+  for f in runuser runuser-l sshd su system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_namespace.so" "$t"
+    if ! grep -q 'pam_namespace.so' "$t"
     then
       # We add two rules.  The first checks whether the user's shell is
       # /usr/bin/oo-trap-user, which indicates that this is a gear user,
       # and skips the second rule if it is not.
-      echo -e "session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user" >> "$t"
+      echo -e 'session\t\t[default=1 success=ignore]\tpam_succeed_if.so quiet shell = /usr/bin/oo-trap-user' >> "$t"
 
       # The second rule enables polyinstantiation so that the user gets
       # private /tmp and /dev/shm directories.
-      echo -e "session\t\trequired\tpam_namespace.so no_unmount_on_close" >> "$t"
+      echo -e 'session\t\trequired\tpam_namespace.so no_unmount_on_close' >> "$t"
     fi
   done
 
@@ -1876,27 +1876,27 @@ configure_pam_on_node()
   # /dev/shm directories.  Above, we only enable pam_namespace for
   # OpenShift users, but to be safe, blacklist the root and adm users
   # to be sure we don't polyinstantiate their directories.
-  echo "/tmp        \$HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/tmp.conf
-  echo "/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm" > /etc/security/namespace.d/shm.conf
+  echo '/tmp        $HOME/.tmp/      user:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/tmp.conf
+  echo '/dev/shm  tmpfs  tmpfs:mntopts=size=5M:iscript=/usr/sbin/oo-namespace-init root,adm' > /etc/security/namespace.d/shm.conf
 }
 
 configure_cgroups_on_node()
 {
   local t
   local f
-  for f in "runuser" "runuser-l" "sshd" "system-auth-ac"
+  for f in runuser runuser-l sshd system-auth-ac
   do
     t="/etc/pam.d/$f"
-    if ! grep -q "pam_cgroup" "$t"
+    if ! grep -q 'pam_cgroup' "$t"
     then
-      echo -e "session\t\toptional\tpam_cgroup.so" >> "$t"
+      echo -e 'session\t\toptional\tpam_cgroup.so' >> "$t"
     fi
   done
 
-  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf /etc/cgconfig.conf
-  restorecon -rv /etc/cgconfig.conf
-  mkdir -p /cgroup
-  restorecon -rv /cgroup
+  cp -vf /opt/rh/ruby193/root/usr/share/gems/doc/openshift-origin-node-*/cgconfig.conf '/etc/cgconfig.conf'
+  restorecon -rv '/etc/cgconfig.conf'
+  mkdir -p '/cgroup'
+  restorecon -rv '/cgroup'
   chkconfig cgconfig on
   chkconfig cgred on
 }
@@ -1904,45 +1904,45 @@ configure_cgroups_on_node()
 configure_quotas_on_node()
 {
   # Get the mountpoint for /var/lib/openshift (should be /).
-  local geardata_mnt=$(df -P /var/lib/openshift 2>/dev/null | tail -n 1 | awk '{ print $6 }')
+  local geardata_mnt=$(df -P '/var/lib/openshift' 2>/dev/null | tail -n 1 | awk '{ print $6 }')
 
   if [[ -z "$geardata_mnt" ]]
   then
     echo 'Could not enable quotas for gear data: unable to determine mountpoint.'
   else
     # Enable user quotas for the filesystem housing /var/lib/openshift.
-    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" /etc/fstab
+    sed -i -e "/^[^[:blank:]]\\+[[:blank:]]\\+${geardata_mnt////\/}[[:blank:]]/{/usrquota/! s/[[:blank:]]\\+/,usrquota&/4;}" '/etc/fstab'
     # Remount to enable quotas immediately.
-    mount -o remount "${geardata_mnt}"
+    mount -o remount "$geardata_mnt"
 
     # External mounts, esp. at /var/lib/openshift, may often be created
     # with an incorrect context and quotacheck hits SElinux denials.
-    time restorecon "${geardata_mnt}"
+    time restorecon "$geardata_mnt"
 
     # quotacheck fails if quotas are enabled.
-    quotaoff "${geardata_mnt}"
+    quotaoff "$geardata_mnt"
 
     # Generate user quota info for the mount point.
-    time quotacheck -cmug "${geardata_mnt}"
+    time quotacheck -cmug "$geardata_mnt"
 
     # Fix the SELinux label of the created quota file.
-    restorecon "${geardata_mnt}"/aquota.user
+    restorecon "${geardata_mnt}/aquota.user"
 
     # (Re)enable quotas.
-    time quotaon "${geardata_mnt}"
+    time quotaon "$geardata_mnt"
   fi
 }
 
 configure_idler_on_node()
 {
   [[ "$idle_interval" =~ ^[[:digit:]]+$ ]] || return 0
-  cat <<CRON > /etc/cron.hourly/auto-idler
+  cat <<CRON > '/etc/cron.hourly/auto-idler'
 (
   /usr/sbin/oo-last-access
-  /usr/sbin/oo-auto-idler idle --interval $idle_interval
-) >> /var/log/openshift/node/auto-idler.log 2>&1
+  /usr/sbin/oo-auto-idler idle --interval "$idle_interval"
+) >> '/var/log/openshift/node/auto-idler.log' 2>&1
 CRON
-  chmod +x /etc/cron.hourly/auto-idler
+  chmod +x '/etc/cron.hourly/auto-idler'
 }
 
 # $1 = setting name
@@ -1950,25 +1950,25 @@ CRON
 # $3 = long comment
 set_sysctl()
 {
-  set_conf /etc/sysctl.conf "$1" "$2" '' "$3"
+  set_conf '/etc/sysctl.conf' "$1" "$2" '' "$3"
 }
 
 # Turn some sysctl knobs.
 configure_sysctl_on_node()
 {
-  set_sysctl kernel.sem '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
+  set_sysctl 'kernel.sem' '250  32000 32  4096' 'Accomodate many httpd instances for OpenShift gears.'
 
-  set_sysctl net.ipv4.ip_local_port_range '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_local_port_range' '15000 35530' 'Move the ephemeral port range to accomodate the OpenShift port proxy.'
 
-  set_sysctl net.netfilter.nf_conntrack_max 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
+  set_sysctl 'net.netfilter.nf_conntrack_max' 1048576 'Increase the connection tracking table size for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.ip_forward 1 'Enable forwarding for the OpenShift port proxy.'
+  set_sysctl 'net.ipv4.ip_forward' 1 'Enable forwarding for the OpenShift port proxy.'
 
-  set_sysctl net.ipv4.conf.all.route_localnet 1 'Allow the OpenShift port proxy to route using loopback addresses.'
+  set_sysctl 'net.ipv4.conf.all.route_localnet' 1 'Allow the OpenShift port proxy to route using loopback addresses.'
 
   # As recommended elsewhere and investigated at length in https://bugzilla.redhat.com/show_bug.cgi?id=1085115
   # this is a safe, effective way to keep lots of short requests from exhausting the connection table.
-  set_sysctl net.ipv4.tcp_tw_reuse 1 'Reuse closed connections quickly.' 
+  set_sysctl 'net.ipv4.tcp_tw_reuse' 1 'Reuse closed connections quickly.'
 }
 
 
@@ -1977,11 +1977,11 @@ configure_sshd_on_node()
   # Configure sshd to pass the GIT_SSH environment variable through.
   # The newline is needed because cloud-init doesn't add a newline after the
   # configuration it adds.
-  printf '\nAcceptEnv GIT_SSH' >> /etc/ssh/sshd_config
+  printf '\nAcceptEnv GIT_SSH' >> '/etc/ssh/sshd_config'
 
   # Up the limits on the number of connections to a given node.
-  sed -i -e "s/^#MaxSessions .*$/MaxSessions 40/" /etc/ssh/sshd_config
-  sed -i -e "s/^#MaxStartups .*$/MaxStartups 40/" /etc/ssh/sshd_config
+  sed -i -e 's/^#MaxSessions .*$/MaxSessions 40/' '/etc/ssh/sshd_config'
+  sed -i -e 's/^#MaxStartups .*$/MaxStartups 40/' '/etc/ssh/sshd_config'
 
   RESTART_NEEDED=true
 }
@@ -2012,14 +2012,14 @@ wait_for_mongod()
 # $4 = password (optional)
 execute_mongodb()
 {
-  echo "Running commands on MongoDB:"
-  echo "---"
+  echo 'Running commands on MongoDB:'
+  echo '---'
   echo "$1"
-  echo "---"
+  echo '---'
 
   local userpass=
   if [[ -n "${3+x}" && -n "${4+x}" ]]
-  then userpass="-u ${3} -p ${4} admin"
+  then userpass="-u $3 -p $4 admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
@@ -2039,7 +2039,7 @@ configure_datastore_add_users()
   wait_for_mongod
 
   time execute_mongodb "$(
-    if [[ ${datastore_replicants} =~ , ]]
+    if [[ "$datastore_replicants" =~ , ]]
     then
       echo 'while (rs.isMaster().primary == null) { sleep(5); }'
     fi
@@ -2052,7 +2052,7 @@ configure_datastore_add_users()
     fi
 
     # Add the user that the broker will use.
-    echo "use ${mongodb_name}"
+    echo "use $mongodb_name"
     echo "db.addUser('${mongodb_broker_user}', '${mongodb_broker_password}')"
   )"
   set -x
@@ -2069,10 +2069,10 @@ configure_datastore_add_replicants()
 
   # initiate the replica set with just this host
   time execute_mongodb 'rs.initiate()' '"ok" : 1' ||
-    abort_install "OpenShift: Failed to form MongoDB replica set; please do this manually."
+    abort_install 'OpenShift: Failed to form MongoDB replica set; please do this manually.'
 
   local master_out="$(echo 'while (rs.isMaster().primary == null) { sleep(5); }; print("host="+rs.isMaster().primary)' | mongo | grep 'host=')" ||
-    abort_install "OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually."
+    abort_install 'OpenShift: Failed to query the MongoDB replica set master; please verify the replica set configuration manually.'
 
   configure_datastore_add_users
 
@@ -2090,15 +2090,15 @@ configure_datastore_add_replicants()
       for i in {1..10}
       do
         echo "Attempting to connect to ${replicant}..."
-        if echo "" | mongo $replicant
+        if echo | mongo "$replicant"
         then
           break
         fi
         sleep 60
       done
 
-      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' ${mongodb_admin_user} ${mongodb_admin_password} ||
-        abort_install "OpenShift: Failed to add ${replicant} to replica set; please verify the replica set manually"
+      time execute_mongodb "rs.add(\"${replicant}\")" '"ok" : 1' "$mongodb_admin_user" "$mongodb_admin_password" ||
+        abort_install "OpenShift: Failed to add $replicant to replica set; please verify the replica set manually"
     fi
   done
 
@@ -2117,7 +2117,7 @@ configure_datastore()
   # Use a smaller default size for databases.
   set_mongodb smallfiles true
 
-  if [[ ${datastore_replicants} =~ , ]]
+  if [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will be part of a replicated setup.
 
@@ -2128,21 +2128,21 @@ configure_datastore()
     set_mongodb journal true
 
     # Enable replication.
-    set_mongodb replSet "${mongodb_replset}"
+    set_mongodb replSet "$mongodb_replset"
 
     # Configure a key for the replica set.
-    set_mongodb keyFile /etc/mongodb.keyfile
+    set_mongodb keyFile '/etc/mongodb.keyfile'
 
-    rm -f /etc/mongodb.keyfile
-    echo "${mongodb_key}" > /etc/mongodb.keyfile
-    chown -v mongodb.mongodb /etc/mongodb.keyfile
-    chmod -v 400 /etc/mongodb.keyfile
+    rm -f '/etc/mongodb.keyfile'
+    echo "$mongodb_key" > '/etc/mongodb.keyfile'
+    chown -v 'mongodb.mongodb' '/etc/mongodb.keyfile'
+    chmod -v 400 '/etc/mongodb.keyfile'
   fi
 
   # If mongod is running on a separate host from the broker OR
   # we are configuring a replica set, open up the firewall to allow
   # other broker or datastore hosts to connect.
-  if broker && ! [[ ${datastore_replicants} =~ , ]]
+  if broker && ! [[ "$datastore_replicants" =~ , ]]
   then
     echo 'The broker and data store are on the same host.'
     echo 'Skipping firewall and mongod configuration;'
@@ -2151,10 +2151,10 @@ configure_datastore()
     echo 'The data store needs to be accessible externally.'
 
     echo 'Configuring the firewall to allow connections to mongod...'
-    firewall_allow[mongodb]=tcp:27017
+    firewall_allow[mongodb]='tcp:27017'
 
     echo 'Configuring mongod to listen on all interfaces...'
-    set_mongodb bind_ip 0.0.0.0
+    set_mongodb bind_ip '0.0.0.0'
   fi
 
   # Configure mongod to start on boot.
@@ -2163,7 +2163,7 @@ configure_datastore()
   # Start mongod so we can perform some administration now.
   service mongod start
 
-  if ! [[ ${datastore_replicants} =~ , ]]
+  if ! [[ "$datastore_replicants" =~ , ]]
   then
     # This mongod will _not_ be part of a replicated setup.
     configure_datastore_add_users
@@ -2180,9 +2180,9 @@ configure_port_proxy()
 {
   chkconfig openshift-iptables-port-proxy on
   sed -i '/:OUTPUT ACCEPT \[.*\]/a \
-:rhc-app-comm - [0:0]' /etc/sysconfig/iptables
+:rhc-app-comm - [0:0]' '/etc/sysconfig/iptables'
   sed -i '/-A INPUT -i lo -j ACCEPT/a \
--A INPUT -j rhc-app-comm' /etc/sysconfig/iptables
+-A INPUT -j rhc-app-comm' '/etc/sysconfig/iptables'
 }
 
 configure_gears()
@@ -2197,7 +2197,7 @@ configure_gears()
     sed -i -e '
       /outputtype\b/I coutputType = syslog
       /outputtypefromenviron/I coutputTypeFromEnviron = true
-    ' /etc/openshift/logshifter.conf
+    ' '/etc/openshift/logshifter.conf'
     # use rsyslog7 so we can annotate
     # disable some of the stock options shipped
     sed -i -e '
@@ -2206,9 +2206,9 @@ configure_gears()
       /ModLoad imjournal/ s/^/#/    # imjournal module is not even available...
       /IMJournalStateFile/ s/^/#/
       /OmitLocalLogging/ s/^/#/
-    ' /etc/rsyslog.conf
+    ' '/etc/rsyslog.conf'
     # enable custom log format via imuxsock
-    cat <<'LOGCONF' >> /etc/rsyslog.d/imuxsock-and-openshift-gears.conf
+    cat <<'LOGCONF' >> '/etc/rsyslog.d/imuxsock-and-openshift-gears.conf'
 # load the modules as necessary for gear logs to be annotated
 module(load="imuxsock" SysSock.Annotate="on" SysSock.ParseTrusted="on" SysSock.UsePIDFromSystem="on")
 module(load="mmopenshift")
@@ -2251,12 +2251,12 @@ LOGCONF
 # Enable services to start on boot for the node.
 enable_services_on_node()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   # Allow connections to openshift-node-web-proxy
-  firewall_allow[ws]=tcp:8000
-  firewall_allow[wss]=tcp:8443
+  firewall_allow[ws]='tcp:8000'
+  firewall_allow[wss]='tcp:8443'
 
   # Allow connections to openshift-sni-proxy
   if is_true "$enable_sni_proxy"
@@ -2280,8 +2280,8 @@ enable_services_on_node()
 # Enable services to start on boot for the broker and fix up some issues.
 enable_services_on_broker()
 {
-  firewall_allow[https]=tcp:443
-  firewall_allow[http]=tcp:80
+  firewall_allow[https]='tcp:443'
+  firewall_allow[http]='tcp:80'
 
   chkconfig httpd on
   chkconfig network on
@@ -2299,10 +2299,10 @@ generate_mcollective_pools_configuration()
   for replicant in ${activemq_replicants//,/ }
   do
     let num_replicants=num_replicants+1
-    new_member="plugin.activemq.pool.${num_replicants}.host = ${replicant}
+    new_member="plugin.activemq.pool.${num_replicants}.host = $replicant
 plugin.activemq.pool.${num_replicants}.port = 61613
-plugin.activemq.pool.${num_replicants}.user = ${mcollective_user}
-plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
+plugin.activemq.pool.${num_replicants}.user = $mcollective_user
+plugin.activemq.pool.${num_replicants}.password = $mcollective_password
 "
     members="${members}${new_member}"
   done
@@ -2317,8 +2317,8 @@ plugin.activemq.pool.${num_replicants}.password = ${mcollective_password}
 # https://bugzilla.redhat.com/show_bug.cgi?id=963332
 configure_mcollective_for_activemq_on_broker()
 {
-  local mcollective_cfg="/opt/rh/ruby193/root/etc/mcollective/client.cfg"
-  cat <<EOF > $mcollective_cfg
+  local mcollective_cfg='/opt/rh/ruby193/root/etc/mcollective/client.cfg'
+  cat <<EOF > "$mcollective_cfg"
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2347,13 +2347,13 @@ plugin.yaml = /opt/rh/ruby193/root/etc/mcollective/facts.yaml
 
 EOF
 
-  chown apache:apache $mcollective_cfg
-  chmod 640 $mcollective_cfg
+  chown 'apache:apache' "$mcollective_cfg"
+  chmod 640 "$mcollective_cfg"
 
   # Make sure the MCollective client log is created with proper ownership.
   # If root owns it, the broker (apache user) can't log to it.
-  touch /var/log/openshift/broker/ruby193-mcollective-client.log
-  chown apache:root /var/log/openshift/broker/ruby193-mcollective-client.log
+  touch '/var/log/openshift/broker/ruby193-mcollective-client.log'
+  chown 'apache:root' '/var/log/openshift/broker/ruby193-mcollective-client.log'
 
   RESTART_NEEDED=true
 }
@@ -2362,7 +2362,7 @@ EOF
 # Configure mcollective on the node to use ActiveMQ.
 configure_mcollective_for_activemq_on_node()
 {
-  cat <<EOF > /opt/rh/ruby193/root/etc/mcollective/server.cfg
+  cat <<EOF > '/opt/rh/ruby193/root/etc/mcollective/server.cfg'
 main_collective = mcollective
 collectives = mcollective
 libdir = /opt/rh/ruby193/root/usr/libexec/mcollective
@@ -2443,7 +2443,7 @@ configure_activemq()
   networkConnectors="${networkConnectors:+$networkConnectors    </networkConnectors>$'\n'}"
 
   local schedulerSupport= routingPolicy=
-  if is_true "${enable_routing_plugin}"
+  if is_true "$enable_routing_plugin"
   then
     schedulerSupport='schedulerSupport="true"'
     IFS= read -r -d '' routingPolicy <<'EOF' || :
@@ -2563,10 +2563,10 @@ $networkConnectors
           <simpleAuthenticationPlugin>
              <users>
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
-               ${authenticationUser_amq}
+               $authenticationUser_amq
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
                $( if is_true "$enable_routing_plugin"
-                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+                  then echo "<authenticationUser username=\"${routing_plugin_user}\" password=\"${routing_plugin_pass}\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -2590,7 +2590,7 @@ $networkConnectors
               </authorizationMap>
             </map>
           </authorizationPlugin>
-${routingPolicy}
+$routingPolicy
         </plugins>
 
           <!--
@@ -2658,8 +2658,8 @@ ${routingPolicy}
 EOF
 
   # Allow connections to ActiveMQ.
-  firewall_allow[stomp]=tcp:61613
-  allow_openwire && firewall_allow[openwire]=tcp:61616
+  firewall_allow[stomp]='tcp:61613'
+  allow_openwire && firewall_allow[openwire]='tcp:61616'
 
   # Configure ActiveMQ to start on boot.
   chkconfig activemq on
@@ -2675,18 +2675,18 @@ install_named_pkgs()
 configure_named()
 {
   # Ensure we have a key for service named status to communicate with BIND.
-  rndc-confgen -a -r /dev/urandom
+  rndc-confgen -a -r '/dev/urandom'
   restorecon /etc/rndc.* /etc/named.*
-  chown root:named /etc/rndc.key
-  chmod 640 /etc/rndc.key
+  chown 'root:named' '/etc/rndc.key'
+  chmod 640 '/etc/rndc.key'
 
   # Set up DNS forwarding if so directed.
-  local forwarders="recursion no;"
+  local forwarders='recursion no;'
   if is_true "$enable_dns_forwarding"
   then
-    echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
-    restorecon /var/named/forwarders.conf
-    chmod 644 /var/named/forwarders.conf
+    echo "forwarders { ${nameservers} } ;" > '/var/named/forwarders.conf'
+    restorecon '/var/named/forwarders.conf'
+    chmod 644 '/var/named/forwarders.conf'
     forwarders='// set forwarding to the next nearest server (from DHCP response)
 	forward only;
         include "forwarders.conf";
@@ -2696,15 +2696,15 @@ configure_named()
 
   # Install the configuration file for the OpenShift Enterprise domain
   # name.
-  rm -rf /var/named/dynamic
-  mkdir -p /var/named/dynamic
+  rm -rf '/var/named/dynamic'
+  mkdir -p '/var/named/dynamic'
 
-  chgrp named -R /var/named
-  chown named -R /var/named/dynamic
-  restorecon -rv /var/named
+  chgrp named -R '/var/named'
+  chown named -R '/var/named/dynamic'
+  restorecon -rv '/var/named'
 
   # Replace named.conf.
-  cat <<EOF > /etc/named.conf
+  cat <<EOF > '/etc/named.conf'
 // named.conf
 //
 // Provided by Red Hat bind package to configure the ISC BIND named(8) DNS
@@ -2745,8 +2745,8 @@ controls {
 
 include "/etc/named.rfc1912.zones";
 EOF
-  chown root:named /etc/named.conf
-  chcon system_u:object_r:named_conf_t:s0 -v /etc/named.conf
+  chown 'root:named' '/etc/named.conf'
+  chcon 'system_u:object_r:named_conf_t:s0' -v '/etc/named.conf'
 
   # actually set up the domain zone(s)
   # bind_key is used if set, created if not. both domains use same key.
@@ -2757,7 +2757,7 @@ EOF
   configure_hosts_dns
 
   # Configure named to start on boot.
-  firewall_allow[dns]=tcp:53,udp:53
+  firewall_allow[dns]='tcp:53,udp:53'
   chkconfig named on
 
   # Start named so we can perform some updates immediately.
@@ -2772,46 +2772,46 @@ configure_named_zone()
   then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
-    rm -f /var/named/K${zone_tolower}*
-    dnssec-keygen -a ${bind_keyalgorithm} -b ${bind_keysize} -n USER -r /dev/urandom -K /var/named ${zone}
+    rm -f "/var/named/K${zone_tolower}"*
+    dnssec-keygen -a "$bind_keyalgorithm" -b "$bind_keysize" -n USER -r '/dev/urandom' -K '/var/named' "$zone"
     # $zone may have uppercase letters in it.  However the file that
     # dnssec-keygen creates will have the zone in lowercase.
-    bind_key="$(grep Key: /var/named/K${zone_tolower}*.private | cut -d ' ' -f 2)"
-    rm -f /var/named/K${zone_tolower}*
+    bind_key="$(grep 'Key:' "/var/named/K${zone_tolower}"*.private | cut -d ' ' -f 2)"
+    rm -f "/var/named/K${zone_tolower}"*
   fi
 
   # Install the key where BIND and oo-register-dns expect it.
-  cat <<EOF > /var/named/${zone}.key
-key ${zone} {
+  cat <<EOF > "/var/named/${zone}.key"
+key $zone {
   algorithm "${bind_keyalgorithm}";
   secret "${bind_key}";
 };
 EOF
 
   # Create the initial BIND database.
-  cat <<EOF > /var/named/dynamic/${zone}.db
+  cat <<EOF > "/var/named/dynamic/${zone}.db"
 \$ORIGIN .
 \$TTL 1	; 1 seconds (for testing only)
-${zone}		IN SOA	$named_hostname. hostmaster.$zone. (
+${zone}		IN SOA	${named_hostname}. hostmaster.${zone}. (
 				2011112904 ; serial
 				60         ; refresh (1 minute)
 				15         ; retry (15 seconds)
 				1800       ; expire (30 minutes)
 				10         ; minimum (10 seconds)
 				)
-				IN NS	$named_hostname.
-				IN MX	10 mail.$zone.
+				IN NS	${named_hostname}.
+				IN MX	10 mail.${zone}.
 \$ORIGIN ${zone}.
 EOF
 
   # Add a record for the zone to named conf
-  cat <<EOF >> /etc/named.conf
+  cat <<EOF >> '/etc/named.conf'
 include "${zone}.key";
 
 zone "${zone}" IN {
 	type master;
 	file "dynamic/${zone}.db";
-	allow-update { key ${zone} ; } ;
+	allow-update { key $zone ; } ;
 };
 EOF
 }
@@ -2821,7 +2821,7 @@ EOF
 # $2 = domain
 ensure_domain()
 {
-  if [[ $1 = *.* ]]
+  if [[ "$1" = *.* ]]
   then # $1 is already a FQDN or IP address.
     echo "$1"
   else # $1 needs a domain appended.
@@ -2839,9 +2839,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  if [[ "$1" =~ $ip_regex || ! "$2" =~ $ip_regex ]]
   then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  else echo "${1%.${zone}}			IN A	$2" >> "$nsdb"
   fi
 }
 
@@ -2880,23 +2880,23 @@ register_named_entries()
 {
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  local failed="false"
+  local failed=false
   local host_ip
   local host
   local ip
   for host_ip in ${named_entries//,/ }
   do
-    read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    read host ip <<<"${host_ip//:/ }"
+    if [[ "$host" =~ $ip_regex || ! "$ip" =~ $ip_regex ]]
     then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "$hosts_domain_keyfile" -n "$ip"
     then
       echo "WARNING: Failed to register host $host with IP $ip"
-      failed="true"
+      failed=true
     fi
   done
-  is_false "$failed" && echo "OpenShift: Completed updating host DNS entries."
+  "$failed" && echo 'OpenShift: Completed updating host DNS entries.'
   return 0
 }
 
@@ -2906,7 +2906,7 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  if grep -q IPADDR "/etc/sysconfig/network-scripts/ifcfg-$interface"
   then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
@@ -2924,12 +2924,12 @@ configure_dns_resolution()
   # will resolve public addresses even when our private named is
   # nonfunctional.  However, our private named must appear first in
   # order for hostnames private to our OpenShift PaaS to resolve.
-  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" /etc/resolv.conf
+  sed -i -e "/search/ d; 1i# The named we install for our OpenShift PaaS must appear first.\\nsearch ${hosts_domain}.\\nnameserver ${named_ip_addr}\\n" '/etc/resolv.conf'
 
   # Append resolution conf to the DHCP configuration.
-  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" /etc/dhcp/dhclient-$interface.conf
-  sed -i -e "/prepend domain-search ${hosts_domain};/d" /etc/dhcp/dhclient-$interface.conf
-  cat <<EOF >> /etc/dhcp/dhclient-$interface.conf
+  sed -i -e "/prepend domain-name-servers ${named_ip_addr};/d" "/etc/dhcp/dhclient-$interface.conf"
+  sed -i -e "/prepend domain-search ${hosts_domain};/d" "/etc/dhcp/dhclient-$interface.conf"
+  cat <<EOF >> "/etc/dhcp/dhclient-$interface.conf"
 
 prepend domain-name-servers ${named_ip_addr};
 prepend domain-search "${hosts_domain}";
@@ -2952,7 +2952,7 @@ configure_controller()
 {
   if [[ -z "$broker_auth_salt" ]]
   then
-    echo "Warning: broker authentication salt is empty!"
+    echo 'Warning: broker authentication salt is empty!'
   fi
 
   # Configure the broker with the correct domain name, and use random salt
@@ -2968,7 +2968,7 @@ configure_controller()
   # Configure the session secret for the console
   set_console SESSION_SECRET "$console_session_secret"
 
-  if [[ ${datastore_replicants} =~ , ]] || ! datastore
+  if [[ "$datastore_replicants" =~ , ]] || ! datastore
   then
     # MongoDB may be installed remotely or replicated, so configure it
     # with the given hostname(s).
@@ -2987,8 +2987,8 @@ configure_controller()
     set_console SYSLOG_ENABLED true
 
   # Set the ServerName for httpd
-  sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
-      /etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf
+  sed -i -e "s/ServerName .*\$/ServerName ${hostname}/" \
+      '/etc/httpd/conf.d/000002_openshift_origin_broker_servername.conf'
 
   # Configure the broker service to start on boot.
   chkconfig openshift-broker on
@@ -3004,7 +3004,7 @@ configure_messaging_plugin()
   local pool_size=6000
   let "pool_size=30000/$ports"
 
-  local file=/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf
+  local file='/etc/openshift/plugins.d/openshift-origin-msg-broker-mcollective.conf'
   cp "$file"{.example,}
   set_conf "$file" DISTRICTS_FIRST_UID "$district_first_uid"
   set_conf "$file" DISTRICTS_MAX_CAPACITY "$pool_size"
@@ -3022,21 +3022,21 @@ configure_dns_plugin()
     echo 'after installation.'
   fi
 
-  mkdir -p /etc/openshift/plugins.d
-  cat <<EOF > /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+  mkdir -p '/etc/openshift/plugins.d'
+  cat <<EOF > '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_SERVER="${named_ip_addr}"
 BIND_PORT=53
 BIND_ZONE="${domain}"
 EOF
   if [[ -z "$bind_krb_keytab" ]]
   then
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KEYNAME="${domain}"
 BIND_KEYVALUE="${bind_key}"
 BIND_KEYALGORITHM="${bind_keyalgorithm}"
 EOF
   else
-    cat <<EOF >> /etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf
+    cat <<EOF >> '/etc/openshift/plugins.d/openshift-origin-dns-nsupdate.conf'
 BIND_KRB_PRINCIPAL="${bind_krb_principal}"
 BIND_KRB_KEYTAB="${bind_krb_keytab}"
 EOF
@@ -3049,7 +3049,7 @@ EOF
 configure_httpd_auth()
 {
   # Configure the broker to use the remote-user authentication plugin.
-  cp -p /etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf{.example,}
+  cp -p '/etc/openshift/plugins.d/openshift-origin-auth-remote-user.conf'{.example,}
 
   # Configure mod_auth_kerb if both CONF_BROKER_KRB_SERVICE_NAME
   # and CONF_BROKER_KRB_AUTH_REALMS are specified
@@ -3057,27 +3057,28 @@ configure_httpd_auth()
   then
     yum_install_or_exit mod_auth_kerb
     local d
-    for d in /var/www/openshift/broker/httpd/conf.d /var/www/openshift/console/httpd/conf.d
+    for d in '/var/www/openshift/broker/httpd/conf.d' '/var/www/openshift/console/httpd/conf.d'
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
-        -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	$d/openshift-origin-auth-remote-user-kerberos.conf.sample > $d/openshift-origin-auth-remote-user-kerberos.conf
+          -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
+	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return
   fi
 
   # Install the Apache Basic Authentication configuration file.
-  cp -p /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/broker/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
-  cp -p /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample \
-     /var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf
+  cp -p '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user-basic.conf.sample' \
+     '/var/www/openshift/console/httpd/conf.d/openshift-origin-auth-remote-user.conf'
 
   # The above configuration file configures Apache to use
   # /etc/openshift/htpasswd for its password file.
   #
   # Here we create a test user:
-  htpasswd -bc /etc/openshift/htpasswd "$openshift_user1" "$openshift_password1"
+  htpasswd -bc '/etc/openshift/htpasswd' "$openshift_user1" "$openshift_password1"
   #
   # Use the following command to add more users:
   #
@@ -3094,12 +3095,12 @@ configure_routing_plugin()
 {
   if is_true "$enable_routing_plugin"
   then
-    local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
-    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
+    local conffile='/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf'
+    sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' "${conffile}.example" > "$conffile"
     cat <<EOF >> "$conffile"
-ACTIVEMQ_HOST='$activemq_replicants'
-ACTIVEMQ_USERNAME='$routing_plugin_user'
-ACTIVEMQ_PASSWORD='$routing_plugin_pass'
+ACTIVEMQ_HOST='${activemq_replicants}'
+ACTIVEMQ_USERNAME='${routing_plugin_user}'
+ACTIVEMQ_PASSWORD='${routing_plugin_pass}'
 EOF
     RESTART_NEEDED=true
   fi
@@ -3118,7 +3119,7 @@ fix_broker_routing()
       ;;
     mod_rewrite)
       # node vhost obscures the broker vhost still, but can let specific requests past
-      cat <<EOF >> /var/lib/openshift/.httpd.d/nodes.txt
+      cat <<EOF >> '/var/lib/openshift/.httpd.d/nodes.txt'
 __default__ REDIRECT:/console
 __default__/rsync_id_rsa.pub NOPROXY
 __default__/console TOHTTPS:127.0.0.1:8118/console
@@ -3127,12 +3128,12 @@ __default__/admin-console TOHTTPS:127.0.0.1:8080/admin-console
 __default__/assets TOHTTPS:127.0.0.1:8080/assets
 EOF
 
-      httxt2dbm -f DB -i /etc/httpd/conf.d/openshift/nodes.txt -o /etc/httpd/conf.d/openshift/nodes.db
-      chown root:apache /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
-      chmod 750 /etc/httpd/conf.d/openshift/nodes.txt /etc/httpd/conf.d/openshift/nodes.db
+      httxt2dbm -f DB -i '/etc/httpd/conf.d/openshift/nodes.txt' -o '/etc/httpd/conf.d/openshift/nodes.db'
+      chown 'root:apache' '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
+      chmod 750 '/etc/httpd/conf.d/openshift/nodes.txt' '/etc/httpd/conf.d/openshift/nodes.db'
       ;;
     *)
-      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=${node_apache_frontend}"
+      echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
       ;;
   esac
@@ -3142,21 +3143,21 @@ configure_access_keys_on_broker()
 {
   # Generate a broker access key for remote apps (Jenkins) to access
   # the broker.
-  echo "${broker_auth_priv_key}" > /etc/openshift/server_priv.pem
-  openssl rsa -in /etc/openshift/server_priv.pem -pubout > /etc/openshift/server_pub.pem
-  chown apache:apache /etc/openshift/server_pub.pem
-  chmod 640 /etc/openshift/server_pub.pem
+  echo "$broker_auth_priv_key" > '/etc/openshift/server_priv.pem'
+  openssl rsa -in '/etc/openshift/server_priv.pem' -pubout > '/etc/openshift/server_pub.pem'
+  chown 'apache:apache' '/etc/openshift/server_pub.pem'
+  chmod 640 '/etc/openshift/server_pub.pem'
 
   # If a key pair already exists, delete it so that the ssh-keygen
   # command will not have to ask the user what to do.
-  rm -f /root/.ssh/rsync_id_rsa /root/.ssh/rsync_id_rsa.pub
+  rm -f '/root/.ssh/rsync_id_rsa' '/root/.ssh/rsync_id_rsa.pub'
 
   # Generate a key pair for moving gears between nodes from the broker.
-  ssh-keygen -t rsa -b 2048 -P "" -f /root/.ssh/rsync_id_rsa
+  ssh-keygen -t rsa -b 2048 -P '' -f '/root/.ssh/rsync_id_rsa'
   cp /root/.ssh/rsync_id_rsa* /etc/openshift/
   # the .pub key needs to go on nodes. So, we provide it via a standard
   # location on httpd:
-  cp /root/.ssh/rsync_id_rsa.pub /var/www/html/
+  cp '/root/.ssh/rsync_id_rsa.pub' '/var/www/html/'
   # The node install script can retrieve this or it can be performed manually:
   #   # wget -q -O- --no-check-certificate https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname} >> /root/.ssh/authorized_keys
   # In order to enable this during the install, we turn on httpd.
@@ -3167,16 +3168,16 @@ configure_wildcard_ssl_cert_on_node()
 {
   # Generate a 2048 bit key and self-signed cert.
   cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-*.${domain}
-root@${domain}
+*.$domain
+root@$domain
 EOF
 
 }
@@ -3184,17 +3185,17 @@ EOF
 configure_broker_ssl_cert()
 {
   # Generate a 2048 bit key and self-signed cert
-  cat << EOF | openssl req -new -rand /dev/urandom \
-	-newkey rsa:2048 -nodes -keyout /etc/pki/tls/private/localhost.key \
+  cat << EOF | openssl req -new -rand '/dev/urandom' \
+	-newkey 'rsa:2048' -nodes -keyout '/etc/pki/tls/private/localhost.key' \
 	-x509 -days 3650 \
-	-out /etc/pki/tls/certs/localhost.crt 2> /dev/null
+	-out '/etc/pki/tls/certs/localhost.crt' 2> /dev/null
 XX
 SomeState
 SomeCity
 OpenShift Enterprise default
 Temporary certificate
-${broker_hostname}
-root@${domain}
+$broker_hostname
+root@$domain
 EOF
 }
 
@@ -3203,19 +3204,19 @@ configure_hostname()
 {
   if [[ ! "$hostname" =~ ^[0-9.]*$ ]]  # hostname is not just an IP
   then
-    set_conf /etc/sysconfig/network HOSTNAME "$hostname"
-    hostname "${hostname}"
+    set_conf '/etc/sysconfig/network' HOSTNAME "$hostname"
+    hostname "$hostname"
   fi
 }
 
 # Set some parameters in the OpenShift node configuration files.
 configure_node()
 {
-  local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
-  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]
-  then cp "$resrc.${node_profile}" $resrc
+  local resrc='/etc/openshift/resource_limits.conf'
+  if [[ -f "${resrc}.${node_profile}.${node_host_type}" ]]
+  then cp "${resrc}.${node_profile}.${node_host_type}" "$resrc"
+  elif [[ -f "${resrc}.${node_profile}" ]]
+  then cp "${resrc}.${node_profile}" "$resrc"
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -3236,25 +3237,25 @@ configure_node()
   local conf=/etc/openshift/node.conf
   case "$node_apache_frontend" in
     mod_rewrite)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/vhost/mod-rewrite/" "$conf"
       ;;
     vhost)
-      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" $conf
+      sed -i -e "/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/mod-rewrite/vhost/" "$conf"
       ;;
   esac
 
   if is_true "$enable_sni_proxy"
   then
     # configure in the sni proxy
-    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf ||
-      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
+    grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' "$conf" ||
+      sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' "$conf"
     local port_list=$(seq -s, "$sni_first_port" "$sni_last_port")
     local sniconf='/etc/openshift/node-plugins.d/openshift-origin-frontend-haproxy-sni-proxy.conf'
     set_conf "$sniconf" PROXY_PORTS "$port_list"
   fi
 
-  echo $broker_hostname > /etc/openshift/env/OPENSHIFT_BROKER_HOST
-  echo $domain > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
+  echo "$broker_hostname" > /etc/openshift/env/OPENSHIFT_BROKER_HOST
+  echo "$domain" > /etc/openshift/env/OPENSHIFT_CLOUD_DOMAIN
 
   # Set the ServerName for httpd
   sed -i -e "s/ServerName .*$/ServerName ${hostname}/" \
@@ -3280,24 +3281,24 @@ PLATFORM_LOG_CLASS=SyslogLogger\
 PLATFORM_SYSLOG_THRESHOLD=LOG_INFO\
 PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
-    echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
+    echo 'local0.*  /var/log/messages' > '/etc/rsyslog.d/openshift-node-platform.conf'
   fi
   if [[ "$log_to_syslog" = *frontend* ]]
   then
     # Send the frontend logs to syslog (in addition to file).
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' '/etc/sysconfig/httpd'
   fi
   if is_true "$node_log_context"
   then
     # Annotate the frontend logs with UUIDs.
-    set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
+    set_node PLATFORM_LOG_CONTEXT_ENABLED 1
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
-    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
+    sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' '/etc/sysconfig/httpd'
   fi
   if [[ -n "$metrics_interval" ]]
   then
     # Configure watchman with given the interval.
-    set_node WATCHMAN_METRICS_ENABLED 'true'
+    set_node WATCHMAN_METRICS_ENABLED true
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
   fi
 }
@@ -3313,40 +3314,40 @@ update_openshift_facts_on_node()
 # public key (if available) and add it to node's authorized keys.
 install_rsync_pub_key()
 {
-  mkdir -p /root/.ssh
-  chmod 700 /root/.ssh
+  mkdir -p '/root/.ssh'
+  chmod 700 '/root/.ssh'
 
   local wait=600
   local end=`date -d "$wait seconds" +%s`
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]
+  while [[ `date +%s` -lt "$end" ]]
   do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    if ! cert="$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=$node_hostname")"
     then
       sleep 5
     else
-      if ! ssh-keygen -lf /dev/stdin <<< "$cert"
+      if ! ssh-keygen -lf '/dev/stdin' <<< "$cert"
       then
         break
       else
-        echo "$cert" >> /root/.ssh/authorized_keys
-        echo "OpenShift node: SSH key downloaded from broker successfully."
-        chmod 644 /root/.ssh/authorized_keys
+        echo "$cert" >> '/root/.ssh/authorized_keys'
+        echo 'OpenShift node: SSH key downloaded from broker successfully.'
+        chmod 644 '/root/.ssh/authorized_keys'
         return
       fi
     fi
   done
 
-  echo "OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually."
+  echo 'OpenShift node: WARNING: could not install rsync_id_rsa.pub key; please do it manually.'
 
 }
 
 echo_installation_intentions()
 {
-  echo "The following components should be installed:"
+  echo 'The following components should be installed:'
   local components='broker node named activemq datastore'
   local component
   for component in $components
@@ -3364,10 +3365,10 @@ echo_installation_intentions()
 configure_console_msg()
 {
   # add the IP to /etc/issue for convenience
-  echo "Install-time IP address: ${cur_ip_addr}" >> /etc/issue
-  echo_installation_intentions >> /etc/issue
-  echo "Check /root/anaconda-post.log to see the %post output." >> /etc/issue
-  echo >> /etc/issue
+  echo "Install-time IP address: $cur_ip_addr" >> '/etc/issue'
+  echo_installation_intentions >> '/etc/issue'
+  echo 'Check /root/anaconda-post.log to see the %post output.' >> '/etc/issue'
+  echo >> '/etc/issue'
 }
 
 
@@ -3407,12 +3408,12 @@ parse_cmdline()
 
 metapkgs_optional()
 {
-  [[ ${metapkgs,,} =~ 'optional' ]]
+  [[ "${metapkgs,,}" =~ 'optional' ]]
 }
 
 metapkgs_recommended()
 {
-  metapkgs_optional || [[ ${metapkgs,,} =~ 'recommended' ]]
+  metapkgs_optional || [[ "${metapkgs,,}" =~ 'recommended' ]]
 }
 
 is_true()
@@ -3439,7 +3440,7 @@ is_false()
 is_xpaas()
 {
   local profile="${1:-$node_profile}"
-  [[ "${profile}" = *xpaas* ]]
+  [[ "$profile" = *xpaas* ]]
 }
 
 # For each component, this function defines a constant function that
@@ -3553,7 +3554,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
       break
     fi
   done
-  if [[ $installing_something = 0 ]]
+  if [[ "$installing_something" = 0 ]]
   then
     for component in $components
     do
@@ -3651,13 +3652,13 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
-    rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
+    rhel_optional_repo="${rhel_optional_repo:-${cdn_repo_base}/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    if [[ "$cdn_repo_base" = "$ose_repo_base" ]]
     then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  elif [[ "$rhel_repo" = "${ose_repo_base}/os" ]]
   then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
@@ -3756,7 +3757,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Set $default_gear_capabilities to $CONF_DEFAULT_GEAR_CAPABILITIES
   [[ -n "${CONF_DEFAULT_GEAR_CAPABILITIES:+x}" ]] && isset_default_gear_capabilities() { :; }
-  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-${valid_gear_sizes}}"
+  broker && default_gear_capabilities="${CONF_DEFAULT_GEAR_CAPABILITIES:-$valid_gear_sizes}"
 
   # Set $default_gear_size to $CONF_DEFAULT_GEAR_SIZE
   [[ -n "${CONF_DEFAULT_GEAR_SIZE:+x}" ]] && isset_default_gear_size() { :; }
@@ -3770,7 +3771,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   ports_per_gear="${CONF_PORTS_PER_GEAR:-$def_ports}"
   district_first_uid="${CONF_DISTRICT_FIRST_UID:-1000}"
   let "district_uid_pool=30000/$ports_per_gear"
-  let "district_last_uid=$district_first_uid+$district_uid_pool-1"
+  let "district_last_uid=${district_first_uid}+${district_uid_pool}-1"
   isolate_gears="${CONF_ISOLATE_GEARS:-true}"
   # determine node sni proxy settings
   local def_enable="false"; is_xpaas && def_enable="true"
@@ -3794,28 +3795,28 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
 
   # Generate a random salt for the broker authentication.
   randomized=$(openssl rand -base64 20)
-  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-${randomized}}"
+  broker && broker_auth_salt="${CONF_BROKER_AUTH_SALT:-$randomized}"
 
   # Generate a random session secret for broker sessions.
   randomized=$(openssl rand -hex 64)
-  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-${randomized}}"
+  broker && broker_session_secret="${CONF_BROKER_SESSION_SECRET:-$randomized}"
 
   # Generate a random session secret for console sessions.
   randomized=$(openssl rand -hex 64)
-  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-${randomized}}"
+  broker && console_session_secret="${CONF_CONSOLE_SESSION_SECRET:-$randomized}"
 
   # Generate a new 2048 bit RSA keypair for broker authentication if
   # CONF_BROKER_AUTH_PRIV_KEY not set
   broker && broker_auth_priv_key="${CONF_BROKER_AUTH_PRIV_KEY:-$(openssl genrsa 2048)}"
 
   # If no list of replicants is provided, assume there is only one datastore host.
-  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
+  datastore_replicants="${CONF_DATASTORE_REPLICANTS:-${datastore_hostname}:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
   datastore_replicants="$( for repl in ${datastore_replicants//,/ }
                            do
-                             [[ "$repl" =~ : ]] || repl=$repl:27017
-                             printf ",%s" "${repl}"
+                             [[ "$repl" =~ : ]] || repl="${repl}:27017"
+                             printf ',%s' "$repl"
                            done)"
   datastore_replicants="${datastore_replicants:1}"
 
@@ -3839,18 +3840,18 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   ActiveMQ broker replicants to communicate with one another.  The
   #   amq user is enabled only if replicants are specified using the
   #   activemq_replicants.setting
-  activemq && assign_pass activemq_amq_user_password "password" CONF_ACTIVEMQ_AMQ_USER_PASSWORD
+  activemq && assign_pass activemq_amq_user_password password CONF_ACTIVEMQ_AMQ_USER_PASSWORD
 
   #   This is the user and password shared between broker and node for
   #   communicating over the mcollective topic channels in ActiveMQ.
   #   Must be the same on all broker and node hosts.
   (broker || node || activemq) && mcollective_user="${CONF_MCOLLECTIVE_USER:-mcollective}"
-  (broker || node || activemq) && assign_pass mcollective_password "marionette" CONF_MCOLLECTIVE_PASSWORD
+  (broker || node || activemq) && assign_pass mcollective_password marionette CONF_MCOLLECTIVE_PASSWORD
 
   # Enable authentication for MongoDB.
   if is_true "${CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST:-false}"
-  then enable_datastore_auth='false'
-  else enable_datastore_auth='true'
+  then enable_datastore_auth=false
+  else enable_datastore_auth=true
   fi
 
   #   These are the username and password of the administrative user
@@ -3860,19 +3861,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   enforce authentication.
   datastore && mongodb_admin_user="${CONF_MONGODB_ADMIN_USER:-admin}"
   datastore && tmpvar=${CONF_MONGODB_ADMIN_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  datastore &&  assign_pass mongodb_admin_password "mongopass" tmpvar
+  datastore &&  assign_pass mongodb_admin_password mongopass tmpvar
 
   #   These are the username and password of the normal user that will
   #   be created for the broker to connect to the MongoDB datastore. The
   #   broker application's MongoDB plugin is also configured with these
   #   values.
   (datastore || broker) && mongodb_broker_user="${CONF_MONGODB_BROKER_USER:-openshift}"
-  (datastore || broker) && tmpvar=${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}
-  (datastore || broker) && assign_pass mongodb_broker_password "mongopass" tmpvar
+  (datastore || broker) && tmpvar="${CONF_MONGODB_BROKER_PASSWORD:-${CONF_MONGODB_PASSWORD-}}"
+  (datastore || broker) && assign_pass mongodb_broker_password mongopass tmpvar
 
   #   In replicated setup, this is the key that slaves will use to
   #   authenticate with the master.
-  datastore && assign_pass mongodb_key "OSEnterprise" CONF_MONGODB_KEY
+  datastore && assign_pass mongodb_key OSEnterprise CONF_MONGODB_KEY
 
   #   In replicated setup, this is the name of the replica set.
   mongodb_replset="${CONF_MONGODB_REPLSET:-ose}"
@@ -3885,12 +3886,12 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   #   file as a demo/test user. You will likely want to remove it after
   #   installation (or just use a different auth method).
   broker && openshift_user1="${CONF_OPENSHIFT_USER1:-demo}"
-  broker && assign_pass openshift_password1 "changeme" CONF_OPENSHIFT_PASSWORD1
+  broker && assign_pass openshift_password1 changeme CONF_OPENSHIFT_PASSWORD1
 
   # auth info for the topic from the sample routing SPI plugin
   enable_routing_plugin="${CONF_ROUTING_PLUGIN:-false}"
   routing_plugin_user="${CONF_ROUTING_PLUGIN_USER:-routinginfo}"
-  assign_pass routing_plugin_pass "routinginfopasswd" CONF_ROUTING_PLUGIN_PASS
+  assign_pass routing_plugin_pass routinginfopasswd CONF_ROUTING_PLUGIN_PASS
 
   broker_krb_service_name="${CONF_BROKER_KRB_SERVICE_NAME-}"
   broker_krb_auth_realms="${CONF_BROKER_KRB_AUTH_REALMS-}"
@@ -3917,32 +3918,32 @@ init_message()
 
 validate_preflight()
 {
-  echo "OpenShift: Begin preflight validation."
+  echo 'OpenShift: Begin preflight validation.'
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  if ! grep -q 'Enterprise.* 6' /etc/redhat-release
   then
-    echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
+    echo 'OpenShift: This process needs to begin with Enterprise Linux 6 installed.'
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  if ! command -v getenforce || ! [[ "$(getenforce)" =~ Enforcing|Permissive ]]
   then
-    echo "OpenShift: SELinux needs to be installed and enabled."
+    echo 'OpenShift: SELinux needs to be installed and enabled.'
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
   if ! command -v rpm || ! command -v yum
   then
-    echo "OpenShift: rpm and yum must be installed."
+    echo 'OpenShift: rpm and yum must be installed.'
     preflight_failure=1
   fi
   if ! rpm -q rpm yum
   then
-    echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
+    echo 'OpenShift: rpm command failed; there may be a problem with the RPM DB.'
     preflight_failure=1
   fi
 
@@ -3955,12 +3956,12 @@ validate_preflight()
     #
     # Note: With RHN, we need credentials both for registration and
     # adding channels.
-    if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
+    if ! [[ -f '/etc/sysconfig/rhn/systemid' ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhn requires an RHN user and password."
+        echo 'OpenShift: Install method rhn requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3979,7 +3980,7 @@ validate_preflight()
       set +x # Don't log password.
       if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
       then
-        echo "OpenShift: Install method rhsm requires an RHN user and password."
+        echo 'OpenShift: Install method rhsm requires an RHN user and password.'
         preflight_failure=1
       fi
       set -x
@@ -3999,14 +4000,14 @@ validate_preflight()
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
           ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
     then
-      echo "OpenShift: Install method rhsm requires a poolid."
+      echo 'OpenShift: Install method rhsm requires a poolid.'
       preflight_failure=1
     fi
   fi
 
   if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
   then
-    echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
+    echo 'OpenShift: Install method yum requires providing URLs for at least OpenShift repos.'
     preflight_failure=1
   fi
 
@@ -4014,21 +4015,21 @@ validate_preflight()
   # ... ?
 
   [[ -n "$preflight_failure" ]] && abort_install
-  echo "OpenShift: Completed preflight validation."
+  echo 'OpenShift: Completed preflight validation.'
 }
 
 install_rpms()
 {
-  echo "OpenShift: Begin installing RPMs."
+  echo 'OpenShift: Begin installing RPMs.'
   # We often rely on the latest SELinux policy and other updates.
-  echo "OpenShift: yum update"
+  echo 'OpenShift: yum update'
   yum $disable_plugin clean all
 
   local count=0
   while true
   do
     yum $disable_plugin update -y && break
-    if [[ $count -gt 3 ]]
+    if [[ "$count" -gt 3 ]]
     then abort_install
     fi
     let count+=1
@@ -4047,12 +4048,12 @@ install_rpms()
   node && install_cartridges
   node && remove_abrt_addon_python
   broker && install_rhc_pkg
-  echo "OpenShift: Completed installing RPMs."
+  echo 'OpenShift: Completed installing RPMs.'
 }
 
 configure_host()
 {
-  echo "OpenShift: Begin configuring host."
+  echo 'OpenShift: Begin configuring host.'
   is_true "$enable_ntp" && synchronize_clock
   # Note: configure_named must run before configure_controller if we are
   # installing both named and broker on the same host.
@@ -4062,18 +4063,18 @@ configure_host()
   is_false "$keep_hostname" && configure_hostname
 
   # Minimize grub timeout on startup.
-  set_conf /etc/grub.conf timeout 1
+  set_conf '/etc/grub.conf' timeout 1
 
   # Remove VirtualHost from the default httpd ssl.conf to prevent a warning.
-  sed -i '/VirtualHost/,/VirtualHost/ d' /etc/httpd/conf.d/ssl.conf
+  sed -i '/VirtualHost/,/VirtualHost/ d' '/etc/httpd/conf.d/ssl.conf'
 
   # Reset the firewall to disable lokkit and initialise iptables configuration.
   configure_firewall
 
   # All hosts should enable SSH access.
-  firewall_allow[ssh]=tcp:22
+  firewall_allow[ssh]='tcp:22'
   configure_firewall_add_rules
-  echo "OpenShift: Completed configuring host."
+  echo 'OpenShift: Completed configuring host.'
 }
 
 configure_firewall()
@@ -4084,7 +4085,7 @@ configure_firewall()
   echo '--disabled' > "$conf"
 
   # Configure iptables.
-cat > /etc/sysconfig/iptables <<'EOF'
+cat > '/etc/sysconfig/iptables' <<'EOF'
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
@@ -4104,12 +4105,12 @@ EOF
 # Note: This function must be run after configure_firewall.
 configure_firewall_add_rules()
 {
-  local rules=""
+  local rules=
   local port
   local prot
   local rule
   local svc
-  for svc in ${!firewall_allow[@]}
+  for svc in "${!firewall_allow[@]}"
   do
     rules+="$(
       for rule in ${firewall_allow[$svc]//,/ }
@@ -4124,7 +4125,7 @@ configure_firewall_add_rules()
 
   # Insert the rules specified by ${firewall_allow[@]} before the first
   # REJECT rule in the INPUT chain.
-  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" /etc/sysconfig/iptables
+  sed -i -e $'/-A INPUT -j REJECT/i \\\n'"${rules:3}" '/etc/sysconfig/iptables'
 }
 
 configure_gear_isolation_firewall()
@@ -4134,7 +4135,7 @@ configure_gear_isolation_firewall()
 
 configure_openshift()
 {
-  echo "OpenShift: Begin configuring OpenShift."
+  echo 'OpenShift: Begin configuring OpenShift.'
 
   # Prepare services that the broker and node depend on.
   datastore && configure_datastore
@@ -4174,16 +4175,16 @@ configure_openshift()
   node && configure_gear_isolation_firewall
 
   sysctl -p || :
-  restorecon -rv /etc/openshift
+  restorecon -rv '/etc/openshift'
 
   PASSWORDS_TO_DISPLAY=true
   RESTART_NEEDED=true
-  echo "OpenShift: Completed configuring OpenShift."
+  echo 'OpenShift: Completed configuring OpenShift.'
 }
 
 restart_services()
 {
-  echo "OpenShift: Begin restarting services."
+  echo 'OpenShift: Begin restarting services.'
 
   service iptables restart
 
@@ -4210,41 +4211,41 @@ restart_services()
   node && service openshift-watchman restart
 
   # Ensure OpenShift facts are updated.
-  node && /etc/cron.minutely/openshift-facts
+  node && '/etc/cron.minutely/openshift-facts'
 
-  echo "OpenShift: Completed restarting services."
+  echo 'OpenShift: Completed restarting services.'
 }
 
 run_diagnostics()
 {
-  echo "OpenShift: Begin running oo-diagnostics."
+  echo 'OpenShift: Begin running oo-diagnostics.'
   date +%Y-%m-%d-%H:%M:%S
   # prepending the output of oo-diagnostics breaks the ansi color coding
   # remove all ansi escape sequences from oo-diagnostics output
   oo-diagnostics |& sed -u -e 's/\x1B\[[0-9;]*[JKmsu]//g' -e 's/^/OpenShift: oo-diagnostics output - /g'
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed running oo-diagnostics."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed running oo-diagnostics.'
 }
 
 reboot_after()
 {
-  echo "OpenShift: Rebooting after install."
+  echo 'OpenShift: Rebooting after install.'
   reboot
 }
 
 configure_districts()
 {
-  echo "OpenShift: Configuring districts."
-  date +%Y-%m-%d-%H:%M:%S
+  echo 'OpenShift: Configuring districts.'
+  date '+%Y-%m-%d-%H:%M:%S'
 
-  local restart=$RESTART_NEEDED
+  local restart="$RESTART_NEEDED"
   if is_true "$default_districts"
   then
     local p
     for p in ${valid_gear_sizes//,/ }
     do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
-      oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+      oo-admin-ctl-district -p "$p" -n "default-$p" -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
     done
   else
@@ -4258,12 +4259,12 @@ configure_districts()
     do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
-      firstnode=${nodes//,*/}
+      firstnode="${nodes//,*/}"
       # Query the node for the node profile via MCollective.
-      profile=""
+      profile=
       for i in {1..10}
       do
-        profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
+        profile="$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null)" \
          && break
         sleep 10
       done
@@ -4271,7 +4272,7 @@ configure_districts()
       then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
-        oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
+        oo-admin-ctl-district -p "$profile" -n "$district" -c add-node -i "$nodes" |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
         is_xpaas "$profile" && configure_messaging_plugin  # back to default
       else
         echo "OpenShift: Could not determine gear profile for nodes: ${nodes}, cannot add to district $district"
@@ -4279,15 +4280,15 @@ configure_districts()
     done
   fi
   # Configuring districts should not normally require a service restart.
-  RESTART_NEEDED=$restart
+  RESTART_NEEDED="$restart"
 
-  date +%Y-%m-%d-%H:%M:%S
-  echo "OpenShift: Completed configuring districts."
+  date '+%Y-%m-%d-%H:%M:%S'
+  echo 'OpenShift: Completed configuring districts.'
 }
 
 post_deploy()
 {
-  echo "OpenShift: Begin post deployment steps."
+  echo 'OpenShift: Begin post deployment steps.'
 
   if broker
   then
@@ -4297,7 +4298,7 @@ post_deploy()
       RESTART_NEEDED=true
     fi
 
-    $RESTART_NEEDED && restart_services && RESTART_COMPLETED=true
+    "$RESTART_NEEDED" && restart_services && RESTART_COMPLETED=true
 
     # Import cartridges.
     oo-admin-ctl-cartridge -c import-node --activate --obsolete
@@ -4307,7 +4308,7 @@ post_deploy()
 
   node && install_rsync_pub_key
 
-  echo "OpenShift: Completed post deployment steps."
+  echo 'OpenShift: Completed post deployment steps.'
 }
 
 do_all_actions()
@@ -4353,8 +4354,8 @@ RESTART_COMPLETED=false
 # Make sure /sbin and /usr/sbin are in PATH
 for admin_path in /sbin /usr/sbin
 do
-  if [[ :$PATH: != *:"${admin_path}":* ]]
-  then PATH=${PATH}:${admin_path}
+  if [[ ":$PATH:" != *:"$admin_path":* ]]
+  then PATH="${PATH}:${admin_path}"
   fi
 done
 
@@ -4364,10 +4365,10 @@ declare -A firewall_allow
 
 set_defaults
 
-date +%Y-%m-%d-%H:%M:%S
+date '+%Y-%m-%d-%H:%M:%S'
 for action in ${actions//,/ }
 do
-  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: ${action}"
+  [[ "$(type -t "$action")" = function ]] || abort_install "Invalid action: $action"
   "$action"
 done
 date +%Y-%m-%d-%H:%M:%S
@@ -4376,9 +4377,9 @@ date +%Y-%m-%d-%H:%M:%S
 # host will automatically reboot anyway after the kickstart script completes.
 [[ "$environment" = ks ]] && RESTART_NEEDED=false
 
-$RESTART_NEEDED && ! $RESTART_COMPLETED && restart_services
+"$RESTART_NEEDED" && ! "$RESTART_COMPLETED" && restart_services
 
-$PASSWORDS_TO_DISPLAY && display_passwords
+"$PASSWORDS_TO_DISPLAY" && display_passwords
 
 %end
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1704,6 +1704,7 @@ configure_outgoing_http_proxy()
     # an external tool instead?).
     shopt -s extglob # for *()
     proxies_stanza="${proxies_stanza//$'\n'*([[:space:]])$'\n'/$'\n'}"
+    shopt -u extglob
     mkdir -p '/etc/openshift/skel/.m2'
     local settings_xml='/etc/openshift/skel/.m2/settings.xml'
     if ! [[ -e "$settings_xml" ]] || ! grep -q '<proxies>' "$settings_xml"

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -217,7 +217,8 @@
 #     activemq - installs the messaging bus
 #     datastore - installs the MongoDB datastore
 #     node - installs node functionality
-#   Default: all.
+#     router - installs nginx as an external load-balancer/routing layer
+#   Default: all but router.
 #   Only the specified components are installed and configured.
 #   e.g. install_components=broker,datastore only installs the broker
 #   and DB, and assumes you have used other hosts for messaging and DNS.
@@ -416,8 +417,9 @@
 # named_hostname / CONF_NAMED_HOSTNAME
 # activemq_hostname / CONF_ACTIVEMQ_HOSTNAME
 # datastore_hostname / CONF_DATASTORE_HOSTNAME
+# router_hostname / CONF_ROUTER_HOSTNAME
 #   Default: the root plus the host domain, e.g. broker.example.com - except
-#   named=ns1.example.com
+#   named=ns1.example.com and router=www.example.com
 #
 #   These supply the FQDN of the hosts containing these components. Used
 #   for configuring the host's name at install, and also for clients to
@@ -436,6 +438,7 @@
 #CONF_NAMED_HOSTNAME="ns1.example.com"
 #CONF_ACTIVEMQ_HOSTNAME="activemq.example.com"
 #CONF_DATASTORE_HOSTNAME="datastore.example.com"
+#CONF_ROUTER_HOSTNAME="www.example.com"
 
 # syslog / CONF_SYSLOG
 #   Default: log only to files
@@ -528,6 +531,33 @@
 #CONF_ROUTING_PLUGIN_PASS=...
 #   Default: <randomized>
 #   Default with CONF_NO_SCRAMBLE: routinginfopasswd
+
+# enable_ha / CONF_ENABLE_HA
+#   Default: false
+#   When enabled, this installation script will configure the OpenShift broker
+#   to allow HA applications (setting ALLOW_HA_APPLICATIONS=true in
+#   /etc/openshift/broker.conf), add DNS CNAME records for highly available
+#   access to applications (MANAGE_HA_DNS=true in broker.conf) where those CNAME
+#   records will point to an external load-balancer (see CONF_ROUTER_HOSTNAME),
+#   and configure the broker so that accounts have permission to create HA
+#   applications by default (DEFAULT_ALLOW_HA=true in broker.conf).
+#CONF_ENABLE_HA=true
+
+# router / CONF_ROUTER
+#   Default: none
+#   When CONF_INSTALL_COMPONENTS includes router or broker, this setting
+#   specifies the router that will be installed or configured.  The following
+#   values are recognized:
+#     nginx - install and configure nginx and the routing daemon when
+#       CONF_INSTALL_COMPONENTS includes "router".
+#     f5 - install and configure the routing daemon for F5 BIG-IP LTM when
+#       CONF_INSTALL_COMPONENTS includes "broker".
+#   Note that installing and configuring F5 itself is outside the scope of this
+#   installation script.  Also note that in the case of F5, the routing daemon
+#   must run on the broker hosts whereas in the case of nginx, the routing
+#   daemon must run on the router alongside nginx.
+#CONF_ROUTER=f5
+#CONF_ROUTER=nginx
 
 # Settings for configuring Kerberos as user authentication method
 #
@@ -1146,7 +1176,7 @@ configure_repos()
   then need_extra_repo() { :; }
   fi
 
-  if activemq || broker || datastore || named
+  if activemq || broker || datastore || named || router
   then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
     # packages.  The ose-infrastructure and ose-node channels also include
@@ -1538,6 +1568,20 @@ install_rhc_pkg()
   yum_install_or_exit rhc
 }
 
+# Install the router (nginx).
+install_router_pkgs()
+{
+  case "$router" in
+    (f5)
+      # Nothing to do; setting up an F5 instance is outside the scope of this
+      # script.
+      ;;
+    (nginx)
+      yum_install_or_exit nginx16-nginx rubygem-openshift-origin-routing-daemon
+      ;;
+  esac
+}
+
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
@@ -1704,6 +1748,7 @@ install_broker_pkgs()
   pkgs="$pkgs openshift-origin-console"
   pkgs="$pkgs rubygem-openshift-origin-admin-console"
   is_true "$enable_routing_plugin" && pkgs="$pkgs rubygem-openshift-origin-routing-activemq"
+  [[ "$router" = f5 ]] && pkgs="$pkgs rubygem-openshift-origin-routing-daemon"
 
   # We use semanage in configure_selinux_policy_on_broker, so we need to
   # install policycoreutils-python.
@@ -1951,6 +1996,7 @@ set_mongodb() { set_conf /etc/mongodb.conf "$@"; }
 set_broker() { set_conf /etc/openshift/broker.conf "$@"; }
 set_console() { set_conf /etc/openshift/console.conf "$@"; }
 set_node() { set_conf /etc/openshift/node.conf "$@"; }
+set_routing_daemon() { set_conf /etc/openshift/routing-daemon.conf "$@"; }
 
 # Fix up SELinux policy on the broker.
 configure_selinux_policy_on_broker()
@@ -3037,6 +3083,7 @@ configure_hosts_dns()
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
+    router && add_host_to_zone "$router_hostname" "$cur_ip_addr"
   elif [[ "$named_entries" =~ : ]]
   then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
@@ -3144,6 +3191,18 @@ configure_controller()
 
   # Configure the session secret for the console
   set_console SESSION_SECRET "$console_session_secret"
+
+  if is_true "$enable_ha"
+  then
+    # Enable highly available applications, manage DNS CNAME records for highly
+    # available access to applications where those records will point to the
+    # external router, and grant permission to create HA applications to new
+    # accounts by default.
+    set_broker ALLOW_HA_APPLICATIONS true
+    set_broker MANAGE_HA_DNS true
+    set_broker DEFAULT_ALLOW_HA true
+    set_broker ROUTER_HOSTNAME "$router_hostname"
+  fi
 
   if [[ "$datastore_replicants" =~ , ]] || ! datastore
   then
@@ -3268,6 +3327,23 @@ configure_httpd_auth()
   RESTART_NEEDED=true
 }
 
+configure_routing_daemon()
+{
+  # The routing daemon runs on the broker in the case that $router = f5
+  # or on the router in the case that $router = nginx.
+  [[ -z "$router" ]] && return 0
+  [[ "$router" = f5 ]] && ! broker && return 0
+  [[ "$router" = nginx ]] && ! router && return 0
+
+  set_routing_daemon LOAD_BALANCER "$router"
+  set_routing_daemon ACTIVEMQ_HOST "$activemq_replicants"
+  set_routing_daemon ACTIVEMQ_USER "$routing_plugin_user"
+  set_routing_daemon ACTIVEMQ_PASSWORD "$routing_plugin_pass"
+  set_routing_daemon CLOUD_DOMAIN "$domain"
+
+  [[ "$router" = nginx ]] && service openshift-routing-daemon start
+}
+
 configure_routing_plugin()
 {
   if is_true "$enable_routing_plugin"
@@ -3312,6 +3388,31 @@ EOF
     *)
       echo "Invalid value: CONF_NODE_APACHE_FRONTEND=$node_apache_frontend"
       abort_install
+      ;;
+  esac
+}
+
+configure_router()
+{
+  case "$router" in
+    (f5)
+      # Nothing to do; configuration of F5 is outside the scope of this script.
+      ;;
+    (nginx)
+      firewall_allow[https]='tcp:443'
+      firewall_allow[http]='tcp:80'
+      setsebool -P httpd_can_network_connect=true
+      # Don't try to start nginx unless /etc/pki/tls/certs/node.example.com.crt
+      # and /etc/pki/tls/private/node.example.com.key exist because nginx will
+      # fail to start without them.
+      #
+      # These files should be copies of /etc/pki/tls/certs/localhost.crt and
+      # /etc/pki/tls/private/localhost.key, respectively, from a node host.
+      if [[ -e /etc/pki/tls/certs/node.example.com.crt &&
+            -e /etc/pki/tls/private/node.example.com.key ]]
+      then
+        service nginx16-nginx start
+      fi
       ;;
   esac
 }
@@ -3536,6 +3637,7 @@ echo_installation_intentions()
   echo "Configuring with named with IP address ${named_ip_addr}."
   broker && echo "Configuring with datastore with hostname ${datastore_hostname}."
   echo "Configuring with activemq with hostname ${activemq_hostname}."
+  echo "Configuring with router with hostname ${router_hostname}."
 }
 
 # Modify console message to show install info
@@ -3675,7 +3777,7 @@ set_defaults()
   # The declare statement below is generated by the following command:
   #
   #   echo local -A valid_settings=\( $(grep -o 'CONF_[0-9A-Z_]\+' openshift.ks |sort -u |grep -v -F -e CONF_BAZ -e CONF_FOO |sed -e 's/.*/[&]=/') \)
-local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
+local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]= [CONF_ACTIVEMQ_ADMIN_PASSWORD]= [CONF_ACTIVEMQ_AMQ_USER_PASSWORD]= [CONF_ACTIVEMQ_HOSTNAME]= [CONF_ACTIVEMQ_REPLICANTS]= [CONF_AMQ_EXTRA_REPO]= [CONF_BIND_KEY]= [CONF_BIND_KEYALGORITHM]= [CONF_BIND_KEYSIZE]= [CONF_BIND_KEYVALUE]= [CONF_BIND_KRB_KEYTAB]= [CONF_BIND_KRB_PRINCIPAL]= [CONF_BROKER_AUTH_PRIV_KEY]= [CONF_BROKER_AUTH_SALT]= [CONF_BROKER_HOSTNAME]= [CONF_BROKER_IP_ADDR]= [CONF_BROKER_KRB_AUTH_REALMS]= [CONF_BROKER_KRB_SERVICE_NAME]= [CONF_BROKER_SESSION_SECRET]= [CONF_CARTRIDGES]= [CONF_CDN_LAYOUT]= [CONF_CDN_REPO_BASE]= [CONF_CONSOLE_SESSION_SECRET]= [CONF_DATASTORE_HOSTNAME]= [CONF_DATASTORE_REPLICANTS]= [CONF_DEFAULT_DISTRICTS]= [CONF_DEFAULT_GEAR_CAPABILITIES]= [CONF_DEFAULT_GEAR_SIZE]= [CONF_DISTRICT_FIRST_UID]= [CONF_DISTRICT_MAPPINGS]= [CONF_DOMAIN]= [CONF_ENABLE_HA]= [CONF_ENABLE_SNI_PROXY]= [CONF_FORWARD_DNS]= [CONF_FUSE_EXTRA_REPO]= [CONF_HOSTS_DOMAIN]= [CONF_HOSTS_DOMAIN_KEYFILE]= [CONF_HTTP_PROXY]= [CONF_HTTPS_PROXY]= [CONF_IDLE_INTERVAL]= [CONF_INSTALL_COMPONENTS]= [CONF_INSTALL_METHOD]= [CONF_INTERFACE]= [CONF_ISOLATE_GEARS]= [CONF_JBOSSEAP_EXTRA_REPO]= [CONF_JBOSSEAP_VERSION]= [CONF_JBOSSEWS_EXTRA_REPO]= [CONF_JBOSS_REPO_BASE]= [CONF_KEEP_HOSTNAME]= [CONF_KEEP_NAMESERVERS]= [CONF_MCOLLECTIVE_PASSWORD]= [CONF_MCOLLECTIVE_USER]= [CONF_METAPKGS]= [CONF_METRICS_INTERVAL]= [CONF_MONGODB_ADMIN_PASSWORD]= [CONF_MONGODB_ADMIN_USER]= [CONF_MONGODB_BROKER_PASSWORD]= [CONF_MONGODB_BROKER_USER]= [CONF_MONGODB_KEY]= [CONF_MONGODB_NAME]= [CONF_MONGODB_PASSWORD]= [CONF_MONGODB_REPLSET]= [CONF_NAMED_ENTRIES]= [CONF_NAMED_HOSTNAME]= [CONF_NAMED_IP_ADDR]= [CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST]= [CONF_NODE_APACHE_FRONTEND]= [CONF_NODE_HOSTNAME]= [CONF_NODE_HOST_TYPE]= [CONF_NODE_IP_ADDR]= [CONF_NODE_LOG_CONTEXT]= [CONF_NODE_PROFILE]= [CONF_NODE_PROFILE_NAME]= [CONF_NO_NTP]= [CONF_NO_SCRAMBLE]= [CONF_OPENSHIFT_PASSWORD]= [CONF_OPENSHIFT_PASSWORD1]= [CONF_OPENSHIFT_USER]= [CONF_OPENSHIFT_USER1]= [CONF_OPTIONAL_REPO]= [CONF_OSE_ERRATA_BASE]= [CONF_OSE_EXTRA_REPO_BASE]= [CONF_OSE_REPO_BASE]= [CONF_PORTS_PER_GEAR]= [CONF_PROFILE_NAME]= [CONF_REPOS_BASE]= [CONF_RHEL_EXTRA_REPO]= [CONF_RHEL_OPTIONAL_REPO]= [CONF_RHEL_REPO]= [CONF_RHN_PASS]= [CONF_RHN_REG_ACTKEY]= [CONF_RHN_REG_NAME]= [CONF_RHN_REG_OPTS]= [CONF_RHN_REG_PASS]= [CONF_RHN_USER]= [CONF_RHSCL_EXTRA_REPO]= [CONF_RHSCL_REPO_BASE]= [CONF_ROUTER]= [CONF_ROUTER_HOSTNAME]= [CONF_ROUTING_PLUGIN]= [CONF_ROUTING_PLUGIN_PASS]= [CONF_ROUTING_PLUGIN_USER]= [CONF_SM_REG_NAME]= [CONF_SM_REG_PASS]= [CONF_SM_REG_POOL]= [CONF_SNI_FIRST_PORT]= [CONF_SNI_PROXY_PORTS]= [CONF_SYSLOG]= [CONF_VALID_GEAR_SIZES]= [CONF_YUM_EXCLUDE_PKGS]= )
 
   set +x # don't log passwords
   local setting
@@ -3701,7 +3803,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   actions="${CONF_ACTIONS:-do_all_actions}"
 
   # Following are the different components that can be installed:
-  local components='broker node named activemq datastore'
+  local components='broker node named activemq datastore router'
 
   # By default, each component is _not_ installed.
   local component
@@ -3715,7 +3817,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   for component in ${CONF_INSTALL_COMPONENTS//,/ }
   do
     case "$component" in
-      (broker|node|named|activemq|datastore) ;;
+      (broker|node|named|activemq|datastore|router) ;;
       (*) abort_install "Unrecognized component: $component" ;;
     esac
     eval "$component() { :; }"
@@ -3733,7 +3835,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   done
   if [[ "$installing_something" = 0 ]]
   then
-    for component in $components
+    for component in ${components//router} # default: all but router
     do
       eval "$component() { :; }"
     done
@@ -3774,6 +3876,7 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   named_hostname=$(ensure_domain "${CONF_NAMED_HOSTNAME:-ns1}" "$hosts_domain")
   activemq_hostname=$(ensure_domain "${CONF_ACTIVEMQ_HOSTNAME:-activemq}" "$hosts_domain")
   datastore_hostname=$(ensure_domain "${CONF_DATASTORE_HOSTNAME:-datastore}" "$hosts_domain")
+  router_hostname=$(ensure_domain "${CONF_ROUTER_HOSTNAME:-www}" "$domain")
 
   # The hostname name for this host.
   # Note: If this host is, e.g., both a broker and a datastore, we want
@@ -3788,6 +3891,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   then hostname="$activemq_hostname"
   elif datastore
   then hostname="$datastore_hostname"
+  elif router
+  then hostname="$router_hostname"
   fi
 
   # Grab the IP address set during installation.
@@ -4076,6 +4181,9 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   outgoing_http_proxy="${CONF_HTTP_PROXY-}"
   outgoing_https_proxy="${CONF_HTTPS_PROXY-}"
 
+  enable_ha="${CONF_ENABLE_HA-false}"
+  router="${CONF_ROUTER-}"
+
   # cartridge dependency metapackages
   metapkgs="${CONF_METAPKGS:-recommended}"
 
@@ -4228,6 +4336,7 @@ install_rpms()
   node && install_cartridges
   node && remove_abrt_addon_python
   broker && install_rhc_pkg
+  router && install_router_pkgs
   echo 'OpenShift: Completed installing RPMs.'
 }
 
@@ -4353,6 +4462,9 @@ configure_openshift()
   node && update_openshift_facts_on_node
 
   node && broker && fix_broker_routing
+
+  { broker || router; } && configure_routing_daemon
+  router && configure_router
 
   configure_firewall_add_rules
   node && configure_gear_isolation_firewall

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1030,9 +1030,11 @@ synchronize_clock()
 assign_pass()
 {
  # If the ENV variable is set, use it
-  if [[ -n "${!3-}" ]]; then
+  if [[ -n "${!3-}" ]]
+  then
     printf -v "$1" '%s' "${!3}"
-  elif is_true "$no_scramble" ; then
+  elif is_true "$no_scramble"
+  then
     printf -v "$1" '%s' "$2"
   else
     local randomized=$(openssl rand -base64 20)
@@ -1058,23 +1060,28 @@ display_passwords()
   subs[mongodb]="MongoDB"
   subs[activemq]="ActiveMQ"
 
-  for k in "${!passwords[@]}"; do
+  for k in "${!passwords[@]}"
+  do
     out_string=""
     matchingvar=""
-    for postfix in password password1 pass; do
+    for postfix in password password1 pass
+    do
       vprefix=${k%${postfix}}
       [[ "$vprefix" != "$k" ]] && break
     done
 
-    for v in "${vprefix}user" "${vprefix}user1"; do
-      if [[ -n "${!v+x}" ]]; then
+    for v in "${vprefix}user" "${vprefix}user1"
+    do
+      if [[ -n "${!v+x}" ]]
+      then
         matchingvar=$v
         break
       fi
     done
 
     formattedprefix=${vprefix//_/ }
-    for s in ${!subs[@]}; do
+    for s in ${!subs[@]}
+    do
       formattedprefix=${formattedprefix//${s}/${subs[$s]}}
     done
 
@@ -1096,17 +1103,18 @@ configure_repos()
   # Make need_${repo}_repo return false by default.
   local repo
   for repo in optional infra node client_tools extra \
-              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews; do
-      eval "need_${repo}_repo() { false; }"
+              fuse_cartridge amq_cartridge jbosseap_cartridge jbosseap jbossews
+  do eval "need_${repo}_repo() { false; }"
   done
 
   is_true "$enable_optional_repo" && need_optional_repo() { :; }
 
-  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]; then
-    need_extra_repo() { :; }
+  if [[ -n "${jbossews_extra_repo}${jbosseap_extra_repo}${rhel_optional_repo}${rhscl_extra_repo}${fuse_extra_repo}${amq_extra_repo}" ]]
+  then need_extra_repo() { :; }
   fi
 
-  if activemq || broker || datastore || named; then
+  if activemq || broker || datastore || named
+  then
     # The ose-infrastructure channel has the activemq, broker, and mongodb
     # packages.  The ose-infrastructure and ose-node channels also include
     # the yum-plugin-priorities package, which is needed for the installation
@@ -1124,7 +1132,8 @@ configure_repos()
   # install the client tools repo along with the infrastructure repo.
   need_infra_repo && need_client_tools_repo() { :; }
 
-  if node; then
+  if node
+  then
     # The ose-node channel has node packages including all the cartridges.
     need_node_repo() { :; }
 
@@ -1180,12 +1189,15 @@ configure_yum_repos()
 configure_ose_yum_repos()
 {
   local repo
-  for repo in infra node jbosseap_cartridge client_tools; do
-    if [[ -n "$ose_repo_base" ]]; then
+  for repo in infra node jbosseap_cartridge client_tools
+  do
+    if [[ -n "$ose_repo_base" ]]
+    then
       local layout=puddle; [[ -n "$cdn_layout" ]] && layout=cdn
       "need_${repo}_repo" && def_ose_yum_repo "$ose_repo_base" "$layout" "$repo"
     fi
-    if [[ -n "$ose_extra_repo_base" ]]; then
+    if [[ -n "$ose_extra_repo_base" ]]
+    then
       "need_${repo}_repo" && def_ose_yum_repo "$ose_extra_repo_base" 'extra' "$repo"
     fi
   done
@@ -1199,7 +1211,8 @@ configure_rhel_repo()
   # installing from RHEL. The post section cannot access the method that
   # was used in the base install. This configures a RHEL yum repo which
   # you must supply.
-if [[ -n "${rhel_repo}" ]]; then
+if [[ -n "${rhel_repo}" ]]
+then
   cat > /etc/yum.repos.d/rhel.repo <<YUM
 [rhel6]
 name=RHEL 6 base OS
@@ -1216,7 +1229,8 @@ fi
 
 configure_optional_repo()
 {
-if [[ -n "${rhel_optional_repo}" ]]; then
+if [[ -n "${rhel_optional_repo}" ]]
+then
   cat > /etc/yum.repos.d/rheloptional.repo <<YUM
 [rhel6_optional]
 name=RHEL 6 Optional
@@ -1264,7 +1278,8 @@ YUM
 
 configure_rhscl_repo()
 {
-  if [[ -n "${rhscl_repo_base}" ]]; then
+  if [[ -n "${rhscl_repo_base}" ]]
+  then
     cat <<YUM > /etc/yum.repos.d/rhscl.repo
 [rhscl]
 name=rhscl
@@ -1292,7 +1307,8 @@ configure_cart_repos()
   # in which case, add a repo base just for them. Use extras if needed for now.
 
   local repo
-  for repo in "${!url[@]}"; do
+  for repo in "${!url[@]}"
+  do
     "need_${repo}_repo" || continue
     cat <<YUM > "/etc/yum.repos.d/${repo}.repo"
 [${repo}]
@@ -1312,7 +1328,8 @@ YUM
 configure_extra_repos()
 {
   local extra_repo_file=/etc/yum.repos.d/ose_extra.repo
-  if [[ -e "${extra_repo_file}" ]]; then
+  if [[ -e "${extra_repo_file}" ]]
+  then
       > "${extra_repo_file}"
   fi
 
@@ -1329,9 +1346,11 @@ configure_extra_repos()
   )
 
   local repo
-  for repo in "${!priority[@]}"; do
+  for repo in "${!priority[@]}"
+  do
     local url="${!repo}"
-    if [[ -n "${url}" ]]; then
+    if [[ -n "${url}" ]]
+    then
       cat <<YUM >> "${extra_repo_file}"
 [${repo}]
 name=${repo}
@@ -1376,7 +1395,8 @@ configure_subscription()
 
 configure_rhn_channels()
 {
-  if [[ -n "$rhn_reg_actkey" ]]; then
+  if [[ -n "$rhn_reg_actkey" ]]
+  then
     echo "OpenShift: Register to RHN Classic using an activation key"
     rhnreg_ks --force "--activationkey=${rhn_reg_actkey}" "--profilename=$rhn_profile_name" ${rhn_reg_opts} || abort_install
   else
@@ -1397,8 +1417,8 @@ configure_rhn_channels()
     # Enable the node or infrastructure channel to enable installing the release
     # RPM.
     local repos=('rhel-x86_64-server-6-rhscl-1')
-    if ! need_node_repo || need_infra_repo ; then
-      repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
+    if ! need_node_repo || need_infra_repo
+    then repos+=('rhel-x86_64-server-6-ose-2.2-infrastructure')
     fi
     need_node_repo && repos+=('rhel-x86_64-server-6-ose-2.2-node' 'jb-ews-2-x86_64-server-6-rpm')
     need_client_tools_repo && repos+=('rhel-x86_64-server-6-ose-2.2-rhc')
@@ -1408,8 +1428,8 @@ configure_rhn_channels()
 
     set +x # Don't log password.
     local repo
-    for repo in "${repos[@]}"; do
-      [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
+    for repo in "${repos[@]}"
+    do [[ "$(rhn-channel -l)" = *"$repo"* ]] || rhn-channel --add --channel "$repo" --user "${rhn_user}" --password "${rhn_pass}" || abort_install
     done
     set -x
   fi
@@ -1440,13 +1460,15 @@ configure_rhsm_channels()
 
   # If CONF_SM_REG_POOL was not specified, this for loop is a no-op.
   local poolid
-  for poolid in ${sm_reg_pool//[, :+\/-]/ }; do
+  for poolid in ${sm_reg_pool//[, :+\/-]/ }
+  do
     echo "OpenShift: Registering subscription from pool id $poolid"
     subscription-manager attach --pool "$poolid" || abort_install
   done
 
   # Enable the node or infrastructure repo to enable installing the release RPM
-  if need_node_repo; then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
+  if need_node_repo
+  then subscription-manager repos --enable=rhel-6-server-ose-2.2-node-rpms || abort_install
   else subscription-manager repos --enable=rhel-6-server-ose-2.2-infra-rpms || abort_install
   fi
   configure_subscription
@@ -1464,9 +1486,11 @@ yum_install_or_exit()
 {
   echo "OpenShift: yum install $*"
   local count=0
-  time while true; do
+  time while true
+  do
     yum install -y $* $disable_plugin && return
-    if [[ $count -gt 3 ]]; then
+    if [[ $count -gt 3 ]]
+    then
       echo "OpenShift: Command failed: yum install $*"
       echo "OpenShift: Please ensure relevant repos/subscriptions are configured."
       abort_install
@@ -1526,8 +1550,10 @@ install_node_pkgs()
   pkgs="$pkgs rubygem-openshift-origin-frontend-nodejs-websocket"
   pkgs="$pkgs rubygem-openshift-origin-frontend-haproxy-sni-proxy"
 
-  if [[ "$log_to_syslog" = *gears* ]]; then
-    if rpm -q rsyslog ; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
+    if rpm -q rsyslog
+    then
       # RHEL 6.6's rsyslog7 package conflicts with the earlier RHEL 6 package.
       yum shell --disableplugin=priorities -y <<YUM
 erase rsyslog
@@ -1558,8 +1584,8 @@ YUM
 # This only affects the python v2 cart
 remove_abrt_addon_python()
 {
-  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python; then
-    yum $disable_plugin remove -y abrt-addon-python || abort_install
+  if grep 'Enterprise Linux Server release 6.4' /etc/redhat-release && rpm -q abrt-addon-python && rpm -q openshift-origin-cartridge-python
+  then yum $disable_plugin remove -y abrt-addon-python || abort_install
   fi
 }
 
@@ -1992,13 +2018,14 @@ execute_mongodb()
   echo "---"
 
   local userpass=
-  if [[ -n "${3+x}" && -n "${4+x}" ]]; then
-    userpass="-u ${3} -p ${4} admin"
+  if [[ -n "${3+x}" && -n "${4+x}" ]]
+  then userpass="-u ${3} -p ${4} admin"
   fi
 
   local output="$( echo "$1" | mongo ${userpass} )"
   echo "$output"
-  if [[ -n "${2+x}" ]]; then # test output against regex
+  if [[ -n "${2+x}" ]]
+  then # test output against regex
     [[ "$output" =~ $2 ]] || return 1
   fi
   return 0
@@ -2164,7 +2191,8 @@ configure_gears()
   chkconfig openshift-gears on
 
   # configure gear logging
-  if [[ "$log_to_syslog" = *gears* ]]; then
+  if [[ "$log_to_syslog" = *gears* ]]
+  then
     # make the gear app servers log to syslog by default (overrideable)
     sed -i -e '
       /outputtype\b/I coutputType = syslog
@@ -2231,7 +2259,8 @@ enable_services_on_node()
   firewall_allow[wss]=tcp:8443
 
   # Allow connections to openshift-sni-proxy
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     firewall_allow[sni]="tcp:${sni_first_port}:${sni_last_port}"
     chkconfig openshift-sni-proxy on
   else
@@ -2536,8 +2565,8 @@ $networkConnectors
                <authenticationUser username="${mcollective_user}" password="${mcollective_password}" groups="mcollective,everyone"/>
                ${authenticationUser_amq}
                <authenticationUser username="admin" password="${activemq_admin_password}" groups="mcollective,admin,everyone"/>
-               $( if is_true "$enable_routing_plugin"; then
-                    echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
+               $( if is_true "$enable_routing_plugin"
+                  then echo "<authenticationUser username=\"$routing_plugin_user\" password=\"$routing_plugin_pass\" groups=\"routinginfo,everyone\"/>"
                   fi
                )
              </users>
@@ -2551,7 +2580,8 @@ $networkConnectors
                   <authorizationEntry topic="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry queue="mcollective.>" write="mcollective" read="mcollective" admin="mcollective" />
                   <authorizationEntry topic="ActiveMQ.Advisory.>" read="everyone" write="everyone" admin="everyone"/>
-                  $( if is_true "$enable_routing_plugin"; then
+                  $( if is_true "$enable_routing_plugin"
+                     then
                        echo '<authorizationEntry topic="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                        echo '<authorizationEntry queue="routinginfo.>" write="routinginfo" read="routinginfo" admin="routinginfo" />'
                      fi
@@ -2652,7 +2682,8 @@ configure_named()
 
   # Set up DNS forwarding if so directed.
   local forwarders="recursion no;"
-  if is_true "$enable_dns_forwarding"; then
+  if is_true "$enable_dns_forwarding"
+  then
     echo "forwarders { ${nameservers} } ;" > /var/named/forwarders.conf
     restorecon /var/named/forwarders.conf
     chmod 644 /var/named/forwarders.conf
@@ -2737,7 +2768,8 @@ configure_named_zone()
 {
   local zone="$1"
 
-  if [[ -z "$bind_key" ]]; then
+  if [[ -z "$bind_key" ]]
+  then
     # Generate a new secret key
     local zone_tolower="${zone,,}"
     rm -f /var/named/K${zone_tolower}*
@@ -2807,10 +2839,9 @@ add_host_to_zone()
   # Check that $1 isn't an IP address and that $2 is.
   # All numbers and dots = IP address (not rigorous).
   local ip_regex='^[.0-9]+$'
-  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]; then
-    echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
-  else
-    echo "${1%.${zone}}			IN A	$2" >> $nsdb
+  if [[ $1 =~ $ip_regex || ! $2 =~ $ip_regex ]]
+  then echo "Not adding DNS record to host zone: '$1' should be a hostname and '$2' should be an IP address"
+  else echo "${1%.${zone}}			IN A	$2" >> $nsdb
   fi
 }
 
@@ -2822,17 +2853,19 @@ configure_hosts_dns()
   # Add the glue record for the NS host in the subdomain.
   [[ "$hosts_domain" = *?"$domain" ]] && add_host_to_zone "$named_hostname" "$named_ip_addr" "$domain"
 
-  if [[ -z "$named_entries" ]]; then
+  if [[ -z "$named_entries" ]]
+  then
     # Add A records for any other components that are being installed locally.
     broker && add_host_to_zone "$broker_hostname" "$broker_ip_addr"
     node && add_host_to_zone "$node_hostname" "$node_ip_addr"
     activemq && add_host_to_zone "$activemq_hostname" "$cur_ip_addr"
     datastore && add_host_to_zone "$datastore_hostname" "$cur_ip_addr"
-  elif [[ "$named_entries" =~ : ]]; then
+  elif [[ "$named_entries" =~ : ]]
+  then
     # Add any A records for host:ip pairs passed in via CONF_NAMED_ENTRIES
     local host_ip
-    for host_ip in ${named_entries//,/ }; do
-      add_host_to_zone ${host_ip//:/ }
+    for host_ip in ${named_entries//,/ }
+    do add_host_to_zone ${host_ip//:/ }
     done
   else # If "none" is specified, then just don't add anything.
     echo "Not adding named entries; named_entries = $named_entries"
@@ -2851,11 +2884,14 @@ register_named_entries()
   local host_ip
   local host
   local ip
-  for host_ip in ${named_entries//,/ }; do
+  for host_ip in ${named_entries//,/ }
+  do
     read host ip <<<$(echo ${host_ip//:/ })
-    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]; then
+    if [[ $host =~ $ip_regex || ! $ip =~ $ip_regex ]]
+    then
       echo "Not adding DNS record to host zone: '$host' should be a hostname and '$ip' should be an IP address"
-    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip; then
+    elif ! oo-register-dns -d "$hosts_domain" -h "${host%.$hosts_domain}" -k "${hosts_domain_keyfile}" -n $ip
+    then
       echo "WARNING: Failed to register host $host with IP $ip"
       failed="true"
     fi
@@ -2870,7 +2906,8 @@ configure_network()
   set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" ONBOOT yes
 
   # Check if static IP configured
-  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface; then
+  if grep -q "IPADDR" /etc/sysconfig/network-scripts/ifcfg-$interface
+  then
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" BOOTPROTO none
     set_conf "/etc/sysconfig/network-scripts/ifcfg-$interface" IPV6INIT no
   fi
@@ -3055,7 +3092,8 @@ configure_httpd_auth()
 
 configure_routing_plugin()
 {
-  if is_true "$enable_routing_plugin"; then
+  if is_true "$enable_routing_plugin"
+  then
     local conffile=/etc/openshift/plugins.d/openshift-origin-routing-activemq.conf
     sed -e '/^ACTIVEMQ_\(USERNAME\|PASSWORD\|HOST\)/ d' $conffile.example > $conffile
     cat <<EOF >> "$conffile"
@@ -3174,10 +3212,10 @@ configure_hostname()
 configure_node()
 {
   local resrc=/etc/openshift/resource_limits.conf
-  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]; then
-    cp "$resrc.${node_profile}.${node_host_type}" $resrc
-  elif [[ -f "$resrc.${node_profile}" ]]; then
-    cp "$resrc.${node_profile}" $resrc
+  if [[ -f "$resrc.${node_profile}.${node_host_type}" ]]
+  then cp "$resrc.${node_profile}.${node_host_type}" $resrc
+  elif [[ -f "$resrc.${node_profile}" ]]
+  then cp "$resrc.${node_profile}" $resrc
   fi
   set_conf "$resrc" node_profile "$node_profile_name"
 
@@ -3187,7 +3225,8 @@ configure_node()
   set_node BROKER_HOST "$broker_hostname"
   set_node EXTERNAL_ETH_DEV "$interface"
 
-  if [[ "$ports_per_gear" != 5 ]]; then
+  if [[ "$ports_per_gear" != 5 ]]
+  then
     set_node PORTS_PER_USER "$ports_per_gear" '' \
      'Number of proxy ports available per gear. Increasing the ports per gear'\
      'requires reducing the number of UIDs the district has so that the ports'\
@@ -3204,7 +3243,8 @@ configure_node()
       ;;
   esac
 
-  if is_true "$enable_sni_proxy"; then
+  if is_true "$enable_sni_proxy"
+  then
     # configure in the sni proxy
     grep -q 'OPENSHIFT_FRONTEND_HTTP_PLUGINS=.*sni-proxy' $conf || \
       sed -i -e '/OPENSHIFT_FRONTEND_HTTP_PLUGINS/ s/=/=openshift-origin-frontend-haproxy-sni-proxy,/' $conf
@@ -3226,7 +3266,8 @@ configure_node()
 
 configure_node_logs()
 {
-  if [[ "$log_to_syslog" = *node* ]]; then
+  if [[ "$log_to_syslog" = *node* ]]
+  then
     # Send the node platform logs to syslog instead.
     sed -i -e '
       # comment out existing log settings
@@ -3241,17 +3282,20 @@ PLATFORM_SYSLOG_TRACE_ENABLED=1
     ' /etc/openshift/node.conf
     echo 'local0.*  /var/log/messages' > /etc/rsyslog.d/openshift-node-platform.conf
   fi
-  if [[ "$log_to_syslog" = *frontend* ]]; then
+  if [[ "$log_to_syslog" = *frontend* ]]
+  then
     # Send the frontend logs to syslog (in addition to file).
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftFrontendSyslogEnabled"/' /etc/sysconfig/httpd
   fi
-  if is_true "$node_log_context"; then
+  if is_true "$node_log_context"
+  then
     # Annotate the frontend logs with UUIDs.
     set_node PLATFORM_LOG_CONTEXT_ENABLED '1'
     set_node PLATFORM_LOG_CONTEXT_ATTRS 'request_id,app_uuid,container_uuid'
     sed -i -e 's/^#*\s*OPTIONS="\?\([^"]*\)"\?/OPTIONS="\1 -DOpenShiftAnnotateFrontendAccessLog"/' /etc/sysconfig/httpd
   fi
-  if [[ -n "$metrics_interval" ]]; then
+  if [[ -n "$metrics_interval" ]]
+  then
     # Configure watchman with given the interval.
     set_node WATCHMAN_METRICS_ENABLED 'true'
     set_node WATCHMAN_METRICS_INTERVAL "$metrics_interval"
@@ -3277,9 +3321,11 @@ install_rsync_pub_key()
   echo "OpenShift node: will wait for $wait seconds to fetch SSH key."
 
   local cert
-  while [[ `date +%s` -lt $end ]]; do
+  while [[ `date +%s` -lt $end ]]
+  do
     # Try to get the public key from the broker.
-    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}"); then
+    if ! cert=$(wget -q -O- --no-check-certificate "https://${broker_hostname}/rsync_id_rsa.pub?host=${node_hostname}")
+    then
       sleep 5
     else
       if ! ssh-keygen -lf /dev/stdin <<< "$cert"
@@ -3600,16 +3646,19 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   # CONF_CDN_REPO_BASE is set.
   cdn_layout="${CONF_CDN_REPO_BASE-}"
   cdn_repo_base="${CONF_CDN_REPO_BASE%/}"
-  if [[ -n "$cdn_repo_base" ]]; then
+  if [[ -n "$cdn_repo_base" ]]
+  then
     rhel_repo="${rhel_repo:-$cdn_repo_base/os}"
     jboss_repo_base="${jboss_repo_base:-$cdn_repo_base}"
     rhscl_repo_base="${rhscl_repo_base:-$cdn_repo_base}"
     rhel_optional_repo="${rhel_optional_repo:-$cdn_repo_base/optional/os}"
     ose_repo_base="${ose_repo_base:-$cdn_repo_base}"
-    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]; then # same repo layout
+    if [[ "${cdn_repo_base}" = "${ose_repo_base}" ]]
+    then # same repo layout
       cdn_layout=1  # use the CDN layout for OpenShift yum repos
     fi
-  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]; then # OSE same repo base as RHEL?
+  elif [[ "${rhel_repo}" = "${ose_repo_base}/os" ]]
+  then # OSE same repo base as RHEL?
     cdn_layout=1  # use the CDN layout for OpenShift yum repos
   fi
   ose_extra_repo_base="${CONF_OSE_EXTRA_REPO_BASE%/}"
@@ -3697,8 +3746,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   bind_keysize="${CONF_BIND_KEYSIZE:-256}"
 
   local s
-  for s in valid_gear_sizes default_gear_capabilities default_gear_size; do
-    eval "isset_${s}() { false; }"
+  for s in valid_gear_sizes default_gear_capabilities default_gear_size
+  do eval "isset_${s}() { false; }"
   done
 
   # Set $valid_gear_sizes to $CONF_VALID_GEAR_SIZES
@@ -3763,7 +3812,8 @@ local -A valid_settings=( [CONF_ABORT_ON_UNRECOGNIZED_SETTINGS]= [CONF_ACTIONS]=
   datastore_replicants="${CONF_DATASTORE_REPLICANTS:-$datastore_hostname:27017}"
   # For each replicant that does not have an explicit port number
   # specified, append :27017 to its host name.
-  datastore_replicants="$( for repl in ${datastore_replicants//,/ }; do
+  datastore_replicants="$( for repl in ${datastore_replicants//,/ }
+                           do
                              [[ "$repl" =~ : ]] || repl=$repl:27017
                              printf ",%s" "${repl}"
                            done)"
@@ -3871,29 +3921,34 @@ validate_preflight()
   local preflight_failure=
 
   # Test that this isn't RHEL < 6 or Fedora
-  if ! grep -q "Enterprise.* 6" /etc/redhat-release; then
+  if ! grep -q "Enterprise.* 6" /etc/redhat-release
+  then
     echo "OpenShift: This process needs to begin with Enterprise Linux 6 installed."
     preflight_failure=1
   fi
 
   # Test that SELinux is at least present and not Disabled
-  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]] ; then
+  if ! command -v getenforce || ! [[ $(getenforce) =~ Enforcing|Permissive ]]
+  then
     echo "OpenShift: SELinux needs to be installed and enabled."
     preflight_failure=1
   fi
 
   # Test that rpm/yum exists and isn't totally broken
-  if ! command -v rpm || ! command -v yum; then
+  if ! command -v rpm || ! command -v yum
+  then
     echo "OpenShift: rpm and yum must be installed."
     preflight_failure=1
   fi
-  if ! rpm -q rpm yum; then
+  if ! rpm -q rpm yum
+  then
     echo "OpenShift: rpm command failed; there may be a problem with the RPM DB."
     preflight_failure=1
   fi
 
   # test that subscription parameters are available if needed
-  if [[ "$install_method" = rhn ]]; then
+  if [[ "$install_method" = rhn ]]
+  then
     # Check whether we are already registered with RHN and already have
     # ose-2.2 channels added.  If we are not, we will need RHN
     # credentials so that we can register and add channels ourselves.
@@ -3903,7 +3958,8 @@ validate_preflight()
     if ! [[ -f /etc/sysconfig/rhn/systemid ]] || ! rhn-channel -l | grep -q '^rhel-x86_64-server-6-ose-2.2-\(node\|infrastructure\)'
     then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhn requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3911,15 +3967,18 @@ validate_preflight()
     fi
   fi
 
-  if [[ "$install_method" = rhsm ]]; then
+  if [[ "$install_method" = rhsm ]]
+  then
     # Check whether we are already registered with RHSM.  If we are not,
     # we will need credentials so that we can register ourselves.
     #
     # Note: With RHSM, we need credentials for registration but not for
     # adding channels.
-    if ! subscription-manager identity | grep -q 'identity is:'; then
+    if ! subscription-manager identity | grep -q 'identity is:'
+    then
       set +x # Don't log password.
-      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]; then
+      if [[ -z "$rhn_user" || -z "$rhn_pass" ]]
+      then
         echo "OpenShift: Install method rhsm requires an RHN user and password."
         preflight_failure=1
       fi
@@ -3938,13 +3997,15 @@ validate_preflight()
     # a harmless but possibly alarming "Broken pipe" error message.
     if [[ -z "$sm_reg_pool" ]] &&
         ( [[ -n "$rhn_user" && -n "$rhn_pass" ]] ||
-          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' ); then
+          ! subscription-manager repos | tac | grep -q '\<rhel-6-server-ose-2.2-\(infra\|node\)-rpms$' )
+    then
       echo "OpenShift: Install method rhsm requires a poolid."
       preflight_failure=1
     fi
   fi
 
-  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]; then
+  if [[ "$install_method" = yum && -z "$ose_repo_base" ]]
+  then
     echo "OpenShift: Install method yum requires providing URLs for at least OpenShift repos."
     preflight_failure=1
   fi
@@ -3964,12 +4025,11 @@ install_rpms()
   yum $disable_plugin clean all
 
   local count=0
-  while true; do
-    yum $disable_plugin update -y
-    if [[ $? -eq 0 ]]; then
-      break
-    elif [[ $count -gt 3 ]]; then
-      abort_install
+  while true
+  do
+    yum $disable_plugin update -y && break
+    if [[ $count -gt 3 ]]
+    then abort_install
     fi
     let count+=1
   done
@@ -4178,9 +4238,11 @@ configure_districts()
   date +%Y-%m-%d-%H:%M:%S
 
   local restart=$RESTART_NEEDED
-  if is_true "$default_districts"; then
+  if is_true "$default_districts"
+  then
     local p
-    for p in ${valid_gear_sizes//,/ }; do
+    for p in ${valid_gear_sizes//,/ }
+    do
       is_xpaas "$p" && configure_messaging_plugin 15  # xpaas profile requires more ports
       oo-admin-ctl-district -p $p -n default-${p} -c add-node --available |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
       is_xpaas "$p" && configure_messaging_plugin  # back to default
@@ -4192,18 +4254,21 @@ configure_districts()
     local nodes
     local district
     local mapping
-    for mapping in ${district_mappings//;/ }; do
+    for mapping in ${district_mappings//;/ }
+    do
       district="${mapping%%:*}"
       nodes="${mapping#*:}"
       firstnode=${nodes//,*/}
       # Query the node for the node profile via MCollective.
       profile=""
-      for i in {1..10}; do
+      for i in {1..10}
+      do
         profile=$(oo-ruby -e "require 'mcollective'; include MCollective::RPC; mc=rpcclient('rpcutil'); mc.progress=false; result=mc.custom_request('get_fact', {:fact => 'node_profile'}, ['${firstnode}'], {'identity' => '${firstnode}'}); if not result.empty?;  value=result.first.results[:data][:value]; if not value.nil? and not value.empty?; puts value; exit 0; end; end; exit 1" 2>/dev/null) \
          && break
         sleep 10
       done
-      if [[ -n "$profile" ]]; then
+      if [[ -n "$profile" ]]
+      then
         echo "OpenShift: Adding nodes: $nodes with profile: $profile to district: $district."
         is_xpaas "$profile" && configure_messaging_plugin 15  # xpaas profile requires more ports
         oo-admin-ctl-district -p $profile -n $district -c add-node -i $nodes |& sed -e 's/^\(Error\)/OpenShift: oo-admin-ctl-district - \1/g'
@@ -4224,8 +4289,10 @@ post_deploy()
 {
   echo "OpenShift: Begin post deployment steps."
 
-  if broker; then
-    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size; then
+  if broker
+  then
+    if isset_valid_gear_sizes || isset_default_gear_capabilities || isset_default_gear_size
+    then
       update_controller_gear_size_configs
       RESTART_NEEDED=true
     fi
@@ -4284,9 +4351,10 @@ RESTART_NEEDED=false
 RESTART_COMPLETED=false
 
 # Make sure /sbin and /usr/sbin are in PATH
-for admin_path in /sbin /usr/sbin; do
-  if [[ :$PATH: != *:"${admin_path}":* ]] ; then
-    PATH=${PATH}:${admin_path}
+for admin_path in /sbin /usr/sbin
+do
+  if [[ :$PATH: != *:"${admin_path}":* ]]
+  then PATH=${PATH}:${admin_path}
   fi
 done
 

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1590,7 +1590,7 @@ install_router_pkgs()
 # Set up the system express.conf so our broker will be used by default.
 configure_rhc()
 {
-  # set_conf expects there to be a new line.
+  # set_conf expects there to be a newline character on the last line.
   echo >> '/etc/openshift/express.conf'
 
   # Set up the system express.conf so this broker will be used by default.
@@ -1634,9 +1634,9 @@ configure_outgoing_http_proxy()
       > '/etc/openshift/skel/.npmrc'
 
     # Configure Maven for JBoss.
-    # So far all this fancy^H^H^H^H^Had hoc, good-enough parsing is needed only
-    # for Maven, but it could be moved earlier in the function if its results
-    # could be used elsewhere.
+    # So far we only need to parse the URL for Maven, but it could be moved
+    # earlier in this function if future additions to this function have some
+    # use for the URL components.
     local http_proxy_auth https_proxy_auth \
           http_proxy_user http_proxy_pass https_proxy_user https_proxy_pass \
           http_proxy_host_port https_proxy_host_port \

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -453,7 +453,7 @@
 
 # interface / CONF_INTERFACE
 #   Default: eth0
-#   The network device to configure.  Used by configure_network, 
+#   The network device to configure.  Used by configure_network,
 #   configure_dns_resolution, and configure_node
 #CONF_INTERFACE="eth0"
 
@@ -2912,7 +2912,7 @@ $routingPolicy
 
         Take a look at \${ACTIVEMQ_HOME}/conf/jetty.xml for more details
 
-        If enabling the web console, you should make sure to require 
+        If enabling the web console, you should make sure to require
         authentication in jetty.xml and configure the admin/user
         passwords in jetty-realm.properties.
 
@@ -3341,7 +3341,7 @@ configure_httpd_auth()
     do
       sed -e "s#KrbServiceName.*#KrbServiceName ${broker_krb_service_name}#" \
           -e "s#KrbAuthRealms.*#KrbAuthRealms ${broker_krb_auth_realms}#" \
-	        "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
+          "$d/openshift-origin-auth-remote-user-kerberos.conf.sample" \
           > "$d/openshift-origin-auth-remote-user-kerberos.conf"
     done
     return


### PR DESCRIPTION
##### `openshift.ks`: Stop `ntpd` before `ntpdate` if needed

`synchronize_clock`: If `ntpd` is running, stop it before running `ntpdate` and start it afterwards because otherwise `ntpdate` will exit immediately with 'the NTP socket is in use'.


##### `openshift.sh`: Mark local variables as such

This commit is related to bug 1223551.


##### `openshift.ks`: Use idiomatic Bash in conditions

Use Bash idioms more consistently for conditionals:

• `[[ ]]` instead of `[ ]`;

• `=` instead of `==`;

• `[[ -n "$foo" ]]` instead of `[ "x$foo" != "x" ]`, `[ "${foo}x" != "x" ]` (oops!), `[ "$foo" != "" ]`, or `[[ "$foo" ]]`;

• `[[ -z "$foo" ]]` instead of `[ "x$foo" = x ]`, `! [ x"$foo" != x ]`, or `[ ! "$foo" ]`;

• `$# -ge 1` instead of `"$@"x == x`;

• `[[ cond1 && cond2 ]]` instead of `[ cond1 -a cond2 ]` or `[ cond1 ] && [ cond2 ]`;

• `[[ cond1 || cond2 ]]` instead of `[ cond1 -o cond2 ]`;

• `[[ "$foo" != "$bar" ]]` instead of `! [ "$foo" = "$bar" ]`;

• `[[ "$foo" =~ pattern ]]` instead of `[[ x$foo =~ xpattern ]]`; and

• `[[ -z "${foo+x}" ]]` instead of `! [[ ${foo+1} ]]`.

This commit is related to bug 1223551.


##### `openshift.ks`: Improve comment style consistency

Make comments clearer and more consistent, and delete a stale comment about `rsyslog` (added in commit 4801ef0f1427e3f9cf4069a4038c6ef6904a7e5d, no longer applicable with commit 583de710a4e77e8fc478fdffcf6c9fcd71d2b783).

This commit is related to bug 1223551.


##### `openshift.ks`: Always define `node_profile`

Always define `node_profile`, not only when installing a node, because `is_xpaas` uses `$node_profile`, and `is_xpaas` is used in `configure_districts` and when assigning `ports_per_gear`, which `configure_messaging_plugin` uses.

Delete a useless comment.


##### `openshift.ks`: Always initialize variables

Ensure that variables are always initialized before they are used.

Rename `profile_name` to `rhn_profile_name`, conditionalize its initialization on `$install_method =~ rhn|rhsm`, and group its initialization with the initialization of rhn_user and other parameters related to RHN and RHSM (which requires moving all of this initialization after the initialization of hostname because `$hostname` is referenced in the initialization of `$rhn_profile_name`).

Change `set_defaults` to set

• `named_entries` from `CONF_NAMED_ENTRIES`;

• `keep_nameservers` from `CONF_KEEP_NAMESERVERS`;

• `keep_hostname` from `CONF_KEEP_HOSTNAME`;

• `cdn_layout` from `CONF_CDN_LAYOUT`;

• `enable_optional_repo` from `CONF_OPTIONAL_REPO`;

• `install_method` from `CONF_INSTALL_METHOD`;

• `sm_reg_pool` from `CONF_SM_REG_POOL`;

• `rhn_reg_actkey` from `CONF_RHN_REG_ACTKEY`;

• `rhn_reg_opts` from `CONF_RHN_REG_OPTS`;

• `rhn_user` from `CONF_RHN_USER`;

• `rhn_pass` from `CONF_RHN_PASS`;

• `rhn_profile_name` from `CONF_PROFILE_NAME`;

• `enable_ntp` from the inverse of `CONF_NO_NTP`;

• `enable_dns_forwarding` from `CONF_FORWARD_DNS`;

• `log_to_syslog` from `CONF_SYSLOG`;

• `idle_interval` from `CONF_IDLE_INTERVAL`;

• `node_log_context` from `CONF_NODE_LOG_CONTEXT`;

• `metrics_interval` from `CONF_METRICS_INTERVAL`;

• `enable_datastore_auth` from the inverse of `CONF_NO_DATASTORE_AUTH_FOR_LOCALHOST`;

• `enable_routing_plugin` from `CONF_ROUTING_PLUGIN`;

• `broker_krb_service_name` from `CONF_BROKER_KRB_SERVICE_NAME`; and

• `broker_krb_auth_realms` from `CONF_BROKER_KRB_AUTH_REALMS`.

Modify `set_defaults` to guard against empty values by using `foo="${CONF_BAR-}"` when `CONF_BAR` might be empty and `foo` is supposed to have a empty default value, and to use `[[ -n "${CONF_FOO:+x}" ]]` instead of `[[ -n "$CONF_FOO" ]]` to check whether `CONF_FOO` is specified.

Change `set_defaults` always to initialize `bind_krb_keytab`, `bind_krb_principal`, and `bind_key`, even if they will default to empty strings (`configure_dns_plugin` contains the logic to check for empty values).

Conditionalize the initialization of `sm_reg_pool` on `$install_method =~ rhsm`.

Conditionalize the initialization of `rhn_reg_actkey` on `$install_method =~ rhn`.

Outside of `set_defaults`, use the variables set by `set_defaults` rather than directly referencing `CONF_` variables.

Modify `assign_pass` and `execute_mongodb` to use, e.g., `${2+x}` or `${2-}` as appropriate instead of `${2}` when testing whether optional arguments are specified or not.

`openshift.ks`/`openshift.sh` should now work properly with `set -u`.

This commit is related to bug 1223551.


##### `openshift.ks`: Use `> foo` without `echo` to truncate

In `configure_extra_repos`, use `> foo` instead of `echo > foo` to truncate `foo` to avoid adding an undesired newline to Yum repo files.


##### `openshift.ks`: Quote `$cert` in `install_rsync_pub_key`

In `install_rsync_pub_key`, quote `$cert` when echoing it to `/root/.ssh/authorized_keys` or writing it into `ssh-keygen` because it is not desirable to perform word splitting on the SSH key.

This commit is related to bug 1223551.


##### `openshift.ks`: Add `return 0` where appropriate

Add `return 0` statements to several functions where the last command run may return non-zero.

Add `|| :` after `sysctl -p` because `sysctl -p` returns non-zero when there are unrecognized settings in `/etc/sysctl.conf`, which is the case in a stock RHEL system with the default set of loaded kernel modules.

Add `|| :` after `oo-admin-yum-validator --fix-all` because it always returns non-zero.

Use `yum install ... && return` instead of running `yum install ...` and then `if [[ $? -eq 0 ]]; then return`.

Use `if ! cert=$(wget ...)` instead of `cert=$(wget ...)` and then `if [[ $? -ne 0 ]]` in `install_rsync_pub_key`.

Use `if ! ssh-keygen` instead of running `ssh-keygen` and then using `if [[ $? -ne 0 ]]` in `install_rsync_pub_key`.

Use `profile=$(oo-ruby ...) && break` instead of `profile=$(oo-ruby ...)` and then `if [[ $? -eq 0 ]]; then break; fi` in `configure_districts`.

`openshift.ks`/`openshift.sh` should now work properly with `set -e`.  Note, however, that using `set -e` is not recommended because `set -e` has convoluted semantics that can change between Bash versions (see
<http://mywiki.wooledge.org/BashFAQ/105> for examples).

This commit is related to bug 1223551.


##### `openshift.ks`: Run `quotaoff` before `quotacheck`

Turn of quotas before running `quotacheck` because otherwise `quotacheck` fails.


##### `openshift.ks`: Conditionalize `ln -s` for proxy conf

Modify `fix_broker_routing` to check whether `/etc/httpd/conf.d/000000_openshift_origin_broker_proxy.conf` already exists and create a symlink only if it does not.


##### `openshift.ks`: Use set_conf where possible

Modify `set_conf` to tolerate quotation marks around existing settings, leave `set_conf` as-is regarding tolerance of whitespace, and modify `set_conf` not to insert whitespace around the equals sign when adding settings.

Thus set_conf will recognize foo = bar, foo='bar', and variations, but
will add foo=bar if it find no such setting.

Modify `set_conf to` accept more than five arguments, given which it will add all arguments from `$5` on as separate lines, each prefixed with `# `, before the setting itself.

Define `set_broker`, `set_console`, and `set_node`, based on `set_conf`, for modifying `/etc/openshift/broker.conf`, `/etc/openshift/console.conf`, and `/etc/openshift/node.conf`, respectively.

Group `set_mongodb` with `set_broker`, `set_console`, and `set_node`, and modify `set_mongodb` to follow the pattern of the others.

Use the aforementioned functions wherever possible.


##### `openshift.ks`: Fixup auth=true for oo-accept-broker

Change `auth=true` to `auth = true` in `/etc/mongodb.conf` because `oo-accept-broker` performs a strict pattern match for the latter.

Before commit afcc9169604543ed960646f84063cd4ab375ddc2, `set_mongodb` added the required whitespace.  After, it does not, thus the need for this workaround.


##### `openshift.ks`: Indent `if`/`for`/`while` consistently

Use more consistent indentation for `if`, `elif`, `for`, and `while` blocks.

This commit is related to bug 1223551.


`openshift.ks` Delete unneeded line continuations

Delete line continuations (`\` at ends of lines) where they are already implied by `&&` or `||` at the end of a line.

This commit is related to bug 1223551.


##### `openshift.ks`: Quote consistently

Quote strings according to the following rules:

• Initialize to empty string with `foo=` instead of `foo=''` or `foo=""`.

• Leave shorter string literals unquoted.

• Single-quote longer string literals and string literals with characters other than a-zA-Z0-9_-.

• Leave strings where parameter expansion is desired unquoted if, and only if, word splitting, brace expansion, glob expansion, or pattern matching is desired.  Otherwise, double-quote strings where parameter expansion is desired.

• Leave `$foo` as-is if it stands alone, but use `${foo}` instead in string interpolation involving literals or other variables, unless `$foo` is immediately followed by whitespace or the end of the containing string.

This commit is related to bug 1223551.


##### `openshift.ks`: Fix formatting in `display_passwords`

Fix a subtle formatting error that resulted from quoting parameters.

Before commit 1500f6baab6519a16eeb833c7ea20a3e0dc5caad, word splitting chomped spaces from strings we were appending to the final output string.  After the commit, the quoting prevents word splitting from chomping spaces, so it is necessary to explicitly add a space where it is needed.


##### `openshift.ks`: Only modify `ssl.conf` for broker/node

`configure_host`: Only try to modify `/etc/httpd/conf.d/ssl.conf` when configuring the host as an OpenShift broker or node.


##### `openshift.ks`: Add experimental output annotatation

Add `annotate-output(1)`-inspired annotation to output.

Warning: The use of pipes is racy, so the streams may get crossed.


##### `openshift.ks`: Add outgoing proxy configuration

Add `http_proxy` / `CONF_HTTP_PROXY` and `https_proxy` / `CONF_HTTPS_PROXY` settings.

Add `configure_outgoing_http_proxy` function, which writes proxy configuration to

• `/etc/gitconfig` on broker and node hosts, which both use Git to clone downloadable cartridges;

• `/etc/openshift/env/HTTP_PROXY`, `/etc/openshift/env/HTTPS_PROXY`, and `/etc/openshift/env/NO_PROXY` on node hosts so that gears will have the corresponding environment variables for, which may be needed for cartridge-specific package repositories such as Pear for PHP;

• `/etc/openshift/skel/.m2/settings.xml` on node hosts for Maven; and

• `/etc/openshift/skel/.npmrc` on node hosts for NodeJS npm.

Call `configure_outgoing_http_proxy` from `configure_openshift` on broker and node hosts.

This commit fixes bug 1185876.


##### `openshift.ks`: Configure router and routing-daemon

Add `router_hostname` / `CONF_ROUTER_HOSTNAME`, `router` / `CONF_ROUTER`, and `enable_ha` / `CONF_ENABLE_HA` settings, and add "router" as a component recognized for the `install_components` / `CONF_INSTALL_COMPONENTS` setting.

Note: `install_components` / `CONF_INSTALL_COMPONENTS` defaults to all components except the router.

Change `configure_repos` to enable the infrastructure and Software Collections channels if installing the "router" component.

Change `configure_hosts_dns` to add a DNS record for the router.

Change `install_broker_pkgs` to install the routing daemon if `CONF_ROUTER` is set to "nginx".

Change `configure_controller` to set `ALLOW_HA_APPLICATIONS`, `MANAGE_HA_DNS`, and `DEFAULT_ALLOW_HA` to "true" and `ROUTER_HOSTNAME` to the hostname specified by `CONF_ROUTER_HOSTNAME` if `CONF_ENABLE_HA` is enabled.

Add `install_router_pkgs`, which is a no-op if `CONF_ROUTER` is set to "f5" and installs nginx and the routing daemon if `CONF_ROUTER` is set to "nginx.

Call `install_router_pkgs` from `install_rpms` if installing the "router" component.

Add `configure_routing_daemon`, which is a no-op unless `CONF_ROUTER` is set to "f5" and we are installing the broker, or `CONF_ROUTER` is set to "nginx" and we are installing the router, and otherwise configures `/etc/openshift/routing-daemon.conf` and (if `CONF_ROUTER` is set to "nginx") restarts the daemon.

Call `configure_routing_daemon` from `configure_openshift` if installing the broker or router.  (In the case of F5, the routing daemon runs on the OpenShift broker; in the case of nginx, the routing daemon runs on the router alongside nginx.)

Add `configure_router`, which is a no-up unles `CONF_ROUTER` is set to "nginx" (the script cannot configure F5 for the user), in which case the function configures the firewall and SELinux appropriately and starts nginx.

Call `configure_router` from `configure_openshift` if we are installing the router.

This commit fixes bug 1223554.


##### `openshift.ks`: Rewrite `set_conf()` in sed

Rewrite `set_conf()` to use a single `sed` command and to insert lines more sensibly.

Now if `set_conf` find an existing setting with a value other than the one specified, it comments that setting out as before and inserts the new setting after the old setting.  Otherwise, if the setting is not found in the file, `set_conf` appends the new setting to the end of the file.


##### `openshift.ks`: Fix comment for syntax highlighting

Put comments that contain contractions on their own lines because Vim fails to highlight same-line comments as comments, and thus the punctuation messes up Vim's syntax highlighting.


##### `openshift.ks`: Consistent formatting

Make the formatting a little more consistent, following the guidelines established in commit 1500f6baab6519a16eeb833c7ea20a3e0dc5caad in particular.

This commit is related to bug 1223551.


##### `openshift.ks`: Comments on word-splitting

Add explicit comments to indicate when we want word-splitting.

The one exception is when we are substituting a space for a separator in a `for` loop, such as the following: `for foo in ${bar//, / }`

Other than instances of this exception, either variables should be quoted or explicitly identified as needing word-splitting.

This commit is related to bug 1223551.


##### `openshift.ks`: Declare arrays explicitly

Always specify the `-a` flag when declaring an array, even if we are initializing it with an empty array, for consistency.

This commit is related to bug 1223551.


##### `openshift.ks`: Clean up comments

Clean up a couple of comments.

This commit is related to bug 1223551.


##### `openshift.ks`: `shopt -u extglob` when done

Disable extglob once we no longer need it enabled.


##### `openshift.ks`: `configure_sshd_on_node`: add newline

Add a newline character at the end of the `AcceptEnv` setting.

In `configure_sshd_on_node` function, be sure to write the `\n` EOL marker when adding the `AcceptEnv` setting.

After commit 24d469fd2f2aa0bcc0d430f7ee148598fdb29e23, `configure_sshd_on_node` writes a `\n` to `sshd_config` _before_ the line that the function adds, for the contingency that `sshd_config` already has an incomplete line lacking the EOL marker.  However, after that commit, the function wasn't writing the `\n` _of_ the line that the function adds.  This commit makes the function write both `\n` EOL markers.

This commit fixes bug 1223553.


##### `openshift.ks`: Comment out experimental annotation

Comment out the experimental output annotation that was added in commit 99570d96e855bd8ffc2bb46400b29cad58469ce6.


##### `openshift.ks`: No `ruby193-mcollective-client.log`

Do not create or fix permissions on `ruby193-mcollective-client.log` because we no longer configure MCollective to log to it (see <https://bugzilla.redhat.com/show_bug.cgi?id=963332>).

This commit fixes bug 1223552


##### `openshift.ks`: `configure_outgoing_http_proxy`: return 0
    
Return 0 from `configure_outgoing_http_proxy`.
    
Before this commit, the function would return an error if "broker" were not in `install_components`, which would cause `openshift.ks`/`openshift.sh` to terminate because we use `set -e` now.


##### `openshift.ks`: Fix router configuration
    
Set the correct zone (`$domain`) when creating the router's DNS record.
    
Return 0 from `configure_routing_daemon`.  Before this commit, if `$router` was set to "nginx", `configure_hosts_dns` would return an error, and so `openshift.ks`/`openshift.sh` would terminate because we use `set -e` now.

In `set_defaults`, abort if the router component is enabled at the same time as the broker or node components.  Because all of these components listen on ports 80 and 443, the router cannot co-exist with the broker or node without additional configuration, and it does not make a lot of sense to colocate the router with the other components anyway.


##### `openshift.ks`: `configure_extra_repos`: unbound variable

Fix an unbound-variable error in `configure_extra_repos`.

This commit is related to bug 1223551.


##### `openshift.sh`: `return 0` instead of `:` at end

Use `return 0` instead of `:` at the end of `openshift.sh` for clarity.


##### `openshift.ks`: router configuration fixes

Fix some issues with configuring the router or routing daemon:

* `set_defaults()`: Make `CONF_ROUTING_PLUGIN` default to "true" iff `CONF_INSTALL_COMPONENTS` includes "broker" and `CONF_ROUTER` is non-empty.

* `configure_routing_daemon()`: Comment out settings that are unrelated to the configured load-balancer.

* `configure_routing_daemon()`: `chkconfig openshift-routing-daemon on` and set `RESTART_NEEDED=true` instead of immediately starting the daemon.

* `configure_router()`: `chkconfig nginx16-nginx on` and set `RESTART_NEEDED=true` instead of immediately starting it.

* `restart_services()`: Restart `openshift-routing-daemon` and `nginx16-nginx` if `CONF_INSTALL_COMPONENTS` includes "router" and `$router = nginx`.


##### `openshift.ks`: Fix one quoting consistency issue

Always use single-quotes around the format for the date command.


##### `openshift.ks`: Fix some whitespace issues

Change a tab to spaces, and delete some trailing whitespace.
