### PR TITLE
ooinstall: add support for unattended installation

### DIFF
--- a/oo-install/site_assets/oo-install-bootstrap.sh
+++ b/oo-install/site_assets/oo-install-bootstrap.sh
@@ -70,7 +70,7 @@ then
 else
   clear
 fi
-oo-install --ansible-playbook-directory ${TMPDIR}/INSTALLPKGNAME/openshift-ansible-*/ --ansible-log-path $OO_INSTALL_LOG
+oo-install $cmdlnargs --ansible-playbook-directory ${TMPDIR}/INSTALLPKGNAME/openshift-ansible-*/ --ansible-log-path $OO_INSTALL_LOG
 
 if [ $OO_INSTALL_KEEP_ASSETS == 'true' ]
 then

--- a/oo-install/src/ooinstall/oo_config.py
+++ b/oo-install/src/ooinstall/oo_config.py
@@ -52,7 +52,7 @@ class OOConfig(object):
         if not 'ansible_callback_facts_yaml' in self.settings:
             self.settings['ansible_callback_facts_yaml'] = '{}/callback_facts.yaml'.format(self.settings['ansible_inventory_directory'])
         if not 'ansible_ssh_user' in self.settings:
-            self.settings['ansible_ssh_user'] = 'root'
+            self.settings['ansible_ssh_user'] = ''
 
         self.settings['ansible_inventory_path'] = '{}/hosts'.format(self.settings['ansible_inventory_directory'])
 


### PR DESCRIPTION
This adds support for unattended installs to ooinstall. Some refactoring was
done to better read in defaults passed in via installer.cfg.yaml and/or
command line parameters as well as separating more of the installer logic
from the UX prompts. Additionially some of the defaults were tweaked
to better support the above