### PR TITLE
Update openshift.ks

### DIFF
--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -1014,7 +1014,7 @@ selinux --enforcing
 bootloader --location=mbr --driveorder=vda --append=" rhgb crashkernel=auto quiet console=ttyS0"
 
 zerombr
-clearpart --all --initlabel
+clearpart --all 
 firstboot --disable
 reboot
 


### PR DESCRIPTION
The --initlabel option has been deprecated. To initialize disks with invalid partition tables and clear their contents, we use the zerombr command. It's better to remove this option from the kickstart file as well.

      https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Installation_Guide/s1-kickstart2-options.html

Replace:

clearpart --all --initlabel

with:

clearpart --all