### PR TITLE
oo-install README.md: Updates bundler gem version to match gemfile

### DIFF
--- a/oo-install/README.md
+++ b/oo-install/README.md
@@ -11,7 +11,7 @@ from the command line of any system with ruby 1.8.7 or above plus unzip and curl
 ## Running oo-install from source
 If you would prefer to run the installer from source, you will need to use the [bundler](http://bundler.io/) gem to set up the right environment.
 
-1. `gem install bundler --version '=1.3.5'`
+1. `gem install bundler --version '=1.7.8'`
 2. Clone [openshift-extras](https://github.com/openshift/openshift-extras/)
 3. `cd openshift-extras/oo-install`
 4. `bundle install`


### PR DESCRIPTION
Updates the bundler version in the instructions for "Running oo-install from source".  Instructions say to use `gem install bundler --version '=1.3.5'`, however the Gemfile uses bundler 1.8.7.