### PR TITLE
generate sed --follow-symlinks in oo-install script

### DIFF
--- a/enterprise/install-scripts/amazon/openshift-amz.sh
+++ b/enterprise/install-scripts/amazon/openshift-amz.sh
@@ -990,7 +990,7 @@ set_conf()
   local longcomment=
   (( $# > 0 )) && printf -v longcomment '# %s\\\n' "$@"
 
-  sed -i -e "
+  sed -i --follow-symlinks -e "
     :a
       # Check whether the setting already exists with the specified value.  If
       # it does, jump to :b.

--- a/enterprise/install-scripts/generic/openshift.sh
+++ b/enterprise/install-scripts/generic/openshift.sh
@@ -1964,7 +1964,7 @@ set_conf()
   local longcomment=
   (( $# > 0 )) && printf -v longcomment '# %s\\\n' "$@"
 
-  sed -i -e "
+  sed -i --follow-symlinks -e "
     :a
       # Check whether the setting already exists with the specified value.  If
       # it does, jump to :b.

--- a/enterprise/install-scripts/openshift.ks
+++ b/enterprise/install-scripts/openshift.ks
@@ -2010,7 +2010,7 @@ set_conf()
   local longcomment=
   (( $# > 0 )) && printf -v longcomment '# %s\\\n' "$@"
 
-  sed -i -e "
+  sed -i --follow-symlinks -e "
     :a
       # Check whether the setting already exists with the specified value.  If
       # it does, jump to :b.


### PR DESCRIPTION
Bug 1289645
Bugzilla https://bugzilla.redhat.com/show_bug.cgi?id=1289645
Edit the oo-install script to update /boot/grub/grub.conf when
configuring host. Currently it is not updated as the target
of symbolic link /etc/grub.conf.