### PR TITLE
Prevent named logger propagation

### DIFF
--- a/admin/yum-validator/oo-admin-yum-validator
+++ b/admin/yum-validator/oo-admin-yum-validator
@@ -76,6 +76,7 @@ class OpenShiftYumValidator(object):
         self.opts.loglevel = logging.INFO
         # TODO: log to file if specified, with requested severity
         self.logger = logging.getLogger(name='oo-admin-yum-validator')
+        self.logger.propagate = False
         self.logger.setLevel(self.opts.loglevel)
         ch = logging.StreamHandler(sys.stdout)
         ch.setLevel(self.opts.loglevel)


### PR DESCRIPTION
Under older `subscription-manager` and `python-rhsm` libraries, the
logging fixes for RHEL 6.7 beta caused duplicate log messages to be
output. This commit disables message propagation for the named logger
set up in `oo-admin-yum-validator`, which prevents the `self.logger`
from being silenced by dependent libraries, and prevents the messages
handled by `self.logger` from being repeated by the default `root`
logger.