### PR TITLE
oo-install assistant.rb: Avoids saving before district has a node

### DIFF
--- a/oo-install/lib/installer/assistant.rb
+++ b/oo-install/lib/installer/assistant.rb
@@ -1338,7 +1338,9 @@ module Installer
                 district.add_node_host(node_to_add)
               end
             end
-            if deployment.districts.select { |d| d == district }.empty?
+            if district.node_hosts.length == 0
+              # Bug 1278933 - Check for case where no node was added to district, do NOT save to disk
+            elsif deployment.districts.select { |d| d == district }.empty?
               deployment.add_district! district
             else
               deployment.save_to_disk!


### PR DESCRIPTION
Bug 1278933
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1278933

A user can run into a loop when adding a district when each existing district already has exactly one node.  Aborting the script with ctrl-c at a certain point would end up with an empty district (with no node) being written to the oo-install-cfg.yaml file.

Script should now check for the case where a district has no nodes before saving, and will NOT save to disk for this case.
