### PR TITLE
Degrade to basic RHSM detection for broken repolib

### DIFF
--- a/admin/yum-validator/yumvalidator/check_sources.py
+++ b/admin/yum-validator/yumvalidator/check_sources.py
@@ -365,9 +365,13 @@ class CheckSources(object):
                         init_dep_injection()
                     from subscription_manager.repolib import RepoActionInvoker
                     self._repo_act_invoker = RepoActionInvoker()
+                    # Check if is_managed() works
+                    self._repo_act_invoker.is_managed('this_is-not_a-real_repo')
             except ImportError:
                 self._repo_act_invoker = None
             except SubscriptionManagerNotRegisteredError:
+                self._repo_act_invoker = None
+            except AttributeError: # work around broken repolib implementations
                 self._repo_act_invoker = None
         return self._repo_act_invoker
 


### PR DESCRIPTION
A broken `RepoActionInvoker.is_managed()` method is currently shipped in
RHEL 6.7 beta. This commit allows yum-validator to fail back to less
reliable basic RHSM repo detection techniques when it detects a broken
`is_managed()` implementation.

This is a workaround for bug 1223038
https://bugzilla.redhat.com/show_bug.cgi?id=1223038